### PR TITLE
[WIP] add tests for base class

### DIFF
--- a/linode/objects/base.py
+++ b/linode/objects/base.py
@@ -226,11 +226,10 @@ class Base(object, with_metaclass(FilterableMetaclass)):
                         if obj and isinstance(json[key], dict):
                             obj._populate(json[key])
                         self._set(key, obj)
-                elif type(self).properties[key].slug_relationship \
+                elif  type(self).properties[key].slug_relationship \
                         and not json[key] is None:
                     # create an object of the expected type with the given slug
-                    d = json[key]
-                    self._set(key, type(self).properties[key].slug_relationship(self._client, d['id'], d))
+                    self._set(key, type(self).properties[key].slug_relationship(self._client, json[key]))
                 elif type(json[key]) is dict:
                     self._set(key, MappedObject(**json[key]))
                 elif type(json[key]) is list:

--- a/linode/objects/base.py
+++ b/linode/objects/base.py
@@ -226,10 +226,11 @@ class Base(object, with_metaclass(FilterableMetaclass)):
                         if obj and isinstance(json[key], dict):
                             obj._populate(json[key])
                         self._set(key, obj)
-                elif  type(self).properties[key].slug_relationship \
+                elif type(self).properties[key].slug_relationship \
                         and not json[key] is None:
                     # create an object of the expected type with the given slug
-                    self._set(key, type(self).properties[key].slug_relationship(self._client, json[key]))
+                    d = json[key]
+                    self._set(key, type(self).properties[key].slug_relationship(self._client, d['id'], d))
                 elif type(json[key]) is dict:
                     self._set(key, MappedObject(**json[key]))
                 elif type(json[key]) is list:

--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,7 @@ setup(
         "future",
         "requests",
         "enum34",
+        "mock"
     ],
 
     test_suite = 'setup.get_test_suite'

--- a/test/base_test.py
+++ b/test/base_test.py
@@ -10,7 +10,7 @@ class Bar(Base):
     api_endpoint = "/bar/{id}"
     properties = {
         'id': Property(identifier=True),
-        'value': 'abc'
+        'value': Property()
     }
 
 
@@ -42,7 +42,7 @@ class BaseClassTestCase(TestCase):
             'filterable': 'value',
             'id': 1,
             'something': 'else',
-            'bar': self.bar_dict
+            'bar': 2
         }
         self.foo = Foo(mock.Mock(), 1, self.foo_dict)
 
@@ -56,10 +56,9 @@ class BaseClassTestCase(TestCase):
         self.assertEqual(self.foo.filterable, 'value')
         self.assertEqual(self.foo.something, 'else')
         self.assertIsInstance(self.foo.bar, Bar)
-        
+
         # Assert properties of slug related field
         self.assertEqual(self.foo.bar.id, 2)
-        self.assertEqual(self.foo.bar.value, 'abc')
 
     def test_foo_properties(self):
         """

--- a/test/base_test.py
+++ b/test/base_test.py
@@ -1,6 +1,12 @@
-from unittest import TestCase, mock
+import sys
+from unittest import TestCase
 
 from linode.objects.base import Base, Property
+
+if sys.version_info >= (3, 4):
+    from unittest import mock
+else:
+    import mock
 
 
 class Bar(Base):

--- a/test/base_test.py
+++ b/test/base_test.py
@@ -1,0 +1,72 @@
+from unittest import TestCase, mock
+
+from linode.objects.base import Base, Property
+
+
+class Bar(Base):
+    """
+    A dummy object that can be a child of another object.
+    """
+    api_endpoint = "/bar/{id}"
+    properties = {
+        'id': Property(identifier=True),
+        'value': 'abc'
+    }
+
+
+class Foo(Base):
+    """
+    A dummy object we will use to test methods of the Base class.
+    """
+    api_endpoint = "/foo/{id}"
+    properties = {
+        'filterable': Property(filterable=True),
+        'id': Property(identifier=True),
+        'something': Property(),
+        'bar': Property(slug_relationship=Bar)
+    }
+
+
+class BaseClassTestCase(TestCase):
+    """
+    Tests the Base class by inheriting from it and asserting that things do what they should.
+    """
+
+    def setUp(self):
+        self.bar_dict = {
+            'id': 2,
+            'value': 'abc'
+        }
+
+        self.foo_dict = {
+            'filterable': 'value',
+            'id': 1,
+            'something': 'else',
+            'bar': self.bar_dict
+        }
+        self.foo = Foo(mock.Mock(), 1, self.foo_dict)
+
+    def test_well_formed_foo(self):
+        """
+        Tests that passing in a valid dict like an api response returns an object with dot notation
+        and the correct properties.
+        """
+
+        self.assertEqual(self.foo.id, 1)
+        self.assertEqual(self.foo.filterable, 'value')
+        self.assertEqual(self.foo.something, 'else')
+        self.assertIsInstance(self.foo.bar, Bar)
+        
+        # Assert properties of slug related field
+        self.assertEqual(self.foo.bar.id, 2)
+        self.assertEqual(self.foo.bar.value, 'abc')
+
+    def test_foo_properties(self):
+        """
+        Tests that passing in a valid dict like an api response returns an object with a well formed
+        properties dictionary
+        """
+
+        self.assertTrue(self.foo.properties['id'].identifier)
+        self.assertTrue(self.foo.properties['filterable'].filterable)
+        self.assertFalse(self.foo.properties['something'].filterable)


### PR DESCRIPTION
Add tests for the base class and assert it forms objects well based on dictionaries.

I expect the nested one to fail for now and will throw up a commit with a proposed fix, if i understand the problem correctly.

Proposed fix: use the id key from the data blob. This is assuming (perhaps incorrectly) that anything that would be a slug related field would have an id.