### PR TITLE
Add tag property to DomainRecord

### DIFF
--- a/linode_api4/objects/domain.py
+++ b/linode_api4/objects/domain.py
@@ -21,6 +21,7 @@ class DomainRecord(DerivedBase):
         'service': Property(mutable=True),
         'protocol': Property(mutable=True),
         'ttl_sec': Property(mutable=True),
+        'tag': Property(mutable=True),
     }
 
 


### PR DESCRIPTION
Added `tag` property to `DomainRecord` to support CAA RR types, in line with https://developers.linode.com/api/v4/domains-domain-id-records-record-id