### PR TITLE
bug: Handle empty PaginatedList responses

### DIFF
--- a/linode_api4/paginated_list.py
+++ b/linode_api4/paginated_list.py
@@ -37,7 +37,8 @@ class PaginatedList(object):
         self.page_size = len(page)
         self.max_pages = max_pages
         self.lists = [ None for _ in range(0, self.max_pages) ]
-        self.lists[0] = page
+        if self.lists:
+            self.lists[0] = page
         self.list_cls = type(page[0]) if page else None # TODO if this is None that's bad
         self.objects_parent_id = parent_id
         self.cur = 0 # for being a generator

--- a/test/paginated_list_test.py
+++ b/test/paginated_list_test.py
@@ -79,20 +79,25 @@ class PaginationSlicingTest(TestCase):
         self.assertEqual(self.normal_list[10:5], self.paginated_list[10:5])
 
 
+class TestModel():
+    """
+    This is a test model class used to simulate an actual model that would be
+    returned by the API
+    """
+    @classmethod
+    def make_instance(*args, **kwargs):
+        return TestModel()
+
+
 class PageLoadingTest(TestCase):
     def test_page_size_in_request(self):
         """
         Tests that the correct page_size is added to requests when loading subsequent pages
         """
-        class Test():
-            # the PaginatedList expects a model class here
-            @classmethod
-            def make_instance(*args, **kwargs):
-                return Test()
 
         for i in (25, 100, 500):
             # these are the pages we're sending in to the mocked list
-            first_page = [ Test()  for x in range(i) ]
+            first_page = [ TestModel()  for x in range(i) ]
             second_page = {
                 "data": [{"id": 1}],
                 "pages": 2,
@@ -110,3 +115,14 @@ class PageLoadingTest(TestCase):
 
             # and we called the next page URL with the correct page_size
             assert client.get.call_args == call("//test?page=2&page_size={}".format(i), filters=None)
+
+    def test_no_pages(self):
+        """
+        Tests that this library correctly handles paginated lists with no data, such
+        as if a paginated endpoint is given a filter that matches nothing.
+        """
+        client = MagicMock()
+
+        p = PaginatedList(client, "/test", page=[], max_pages=0, total_items=0)
+
+        assert(len(p) == 0)


### PR DESCRIPTION
Closes #191

If a filter is given to a collection that resulted in no matches, the
resulting API response would include `"pages": 0`, `"page": 0`, and
`"results": 0`.  Those API responses are fine, but this library didn't
handle them, assuming there's always be at least one result.

This change fixes that assumption and allows this library to properly
return empty PaginatedLists.