### PR TITLE
paginated_list: Fix the 'IndexError' exception when max_pages=0

### DIFF
--- a/linode_api4/paginated_list.py
+++ b/linode_api4/paginated_list.py
@@ -35,7 +35,7 @@ class PaginatedList(object):
         self.page_endpoint = page_endpoint
         self.query_filters = filters
         self.page_size = len(page)
-        self.max_pages = max_pages
+        self.max_pages = max_pages if max_pages > 0 else 1
         self.lists = [ None for _ in range(0, self.max_pages) ]
         self.lists[0] = page
         self.list_cls = type(page[0]) if page else None # TODO if this is None that's bad

--- a/test/paginated_list_test.py
+++ b/test/paginated_list_test.py
@@ -4,6 +4,14 @@ from unittest.mock import MagicMock, call
 from linode_api4.paginated_list import PaginatedList
 
 
+class PaginatedListTest(TestCase):
+    def test_init_zero_max_pages(self):
+        """
+        Ensures that PaginatedList can be instatiated with max_pages=0
+        """
+        self.paginated_list = PaginatedList(None, None, max_pages=0)
+
+
 class PaginationSlicingTest(TestCase):
     def setUp(self):
         """


### PR DESCRIPTION
This could happen for example if the image filter was invalid, i.e.
'Image.is_public == None' or the API key simply doesn't have
permissions to list private images.
Along with the fix a new test case class is introduced and intends to
test the very basic functionality of the PaginatedList class, e.g.
instantiation.

Signed-off-by: Erik Skultety <eskultet@redhat.com>