### PR TITLE
Fix README rendering on PyPI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,6 @@
 linode_api4
 ===========
 
-.. highlight:: python
-
 The official python library for the `Linode API v4`_ in python.
 
 **This library is currently in beta.**


### PR DESCRIPTION
[The library's PyPI page](https://pypi.org/project/linode-api4/2.0.1/) shows the README's source as plain text instead of rendering the markup.  This is because the README contains a `.. highlight::` directive, which is a Sphinx extension to reStructuredText that PyPI does not recognize, and so PyPI treats the entire README's markup as invalid and just shows the raw source instead.  Removing the `.. highlight::` directive will allow the README to render on PyPI.

See ["Validating reStructuredText markup"](https://packaging.python.org/guides/making-a-pypi-friendly-readme/#validating-restructuredtext-markup) in the Python Packaging User Guide for information on how to check the validity of your README's markup before uploading to PyPI.