### PR TITLE
Use requests Session() for Keep-Alive support

### DIFF
--- a/linode_api4/linode_client.py
+++ b/linode_api4/linode_client.py
@@ -726,6 +726,7 @@ class LinodeClient:
         self.base_url = base_url
         self._add_user_agent = user_agent
         self.token = token
+        self.session = requests.Session()
 
         #: Access methods related to Linodes - see :any:`LinodeGroup` for
         #: more information
@@ -862,16 +863,16 @@ class LinodeClient:
                 parent_id=parent_id)
 
     def get(self, *args, **kwargs):
-        return self._api_call(*args, method=requests.get, **kwargs)
+        return self._api_call(*args, method=self.session.get, **kwargs)
 
     def post(self, *args, **kwargs):
-        return self._api_call(*args, method=requests.post, **kwargs)
+        return self._api_call(*args, method=self.session.post, **kwargs)
 
     def put(self, *args, **kwargs):
-        return self._api_call(*args, method=requests.put, **kwargs)
+        return self._api_call(*args, method=self.session.put, **kwargs)
 
     def delete(self, *args, **kwargs):
-        return self._api_call(*args, method=requests.delete, **kwargs)
+        return self._api_call(*args, method=self.session.delete, **kwargs)
 
     # ungrouped list functions
     def regions(self, *filters):

--- a/test/base.py
+++ b/test/base.py
@@ -72,7 +72,7 @@ class MethodMock:
         Begins the method mocking
         """
         self.patch = patch(
-            'linode_api4.linode_client.requests.'+self.method,
+            'linode_api4.linode_client.requests.Session.'+self.method,
             return_value=MockResponse(200, self.return_dct)
         )
         self.mock = self.patch.start()
@@ -130,7 +130,7 @@ class ClientBaseCase(TestCase):
     def setUp(self):
         self.client = LinodeClient('testing', base_url='/')
 
-        self.get_patch = patch('linode_api4.linode_client.requests.get',
+        self.get_patch = patch('linode_api4.linode_client.requests.Session.get',
                 side_effect=mock_get)
         self.get_patch.start()
 


### PR DESCRIPTION
The `Session()`[1] class in the requests library uses connection
pools[2] which support HTTP Keep-Alive. The Linode v4 API also supports
this sending back `'Connection': 'keep-alive'` in the headers. Making
use of Keep-Alive's can greatly reduce the amount of time spent on each
request by skipping things like TCP's three-way handshake and TLS
negotiation.

The following code snippet showed an approximate 40% decrease in time
taken to execute when a session was used going from 9.3 seconds to 5.3
seconds using Python 3.6.5.

```
import timy
import linode

client = linode.LinodeClient(token)

@timy.timer(loops=10)
def test(client):
    for user in client.account.get_users():
        pass

    for payment in client.account.get_payments():
        pass

test(client)
```

[1]: http://docs.python-requests.org/en/master/user/advanced/#session-objects
[2]: http://docs.python-requests.org/en/master/user/advanced/#keep-alive