### PR TITLE
Add VLANs and Config Interfaces

### DIFF
--- a/linode_api4/linode_client.py
+++ b/linode_api4/linode_client.py
@@ -745,6 +745,10 @@ class NetworkingGroup(Group):
     def vlans(self, *filters):
         """
         .. note:: This endpoint is in beta. This will only function if base_url is set to `https://api.linode.com/v4beta`.
+        Returns a list of VLANs on your account.
+        
+        :returns: A Paginated List of VLANs on your account.
+        :rtype: PaginatedList of VLAN
         """
         return self.client._get_and_filter(VLAN, *filters)
 

--- a/linode_api4/linode_client.py
+++ b/linode_api4/linode_client.py
@@ -742,6 +742,12 @@ class NetworkingGroup(Group):
     def ipv6_pools(self, *filters):
         return self.client._get_and_filter(IPv6Pool, *filters)
 
+    def vlans(self, *filters):
+        """
+        .. note:: This endpoint is in beta. This will only function if base_url is set to `https://api.linode.com/v4beta`.
+        """
+        return self.client._get_and_filter(VLAN, *filters)
+
     def ips_assign(self, region, *assignments):
         """
         Redistributes :any:`IP Addressees<IPAddress>` within a single region.
@@ -850,6 +856,7 @@ class NetworkingGroup(Group):
                          model=linode, data=params)
 
         linode.invalidate() # clear the Instance's shared IPs
+
 
 class SupportGroup(Group):
     def tickets(self, *filters):

--- a/linode_api4/objects/linode.py
+++ b/linode_api4/objects/linode.py
@@ -182,6 +182,7 @@ class Config(DerivedBase):
         "run_level": Property(mutable=True, filterable=True),
         "virt_mode": Property(mutable=True, filterable=True),
         "memory_limit": Property(mutable=True, filterable=True),
+        "interfaces": Property(mutable=True),
     }
 
     def _populate(self, json):

--- a/linode_api4/objects/linode.py
+++ b/linode_api4/objects/linode.py
@@ -162,6 +162,45 @@ class Type(Base):
     type_class = FilterableAttribute('class')
 
 
+class ConfigInterface:
+    """
+    This is a helper class used to populate 'interfaces' in the Config calss
+    below.
+    """
+    def __init__(self, purpose, label="", ipam_address=""):
+        """
+        Creates a new ConfigInterface
+        """
+        #: The Label for the VLAN this interface is connected to.  Blank for public
+        #: interfaces.
+        self.label = label
+
+        #: The IPAM Address this interface will bring up.  Blank for public interfaces.
+        self.ipam_address = ipam_address
+
+        #: The purpose of this interface.  "public" means this interface can access
+        #: the internet, "vlan" means it is a VLAN interface.
+        self.purpose = purpose
+
+    def __repr__(self):
+        if self.purpose == "public":
+            return "Public Interface"
+        return "Interface {}; purpose: {}; ipam_address: {}".format(
+            self.label, self.purpose, self.ipam_address
+        )
+
+    def _serialize(self):
+        """
+        Returns this object as a dict
+        """
+        return {
+            "label": self.label,
+            "ipam_address": self.ipam_address,
+            "purpose": self.purpose,
+        }
+
+
+
 class Config(DerivedBase):
     api_endpoint="/linode/instances/{linode_id}/configs/{id}"
     derived_url_path="configs"
@@ -182,7 +221,7 @@ class Config(DerivedBase):
         "run_level": Property(mutable=True, filterable=True),
         "virt_mode": Property(mutable=True, filterable=True),
         "memory_limit": Property(mutable=True, filterable=True),
-        "interfaces": Property(mutable=True),
+        "interfaces": Property(mutable=True), # gets setup in _populate below
     }
 
     def _populate(self, json):
@@ -210,6 +249,31 @@ class Config(DerivedBase):
             devices[device_index] = dev
 
         self._set('devices', MappedObject(**devices))
+
+        interfaces = []
+        if "interfaces" in json:
+            interfaces = [
+                ConfigInterface(c["purpose"], label=c["label"], ipam_address=c["ipam_address"])
+                for c in json["interfaces"]
+            ]
+
+        self._set("interfaces", interfaces)
+
+    def _serialize(self):
+        """
+        Overrides _serialize to transform interfaces into json
+        """
+        partial = DerivedBase._serialize(self)
+        interfaces = []
+
+        for c in self.interfaces:
+            if isinstance(c, ConfigInterface):
+                interfaces.append(c._seiralize())
+            else:
+                interfaces.append(c)
+
+        partial["interfaces"] = interfaces
+        return partial
 
 
 class Instance(Base):

--- a/linode_api4/objects/networking.py
+++ b/linode_api4/objects/networking.py
@@ -54,3 +54,19 @@ class IPAddress(Base):
         if not isinstance(linode, Instance):
             raise ValueError("IP Address can only be assigned to a Linode!")
         return { "address": self.address, "linode_id": linode.id }
+
+
+class VLAN(Base):
+    """
+    .. note:: At this time, the Linode API only supports listing VLANs.
+    .. note:: This endpoint is in beta. This will only function if base_url is set to `https://api.linode.com/v4beta`.
+    """
+    api_endpoint = '/networking/vlans/{}'
+    id_attribute = 'label'
+
+    properties = {
+        'label': Property(identifier=True),
+        'created': Property(is_datetime=True),
+        'linodes': Property(filterable=True),
+        'region': Property(slug_relationship=Region, filterable=True)
+    }

--- a/test/fixtures/linode_instances_123_configs.json
+++ b/test/fixtures/linode_instances_123_configs.json
@@ -14,6 +14,13 @@
       "created": "2014-10-07T20:04:00",
       "memory_limit": 0,
       "id": 456789,
+      "interfaces": [
+        {
+          "ipam_address": "0.0.0.0/24",
+          "label": "test-interface",
+          "purpose": "vlan"
+        }
+      ],
       "run_level": "default",
       "initrd": null,
       "virt_mode": "paravirt",

--- a/test/fixtures/linode_instances_123_configs_456789.json
+++ b/test/fixtures/linode_instances_123_configs_456789.json
@@ -1,0 +1,43 @@
+{
+   "root_device":"/dev/sda",
+   "comments":"",
+   "helpers":{
+      "updatedb_disabled":true,
+      "modules_dep":true,
+      "devtmpfs_automount":true,
+      "distro":true,
+      "network":false
+   },
+   "label":"My Ubuntu 17.04 LTS Profile",
+   "created":"2014-10-07T20:04:00",
+   "memory_limit":0,
+   "id":456789,
+   "interfaces":[
+      {
+         "ipam_address":"0.0.0.0/24",
+         "label":"test-interface",
+         "purpose":"vlan"
+      }
+   ],
+   "run_level":"default",
+   "initrd":null,
+   "virt_mode":"paravirt",
+   "kernel":"linode/latest-64bit",
+   "updated":"2014-10-07T20:04:00",
+   "devices":{
+      "sda":{
+         "disk_id":12345,
+         "volume_id":null
+      },
+      "sdc":null,
+      "sde":null,
+      "sdh":null,
+      "sdg":null,
+      "sdb":{
+         "disk_id":12346,
+         "volume_id":null
+      },
+      "sdf":null,
+      "sdd":null
+   }
+}

--- a/test/fixtures/networking_vlans.json
+++ b/test/fixtures/networking_vlans.json
@@ -1,0 +1,16 @@
+{
+  "data": [
+    {
+      "created": "2020-01-01T00:01:01",
+      "label": "vlan-test",
+      "linodes": [
+        111,
+        222
+      ],
+      "region": "us-southeast"
+    }
+  ],
+  "page": 1,
+  "pages": 1,
+  "results": 1
+}

--- a/test/linode_client_test.py
+++ b/test/linode_client_test.py
@@ -270,7 +270,6 @@ class LinodeGroupTest(ClientBaseCase):
                 "root_pass": pw,
             })
 
-
 class LongviewGroupTest(ClientBaseCase):
     """
     Tests methods of the LongviewGroup
@@ -533,3 +532,21 @@ class ObjectStorageGroupTest(ClientBaseCase):
 
             self.assertEqual(m.call_url, '/object-storage/keys')
             self.assertEqual(m.call_data, {"label":"object-storage-key-1"})
+
+class NetworkingGroupTest(ClientBaseCase):
+    """
+    Tests for the NetworkingGroup
+    """
+    def test_get_vlans(self):
+        """
+        Tests that Object Storage Clusters can be retrieved
+        """
+        vlans = self.client.networking.vlans()
+
+        self.assertEqual(len(vlans), 1)
+        self.assertEqual(vlans[0].label, 'vlan-test')
+        self.assertEqual(vlans[0].region.id, 'us-southeast')
+
+        self.assertEqual(len(vlans[0].linodes), 2)
+        self.assertEqual(vlans[0].linodes[0], 111)
+        self.assertEqual(vlans[0].linodes[1], 222)

--- a/test/objects/linode_test.py
+++ b/test/objects/linode_test.py
@@ -279,6 +279,38 @@ class DiskTest(ClientBaseCase):
             self.assertEqual(m.call_data, {"size": 1000})
 
 
+class ConfigTest(ClientBaseCase):
+    """
+    Tests for the Config object
+    """
+
+    def test_update_interfaces(self):
+        """
+        Tests that a configs interfaces update correctly
+        """
+
+        json = self.client.get('/linode/instances/123/configs/456789')
+        config = Config(self.client, 456789, 123, json=json)
+
+        with self.mock_put('/linode/instances/123/configs/456789') as m:
+            new_interfaces = [
+                {
+                    'purpose': 'public'
+                },
+                {
+                    'purpose': 'vlan',
+                    'label': 'cool-vlan'
+                }
+            ]
+
+            config.interfaces = new_interfaces
+
+            config.save()
+
+            self.assertEqual(m.call_url, '/linode/instances/123/configs/456789')
+            self.assertEqual(m.call_data.get('interfaces'), new_interfaces)
+
+
 class TypeTest(ClientBaseCase):
     def test_get_types(self):
         """


### PR DESCRIPTION
This pull request adds support for Linode VLANS and Linode Instance Config Interfaces. As VLANs are currently in beta, base_url must be set to https://api.linode.com/v4beta in order for VLANs to function correctly.