### PR TITLE
Capture and expose the "class" attribute of Linode Type

### DIFF
--- a/linode_api4/objects/linode.py
+++ b/linode_api4/objects/linode.py
@@ -11,6 +11,7 @@ from linode_api4.common import load_and_validate_keys
 from linode_api4.errors import UnexpectedResponseError
 from linode_api4.objects import Base, DerivedBase, Image, Property, Region
 from linode_api4.objects.base import MappedObject
+from linode_api4.objects.filtering import FilterableAttribute
 from linode_api4.objects.networking import IPAddress, IPv6Pool
 from linode_api4.paginated_list import PaginatedList
 
@@ -144,7 +145,22 @@ class Type(Base):
         'memory': Property(filterable=True),
         'transfer': Property(filterable=True),
         'vcpus': Property(filterable=True),
+        # type_class is populated from the 'class' attribute of the returned JSON
     }
+
+    def _populate(self, json):
+        """
+        Allows changing the name "class" in JSON to "type_class" in python
+        """
+        super(Type, self)._populate(json)
+
+        if 'class' in json:
+            setattr(self, 'type_class', json['class'])
+        else:
+            setattr(self, 'type_class', None)
+
+    # allow filtering on this converted type
+    type_class = FilterableAttribute('class')
 
 
 class Config(DerivedBase):

--- a/test/objects/linode_test.py
+++ b/test/objects/linode_test.py
@@ -252,6 +252,7 @@ class TypeTest(ClientBaseCase):
             self.assertIsNotNone(t.id)
             self.assertIsNotNone(t.label)
             self.assertIsNotNone(t.disk)
+            self.assertIsNotNone(t.type_class)
 
     def test_get_type_by_id(self):
         """
@@ -263,3 +264,4 @@ class TypeTest(ClientBaseCase):
         self.assertEqual(t.vcpus, 1)
         self.assertEqual(t.label, "Linode 1024")
         self.assertEqual(t.disk, 20480)
+        self.assertEqual(t.type_class, 'nanode')


### PR DESCRIPTION
Closes #153

This attribute needed to be renamed because "class" is a reserved word.
I'm pretty sure this does the job, but I'm open to feedback and naming
suggestions (`type_class` seems less than ideal, but I can't think of
better).