### PR TITLE
Fix enum34 dependency declaration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,11 +85,13 @@ setup(
     install_requires=[
         "future",
         "requests",
-    ] if sys.version_info >= (3, 4) else [
-        "future",
-        "requests",
-        "enum34",
     ],
+
+    extras_require={
+        ':python_version < "3.4"': [
+            "enum34",
+        ],
+    },
 
     tests_require=[
         "mock",


### PR DESCRIPTION
`setup.py` currently declares `enum34` as a dependency iff it is being run under a Python less than 3.4.  As a result, a wheel built for this project will either omit this dependency entirely (if Python 3.4+ is used to build the wheel) or else it will require `enum34` unconditionally.  This patch fixes this behavior by using `extras_require` to declare `enum34` as a dependency with the marker `python_version < "3.4"`, causing wheels built for the project to properly preserve the conditional dependency.