### PR TITLE
Removed the ancillary outer paren, and added a new closing paren for the

### DIFF
--- a/linode_api4/objects/volume.py
+++ b/linode_api4/objects/volume.py
@@ -47,10 +47,10 @@ class Volume(Base):
         """
         Resizes this Volume
         """
-        result = self._client.post('{}/resize'.format(Volume.api_endpoint, model=self,
-            data={ "size": size }))
+        result = self._client.post('{}/resize'.format(Volume.api_endpoint), model=self,
+            data={ "size": size })
 
-        self._populate(result.json)
+        self._populate(result)
 
         return True
 


### PR DESCRIPTION
Removed the ancillary closing paren on line 52 for the self._client.post() call.
Added a closing paren to the format() call inside the self._client.post() call on line 51.

Removed the un-needed .json attribute on line 53 from the self._populate(result) call.

Doing this has allowed me to resize a volume by the wrapper library successfully and get the correct output.