### PR TITLE
Adds resize method to Instance objects

### DIFF
--- a/linode_api4/objects/linode.py
+++ b/linode_api4/objects/linode.py
@@ -349,6 +349,7 @@ class Instance(Base):
         return True
 
     def resize(self, new_type):
+        new_type = new_type.id if issubclass(type(new_type), Base) else new_type
         resp = self._client.post("{}/resize".format(Instance.api_endpoint), model=self, data={"type": new_type})
 
         if 'error' in resp:

--- a/linode_api4/objects/linode.py
+++ b/linode_api4/objects/linode.py
@@ -348,6 +348,13 @@ class Instance(Base):
             return False
         return True
 
+    def resize(self, new_type):
+        resp = self._client.post("{}/resize".format(Instance.api_endpoint), model=self, data={"type": new_type})
+
+        if 'error' in resp:
+            return False
+        return True
+
     @staticmethod
     def generate_root_password():
         def _func(value):

--- a/test/objects/linode_test.py
+++ b/test/objects/linode_test.py
@@ -160,6 +160,18 @@ class LinodeTest(ClientBaseCase):
             linode.boot()
             self.assertEqual(m.call_url, '/linode/instances/123/boot')
 
+    def test_resize(self):
+        """
+        Tests that you can submit a correct resize api request
+        """
+        linode = Instance(self.client, 123)
+        result = {}
+
+        with self.mock_post(result) as m:
+            linode.resize(new_type='g6-standard-1')
+            self.assertEqual(m.call_url, '/linode/instances/123/resize')
+            self.assertEqual(m.call_data, {'type': 'g6-standard-1'})
+
     def test_boot_with_config(self):
         """
         Tests that you can submit a correct boot with a config api request

--- a/test/objects/linode_test.py
+++ b/test/objects/linode_test.py
@@ -172,6 +172,19 @@ class LinodeTest(ClientBaseCase):
             self.assertEqual(m.call_url, '/linode/instances/123/resize')
             self.assertEqual(m.call_data, {'type': 'g6-standard-1'})
 
+    def test_resize_with_class(self):
+        """
+        Tests that you can submit a correct resize api request with a Base class type
+        """
+        linode = Instance(self.client, 123)
+        ltype = Type(self.client, 'g6-standard-2')
+        result = {}
+
+        with self.mock_post(result) as m:
+            linode.resize(new_type=ltype)
+            self.assertEqual(m.call_url, '/linode/instances/123/resize')
+            self.assertEqual(m.call_data, {'type': 'g6-standard-2'})
+
     def test_boot_with_config(self):
         """
         Tests that you can submit a correct boot with a config api request


### PR DESCRIPTION
Adds a method to resize Instances, calling the resize endpoint for linodes. Requires "type".

Includes test.