### PR TITLE
Preserve raw JSON in objects

### DIFF
--- a/linode_api4/objects/base.py
+++ b/linode_api4/objects/base.py
@@ -76,6 +76,7 @@ class Base(object, with_metaclass(FilterableMetaclass)):
         self._set('_populated', False)
         self._set('_last_updated', datetime.min)
         self._set('_client', client)
+        self._set('_raw_json', None)
 
         for prop in type(self).properties:
             self._set(prop, None)
@@ -199,6 +200,9 @@ class Base(object, with_metaclass(FilterableMetaclass)):
         """
         if not json:
             return
+
+        # hide the raw JSON away in case someone needs it
+        self._set('_raw_json', json)
 
         for key in json:
             if key in (k for k in type(self).properties.keys()

--- a/linode_api4/objects/base.py
+++ b/linode_api4/objects/base.py
@@ -76,6 +76,11 @@ class Base(object, with_metaclass(FilterableMetaclass)):
         self._set('_populated', False)
         self._set('_last_updated', datetime.min)
         self._set('_client', client)
+
+        #: self._raw_json is a copy of the json received from the API on population,
+        #: and cannot be relied upon to be current.  Local changes to mutable fields
+        #: that have not been saved will not be present, and volatile fields will not
+        #: be updated on access.
         self._set('_raw_json', None)
 
         for prop in type(self).properties:

--- a/test/objects/linode_test.py
+++ b/test/objects/linode_test.py
@@ -22,6 +22,22 @@ class LinodeTest(ClientBaseCase):
         self.assertTrue(isinstance(linode.image, Image))
         self.assertEqual(linode.image.label, "Ubuntu 17.04")
 
+        json = linode._raw_json
+        self.assertIsNotNone(json)
+        self.assertEqual(json['id'], 123)
+        self.assertEqual(json['label'], 'linode123')
+        self.assertEqual(json['group'], 'test')
+
+        # test that the _raw_json stored on the object is sufficient to populate
+        # a new object
+        linode2 = Instance(self.client, json['id'], json=json)
+
+        self.assertTrue(linode2._populated)
+        self.assertEqual(linode2.id, linode.id)
+        self.assertEqual(linode2.label, linode.label)
+        self.assertEqual(linode2.group, linode.group)
+        self.assertEqual(linode2._raw_json, linode._raw_json)
+
     def test_rebuild(self):
         """
         Tests that you can rebuild with an image


### PR DESCRIPTION
This addresses the need presented in #141

There is not practical way to serialize objects once processed by this
library, as it applies many helpful (but not necessarily easy to
reverse) transformations to the data it receives from the API.  To
address this, I am preserving the raw JSON response the API returned for
objects.  This JSON is accessible to clients (although currently a
private property of the objects), and is even sufficient to populate a
new object if desired.  However, this approach has a few drawbacks:

 * Changes made to the object's mutable fields are not present in the raw JSON
 * The raw JSON is only updated if the object is repopulated, making it
   possible for the data to be stale if an object is kept in memory for
   a long time

Feedback on this approach is appreciated.  I can take a stab at
reversing the `_populate` function to generate a similar dict, but I
don't know if that's valuable (and it would be significantly more
effort).