### PR TITLE
Don't default new disks to "raw" filesystem types

### DIFF
--- a/linode_api4/objects/linode.py
+++ b/linode_api4/objects/linode.py
@@ -514,7 +514,7 @@ class Instance(Base):
             'size': size,
             'label': label if label else "{}_disk_{}".format(self.label, len(self.disks)),
             'read_only': read_only,
-            'filesystem': filesystem if filesystem else 'raw',
+            'filesystem': filesystem,
             'authorized_keys': authorized_keys,
         }
 


### PR DESCRIPTION
We recently noticed that, when deploying disks from a custom image, they
were being created with a "raw" filesystem type unexpectedly.  These
should inherit the filesystem type from the image they're being restored
from, but if one is provided in the request, the API will use that
instead.  This library tries to be impartial and allow defaults to come
from the API, or errors to be returned if no default is available, so
default to "raw" in this case is unexpected and, I believe, incorrect in
most cases.

This change removes the default filesystem type of "raw" for new disks,
allowing the API to choose whatever value is a sensible default for the
deployment, or error if a value is required (although I don't believe
that will happen, as [the docs](https://www.linode.com/docs/api/linode-instances/#disk-create) don't list this field as required, and I believe it
will default to "ext4").