### PR TITLE
Don't install test/

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
 
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
-    packages=find_packages(exclude=['contrib', 'docs', 'tests']),
+    packages=find_packages(exclude=['contrib', 'docs', 'test', 'test.*']),
 
     # What do we need for this to run
     install_requires=[


### PR DESCRIPTION
Currently, installing the library (whether from source or from a wheel) causes the `test/` directory to be installed as well.  Presumably, this is not what you want, and so this patch fixes that.

(If installing `test/` *is* what you want, I would first try to dissuade you on the basis that there is no mechanism for making use of installed tests, so there's no point to installing them.  If you still feel like installing them, I would more strongly urge you to move the `test/` directory to inside `linode_api4/`, as having `test/` installed at the root level clashes with too many other poorly-made packages that do the same thing.)

Note that this PR causes `test/` to be excluded from sdists; #162 undoes this while still not installing `test/`.