### PR TITLE
add properties to Region object to match API

### DIFF
--- a/linode_api4/objects/region.py
+++ b/linode_api4/objects/region.py
@@ -7,4 +7,6 @@ class Region(Base):
         'id': Property(identifier=True),
         'country': Property(filterable=True),
         'capabilities': Property(),
+        'status': Property(mutable=True),
+        'resolvers': Property(),
     }


### PR DESCRIPTION
The `status` and `resolvers` properties were missing from the Region object. This adds them