### PR TITLE
Fix incorrect endpoint in NetworkingGroup.ip_allocate method

### DIFF
--- a/linode_api4/linode_client.py
+++ b/linode_api4/linode_client.py
@@ -679,7 +679,7 @@ class NetworkingGroup(Group):
         :returns: The new IPAddress
         :rtype: IPAddress
         """
-        result = self.client.post('/networking/ipv4/', data={
+        result = self.client.post('/networking/ips/', data={
             "linode_id": linode.id if isinstance(linode, Base) else linode,
             "type": "ipv4",
             "public": public,


### PR DESCRIPTION
Endpoint in `NetworkingGroup.ip_allocate` was incorrect.
According to [API](https://developers.linode.com/api/v4/networking-ips/#post) `https://api.linode.com/v4/networking/ips` endpoint should be used instead of current.
Note, `instance.ip_allocate(instance, public=False)` works as expected because uses correct endpoint.

Closes #177