### PR TITLE
Include all of test/ in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+graft test
+global-exclude *.pyc


### PR DESCRIPTION
The library's source distribution ("sdist"; the .tar.gz built file) currently includes all of the Python files in `test/` but does not include any of the JSON fixture files, meaning that tests cannot be run from the sdist.  This patch fixes that.