### PR TITLE
Enable testing with Python 3.7 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ python:
     - "3.4"
     - "3.5"
     - "3.6"
+    - "3.7"
+dist: xenial
 install:
     - python setup.py install
     - pip install pylint pytest coverage


### PR DESCRIPTION
I see you've been trying to enable testing with Python 3.7 on Travis but can't get it to work.  You need to set "`distro: xenial`" in order for 3.7 to be available.