### PR TITLE
Allow making requests using non-default page sizes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
     - "3.6"
     - "3.7"
     - "3.8"
+    - "3.9"
 dist: xenial
 install:
     - python setup.py install

--- a/linode_api4/linode_client.py
+++ b/linode_api4/linode_client.py
@@ -1015,7 +1015,7 @@ class ObjectStorageGroup(Group):
 
 
 class LinodeClient:
-    def __init__(self, token, base_url="https://api.linode.com/v4", user_agent=None):
+    def __init__(self, token, base_url="https://api.linode.com/v4", user_agent=None, default_page_size=None):
         """
         The main interface to the Linode API.
 
@@ -1031,11 +1031,17 @@ class LinodeClient:
                            application.  Setting this is not necessary, but some
                            applications may desire this behavior.
         :type user_agent: str
+        :param default_page_size: The default size to request pages at.  If not given,
+                                  the API's default page size is used.  Valid values
+                                  can be found in the API docs, but at time of writing
+                                  are between 25 and 500.
+        :type default_page_size: int
         """
         self.base_url = base_url
         self._add_user_agent = user_agent
         self.token = token
         self.session = requests.Session()
+        self.default_page_size = default_page_size
 
         #: Access methods related to Linodes - see :any:`LinodeGroup` for
         #: more information
@@ -1163,7 +1169,12 @@ class LinodeClient:
         return j
 
     def _get_objects(self, endpoint, cls, model=None, parent_id=None, filters=None):
-        response_json = self.get(endpoint, model=model, filters=filters)
+        # handle non-default page sizes
+        call_endpoint = endpoint
+        if self.default_page_size is not None:
+            call_endpoint += "?page_size={}".format(self.default_page_size)
+
+        response_json = self.get(call_endpoint, model=model, filters=filters)
 
         if not "data" in response_json:
             raise UnexpectedResponseError("Problem with response!", json=response_json)

--- a/linode_api4/linode_client.py
+++ b/linode_api4/linode_client.py
@@ -1015,7 +1015,7 @@ class ObjectStorageGroup(Group):
 
 
 class LinodeClient:
-    def __init__(self, token, base_url="https://api.linode.com/v4", user_agent=None, default_page_size=None):
+    def __init__(self, token, base_url="https://api.linode.com/v4", user_agent=None, page_size=None):
         """
         The main interface to the Linode API.
 
@@ -1031,17 +1031,17 @@ class LinodeClient:
                            application.  Setting this is not necessary, but some
                            applications may desire this behavior.
         :type user_agent: str
-        :param default_page_size: The default size to request pages at.  If not given,
+        :param page_size: The default size to request pages at.  If not given,
                                   the API's default page size is used.  Valid values
                                   can be found in the API docs, but at time of writing
                                   are between 25 and 500.
-        :type default_page_size: int
+        :type page_size: int
         """
         self.base_url = base_url
         self._add_user_agent = user_agent
         self.token = token
         self.session = requests.Session()
-        self.default_page_size = default_page_size
+        self.page_size = page_size
 
         #: Access methods related to Linodes - see :any:`LinodeGroup` for
         #: more information
@@ -1171,8 +1171,8 @@ class LinodeClient:
     def _get_objects(self, endpoint, cls, model=None, parent_id=None, filters=None):
         # handle non-default page sizes
         call_endpoint = endpoint
-        if self.default_page_size is not None:
-            call_endpoint += "?page_size={}".format(self.default_page_size)
+        if self.page_size is not None:
+            call_endpoint += "?page_size={}".format(self.page_size)
 
         response_json = self.get(call_endpoint, model=model, filters=filters)
 

--- a/linode_api4/paginated_list.py
+++ b/linode_api4/paginated_list.py
@@ -84,7 +84,7 @@ class PaginatedList(object):
         return "PaginatedList ({} items)".format(self.total_items)
 
     def _load_page(self, page_number):
-        j = self.client.get("/{}?page={}".format(self.page_endpoint, page_number+1),
+        j = self.client.get("/{}?page={}&page_size={}".format(self.page_endpoint, page_number+1, self.page_size),
                 filters=self.query_filters)
 
         if j['pages'] != self.max_pages or j['results'] != len(self):

--- a/test/paginated_list_test.py
+++ b/test/paginated_list_test.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+from unittest.mock import MagicMock
 
 from linode_api4.paginated_list import PaginatedList
 
@@ -76,3 +77,36 @@ class PaginationSlicingTest(TestCase):
         Tests that backwards indexing works as expected
         """
         self.assertEqual(self.normal_list[10:5], self.paginated_list[10:5])
+
+
+class PageLoadingTest(TestCase):
+    def test_page_size_in_request(self):
+        """
+        Tests that the correct page_size is added to requests when loading subsequent pages
+        """
+        class Test():
+            # the PaginatedList expects a model class here
+            @classmethod
+            def make_instance(*args, **kwargs):
+                return Test()
+
+        for i in (25, 100, 500):
+            # these are the pages we're sending in to the mocked list
+            first_page = [ Test()  for x in range(i) ]
+            second_page = {
+                "data": [{"id": 1}],
+                "pages": 2,
+                "page": 2,
+                "results": i + 1,
+            }
+
+            # our mock client to intercept the requests and return the mocked info
+            client = MagicMock()
+            client.get = MagicMock(return_value=second_page)
+
+            # let's do it!
+            p = PaginatedList(client, "/test", page=first_page, max_pages=2, total_items=i+1)
+            p[i] # load second page
+
+            # and we called the next page URL with the correct page_size
+            assert client.mock_calls[0].args[0].endswith("?page=2&page_size={}".format(i))

--- a/test/paginated_list_test.py
+++ b/test/paginated_list_test.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 from linode_api4.paginated_list import PaginatedList
 
@@ -109,4 +109,4 @@ class PageLoadingTest(TestCase):
             p[i] # load second page
 
             # and we called the next page URL with the correct page_size
-            assert client.mock_calls[0].args[0].endswith("?page=2&page_size={}".format(i))
+            assert client.get.call_args == call("//test?page=2&page_size={}".format(i), filters=None)


### PR DESCRIPTION
Right now, this library never specifies a `page_size` parameter when
requesting objects from the API.  This causes us to always use the
default page size of (presently) 100 items, when (presently) pages from
25 to 500 items is supported.

This change will allow the `LinodeClient` class to accept a
`page_size` argument on creation, which is forwarded along to
the API when making `PaginatedList` objects to change the number of
objects fetched from listing endpoints at a time.

This still needs:

- [x] Tests