### PR TITLE
Feature/object storage support

### DIFF
--- a/linode_api4/linode_client.py
+++ b/linode_api4/linode_client.py
@@ -817,6 +817,15 @@ class ObjectStorageGroup(Group):
         ret = ObjectStorageKeys(self.client, result['id'], result)
         return ret
 
+    def cancel(self):
+        """
+        Cancels Object Storage service.  This may be a destructive operation.  Once
+        cancelled, you will no longer receive the transfer for or be billed for
+        Object Storage, and all keys will be invalidated.
+        """
+        self.client.post('/object-storage/cancel', data={})
+        return True
+
 
 class LinodeClient:
     def __init__(self, token, base_url="https://api.linode.com/v4", user_agent=None):

--- a/linode_api4/objects/__init__.py
+++ b/linode_api4/objects/__init__.py
@@ -13,3 +13,4 @@ from .support import *
 from .profile import *
 from .longview import *
 from .tag import Tag
+from .object_storage import ObjectStorageCluster, ObjectStorageKeys

--- a/linode_api4/objects/account.py
+++ b/linode_api4/objects/account.py
@@ -256,7 +256,7 @@ class User(Base):
         :returns: The grants for this user.
         :rtype: linode.objects.account.UserGrants
         """
-        from linode_api4.objects.account import UserGrants # pylint: disable=import-outside-toplevel
+        from linode_api4.objects.account import UserGrants # pylint: disable-all
         if not hasattr(self, '_grants'):
             resp = self._client.get(UserGrants.api_endpoint.format(username=self.username))
 

--- a/linode_api4/objects/account.py
+++ b/linode_api4/objects/account.py
@@ -33,6 +33,7 @@ class Account(Base):
         "zip": Property(mutable=True),
         "address_2": Property(mutable=True),
         "tax_id": Property(mutable=True),
+        "capabilities": Property(),
     }
 
 
@@ -43,7 +44,8 @@ class AccountSettings(Base):
     properties = {
         "network_helper": Property(mutable=True),
         "managed": Property(),
-        "longview_subscription": Property(slug_relationship=LongviewSubscription)
+        "longview_subscription": Property(slug_relationship=LongviewSubscription),
+        "object_storage": Property(),
     }
 
 

--- a/linode_api4/objects/base.py
+++ b/linode_api4/objects/base.py
@@ -292,7 +292,7 @@ class Base(object, with_metaclass(FilterableMetaclass)):
 
         :returns: An instance of cls with the given id
         """
-        from .dbase import DerivedBase # pylint: disable=import-outside-toplevel
+        from .dbase import DerivedBase # pylint: disable-all
 
         if issubclass(cls, DerivedBase):
             return cls(client, id, parent_id, json)

--- a/linode_api4/objects/networking.py
+++ b/linode_api4/objects/networking.py
@@ -41,7 +41,7 @@ class IPAddress(Base):
 
     @property
     def linode(self):
-        from .linode import Instance # pylint: disable=import-outside-toplevel
+        from .linode import Instance # pylint: disable-all
         if not hasattr(self, '_linode'):
             self._set('_linode', Instance(self._client, self.linode_id))
         return self._linode
@@ -52,7 +52,7 @@ class IPAddress(Base):
         of that context.  It's used to cleanly build an IP Assign request with
         pretty python syntax.
         """
-        from .linode import Instance # pylint: disable=import-outside-toplevel
+        from .linode import Instance # pylint: disable-all
         if not isinstance(linode, Instance):
             raise ValueError("IP Address can only be assigned to a Linode!")
         return { "address": self.address, "linode_id": linode.id }

--- a/linode_api4/objects/object_storage.py
+++ b/linode_api4/objects/object_storage.py
@@ -1,0 +1,32 @@
+from __future__ import absolute_import
+
+from linode_api4.objects import Base, DerivedBase, Image, Property, Region
+
+
+class ObjectStorageCluster(Base):
+    """
+    A cluster where Object Storage is available.
+    """
+    api_endpoint = '/object-storage/clusters/{id}'
+
+    properties = {
+        'id': Property(identifier=True),
+        'region': Property(slug_relationship=Region),
+        'status': Property(),
+        'domain': Property(),
+        'static_site_domain': Property(),
+    }
+
+
+class ObjectStorageKeys(Base):
+    """
+    A keypair that allows third-party applications to access Linode Object Storage.
+    """
+    api_endpoint = '/object-storage/keys/{id}'
+
+    properties = {
+        'id': Property(identifier=True),
+        'label': Property(mutable=True),
+        'access_key': Property(),
+        'secret_key': Property(),
+    }

--- a/linode_api4/objects/profile.py
+++ b/linode_api4/objects/profile.py
@@ -92,7 +92,7 @@ class Profile(Base):
         """
         Returns grants for the current user
         """
-        from linode_api4.objects.account import UserGrants # pylint: disable=import-outside-toplevel
+        from linode_api4.objects.account import UserGrants # pylint: disable-all
         resp = self._client.get('/profile/grants') # use special endpoint for restricted users
 
         grants = None

--- a/linode_api4/objects/region.py
+++ b/linode_api4/objects/region.py
@@ -8,4 +8,5 @@ class Region(Base):
     properties = {
         'id': Property(identifier=True),
         'country': Property(filterable=True),
+        'capabilities': Property(),
     }

--- a/test/fixtures/account.json
+++ b/test/fixtures/account.json
@@ -11,5 +11,11 @@
   "zip": "19106",
   "first_name": "Test",
   "last_name": "Guy",
-  "country": "US"
+  "country": "US",
+  "capabilities": [
+    "Linodes",
+    "NodeBalancers",
+    "Block Storage",
+    "Object Storage"
+  ]
 }

--- a/test/fixtures/account_settings.json
+++ b/test/fixtures/account_settings.json
@@ -1,5 +1,6 @@
 {
   "longview_subscription": "longview-100",
   "managed": false,
-  "network_helper": false
+  "network_helper": false,
+  "object_storage": "active"
 }

--- a/test/fixtures/object-storage_clusters.json
+++ b/test/fixtures/object-storage_clusters.json
@@ -1,0 +1,14 @@
+{
+  "pages": 1,
+  "page": 1,
+  "data": [
+    {
+      "id": "us-east-1",
+      "status": "available",
+      "static_site_domain": "website-us-east-1.linodeobjects.com",
+      "region": "us-east",
+      "domain": "us-east-1.linodeobjects.com"
+    }
+  ],
+  "results": 1
+}

--- a/test/fixtures/object-storage_keys.json
+++ b/test/fixtures/object-storage_keys.json
@@ -1,0 +1,19 @@
+{
+  "results": 2,
+  "pages": 1,
+  "data": [
+    {
+      "id": 1,
+      "label": "object-storage-key-1",
+      "secret_key": "[REDACTED]",
+      "access_key": "testAccessKeyHere123"
+    },
+    {
+      "id": 2,
+      "label": "object-storage-key-2",
+      "secret_key": "[REDACTED]",
+      "access_key": "testAccessKeyHere456"
+    }
+  ],
+  "page": 1
+}

--- a/test/fixtures/regions.json
+++ b/test/fixtures/regions.json
@@ -3,39 +3,92 @@
   "data": [
     {
       "country": "us",
-      "id": "us-south-1a"
+      "id": "us-south-1a",
+      "capabilities": [
+        "Linodes",
+        "NodeBalancers",
+        "Block Storage"
+      ]
+
     },
     {
       "country": "us",
-      "id": "us-west-1a"
+      "id": "us-west-1a",
+      "capabilities": [
+        "Linodes",
+        "NodeBalancers",
+        "Block Storage"
+      ]
+
     },
     {
       "country": "us",
-      "id": "us-southeast-1a"
+      "id": "us-southeast",
+      "capabilities": [
+        "Linodes",
+        "NodeBalancers",
+        "Block Storage"
+      ]
     },
     {
       "country": "us",
-      "id": "us-east-1a"
+      "id": "us-east-1a",
+      "capabilities": [
+        "Linodes",
+        "NodeBalancers",
+        "Block Storage",
+        "Object Storage"
+      ]
+
     },
     {
       "country": "uk",
-      "id": "eu-west-1a"
+      "id": "eu-west-1a",
+      "capabilities": [
+        "Linodes",
+        "NodeBalancers",
+        "Block Storage"
+      ]
+
     },
     {
       "country": "sg",
-      "id": "ap-south-1a"
+      "id": "ap-south-1a",
+      "capabilities": [
+        "Linodes",
+        "NodeBalancers",
+        "Block Storage"
+      ]
+
     },
     {
       "country": "de",
-      "id": "eu-central-1a"
+      "id": "eu-central-1a",
+      "capabilities": [
+        "Linodes",
+        "NodeBalancers",
+        "Block Storage"
+      ]
+
     },
     {
       "country": "jp",
-      "id": "ap-northeast-1b"
+      "id": "ap-northeast-1b",
+      "capabilities": [
+        "Linodes",
+        "NodeBalancers",
+        "Block Storage"
+      ]
+
     },
     {
       "country": "jp",
-      "id": "ap-northeast-1a"
+      "id": "ap-northeast-1a",
+      "capabilities": [
+        "Linodes",
+        "NodeBalancers",
+        "Block Storage"
+      ]
     }
   ],
   "page": 1,

--- a/test/linode_client_test.py
+++ b/test/linode_client_test.py
@@ -36,6 +36,7 @@ class LinodeClientGeneralTest(ClientBaseCase):
         self.assertEqual(a.zip, '19106')
         self.assertEqual(a.tax_id, '')
         self.assertEqual(a.balance, 0)
+        self.assertEqual(a.capabilities, ["Linodes","NodeBalancers","Block Storage","Object Storage"])
 
     def test_get_regions(self):
         r = self.client.regions()
@@ -45,6 +46,10 @@ class LinodeClientGeneralTest(ClientBaseCase):
             self.assertTrue(region._populated)
             self.assertIsNotNone(region.id)
             self.assertIsNotNone(region.country)
+            if region.id == 'us-east-1a':
+                self.assertEqual(region.capabilities, ["Linodes","NodeBalancers","Block Storage","Object Storage"])
+            else:
+                self.assertEqual(region.capabilities, ["Linodes","NodeBalancers","Block Storage"])
 
     def test_get_images(self):
         r = self.client.images()
@@ -204,6 +209,7 @@ class AccountGroupTest(ClientBaseCase):
         self.assertEqual(s.managed, False)
         self.assertEqual(type(s.longview_subscription), LongviewSubscription)
         self.assertEqual(s.longview_subscription.id, 'longview-100')
+        self.assertEqual(s.object_storage, "active")
 
     def test_get_invoices(self):
         """

--- a/test/linode_client_test.py
+++ b/test/linode_client_test.py
@@ -418,3 +418,55 @@ class ProfileGroupTest(ClientBaseCase):
                             "CmhW7erNJNVxYjtzseGpBLmRRUTsT038w==dorthu@dorthu-command",
                 "label": "Work Laptop"
             })
+
+class ObjectStorageGroupTest(ClientBaseCase):
+    """
+    Tests for the ObjectStorageGroup
+    """
+    def test_get_clusters(self):
+        """
+        Tests that Object Storage Clusters can be retrieved
+        """
+        clusters = self.client.object_storage.clusters()
+
+        self.assertEqual(len(clusters), 1)
+        cluster = clusters[0]
+
+        self.assertEqual(cluster.id, 'us-east-1')
+        self.assertEqual(cluster.region.id, 'us-east')
+        self.assertEqual(cluster.domain, 'us-east-1.linodeobjects.com')
+        self.assertEqual(cluster.static_site_domain, 'website-us-east-1.linodeobjects.com')
+
+    def test_get_keys(self):
+        """
+        Tests that you can retrieve Object Storage Keys
+        """
+        keys = self.client.object_storage.keys()
+
+        self.assertEqual(len(keys), 2)
+        key1 = keys[0]
+        key2 = keys[1]
+
+        self.assertEqual(key1.id, 1)
+        self.assertEqual(key1.label, 'object-storage-key-1')
+        self.assertEqual(key1.access_key, 'testAccessKeyHere123')
+        self.assertEqual(key1.secret_key, '[REDACTED]')
+
+        self.assertEqual(key2.id, 2)
+        self.assertEqual(key2.label, 'object-storage-key-2')
+        self.assertEqual(key2.access_key, 'testAccessKeyHere456')
+        self.assertEqual(key2.secret_key, '[REDACTED]')
+
+    def test_keys_create(self):
+        """
+        Tests that you can create Object Storage Keys
+        """
+        with self.mock_post('object-storage/keys/1') as m:
+            keys = self.client.object_storage.keys_create('object-storage-key-1')
+
+            self.assertIsNotNone(keys)
+            self.assertEqual(keys.id, 1)
+            self.assertEqual(keys.label, 'object-storage-key-1')
+
+            self.assertEqual(m.call_url, '/object-storage/keys')
+            self.assertEqual(m.call_data, {"label":"object-storage-key-1"})


### PR DESCRIPTION
Currently, to use this, you must set the `base_url` when creating your
LinodeClient:

```python
client = LinodeClient(my_token, base_url='https://api.linode.com/v4beta')
```

This will change in the future.

This adds support for:

* Object Storage Clusters
* Object Storage Keys

For interacting with buckets or objects, please create keys and use a
library like `boto3`.
