### PR TITLE
remove import splat

### DIFF
--- a/linode/linode_client.py
+++ b/linode/linode_client.py
@@ -4,11 +4,20 @@ import pkg_resources
 from datetime import datetime
 
 from linode.errors import ApiError, UnexpectedResponseError
-from linode.objects import *
-from linode.objects.base import MappedObject
-from linode.objects.filtering import Filter
-from .paginated_list import PaginatedList
+
+from linode.objects import Region
+from linode.objects.account import AccountSettings, Event, Invoice, OAuthClient, Payment, User
+from linode.objects.base import Base, MappedObject
+from linode.objects.domain import Domain
+from linode.objects.filtering import Filter, and_
+from linode.objects.linode import Distribution, Kernel, Linode, StackScript, Type, Volume
+from linode.objects.networking import IPAddress, IPv6Pool
+from linode.objects.nodebalancer import NodeBalancer
+from linode.objects.profile import AuthorizedApp, Profile, Token
+from linode.objects.support import SupportTicket
+
 from .common import load_and_validate_keys
+from .paginated_list import PaginatedList
 
 package_version = pkg_resources.require("linode-api")[0].version,
 


### PR DESCRIPTION
Note: Merge after https://github.com/linode/python-linode-api/pull/65 is merged and rebase

Remove import * from linode_client.py
Makes it easier to navigate, and avoids potential namespace clobbering.
Would also like to remove the import *'s from some of the the `__init__.py`'s in a later PR
