### PR TITLE
made MappedObject serializable to allow alerts to be mutable

### DIFF
--- a/linode_api4/objects/base.py
+++ b/linode_api4/objects/base.py
@@ -69,6 +69,10 @@ class MappedObject:
 
     def __repr__(self):
         return "Mapping containing {}".format(vars(self).keys())
+    
+    @property
+    def dict(self):
+        return self.__dict__
 
 class Base(object, with_metaclass(FilterableMetaclass)):
     """
@@ -191,6 +195,8 @@ class Base(object, with_metaclass(FilterableMetaclass)):
         for k, v in result.items():
             if isinstance(v, Base):
                 result[k] = v.id
+            elif type(v)==MappedObject:
+                result[k] = v.dict
 
         return result
 

--- a/linode_api4/objects/base.py
+++ b/linode_api4/objects/base.py
@@ -72,7 +72,7 @@ class MappedObject:
     
     @property
     def dict(self):
-        return self.__dict__
+        return dict(self.__dict__)
 
 class Base(object, with_metaclass(FilterableMetaclass)):
     """
@@ -195,7 +195,7 @@ class Base(object, with_metaclass(FilterableMetaclass)):
         for k, v in result.items():
             if isinstance(v, Base):
                 result[k] = v.id
-            elif type(v)==MappedObject:
+            elif isinstance(v,MappedObject):
                 result[k] = v.dict
 
         return result

--- a/linode_api4/objects/linode.py
+++ b/linode_api4/objects/linode.py
@@ -222,7 +222,7 @@ class Instance(Base):
         'created': Property(is_datetime=True),
         'updated': Property(volatile=True, is_datetime=True),
         'region': Property(slug_relationship=Region, filterable=True),
-        'alerts': Property(),
+        'alerts': Property(mutable=True),
         'image': Property(slug_relationship=Image, filterable=True),
         'disks': Property(derived_class=Disk),
         'configs': Property(derived_class=Config),

--- a/test/objects/linode_test.py
+++ b/test/objects/linode_test.py
@@ -124,6 +124,13 @@ class LinodeTest(ClientBaseCase):
 
             self.assertEqual(m.call_url, '/linode/instances/123')
             self.assertEqual(m.call_data, {
+                "alerts": {
+                    "cpu": 90,
+                    "io": 5000,
+                    "network_in": 5,
+                    "network_out": 5,
+                    "transfer_quota": 80
+                },
                 "label": "NewLinodeLabel",
                 "group": "new_group",
                 "tags": ["something"],


### PR DESCRIPTION
created a getter for the dict object inside MappedObject to allow it to be called during serialize in order to allow MappedObject to be converted to JSON so it can be passed in an API calls. This allows the editing of instance Alerts in the API. 