### PR TITLE
Fixed type checking issue with bucket_access in keys_create

### DIFF
--- a/linode_api4/common.py
+++ b/linode_api4/common.py
@@ -27,7 +27,7 @@ def load_and_validate_keys(authorized_keys):
 
     for k in authorized_keys:
         accepted_types = ('ssh-dss', 'ssh-rsa', 'ecdsa-sha2-nistp', 'ssh-ed25519')
-        if any([ t for t in accepted_types if k.startswith(t) ]):
+        if any([ t for t in accepted_types if k.startswith(t) ]): # pylint: disable=use-a-generator
             # this looks like a key, cool
             ret.append(k)
         else:

--- a/linode_api4/linode_client.py
+++ b/linode_api4/linode_client.py
@@ -726,7 +726,7 @@ class AccountGroup(Group):
         }
         result = self.client.post('/account/users', data=params)
 
-        if not 'email' and 'restricted' and 'username' in result:
+        if not all([c in result for c in ('email', 'restricted', 'username')]):
             raise UnexpectedResponseError('Unexpected response when creating user!', json=result)
 
         u = User(self.client, result['username'], result)

--- a/linode_api4/linode_client.py
+++ b/linode_api4/linode_client.py
@@ -979,7 +979,7 @@ class ObjectStorageGroup(Group):
                 {
                     "permissions": c.get("permissions"),
                     "bucket_name": c.get("bucket_name"),
-                    "cluster": c.id if "cluster" in c and issubclass(c["cluster"], Base) else c.get("cluster"),
+                    "cluster": c.id if "cluster" in c and issubclass(type(c["cluster"]), Base) else c.get("cluster"),
                 } for c in bucket_access
             ]
 

--- a/linode_api4/linode_client.py
+++ b/linode_api4/linode_client.py
@@ -726,7 +726,7 @@ class AccountGroup(Group):
         }
         result = self.client.post('/account/users', data=params)
 
-        if not all([c in result for c in ('email', 'restricted', 'username')]):
+        if not all([c in result for c in ('email', 'restricted', 'username')]): # pylint: disable=use-a-generator
             raise UnexpectedResponseError('Unexpected response when creating user!', json=result)
 
         u = User(self.client, result['username'], result)


### PR DESCRIPTION
This pull requests fixes an issue with `ObjectStorageGroup.keys_create()` that causes errors when `bucket_access` is specified.