### PR TITLE
feature/retry-logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ docs/_build/*
 .coverage
 .pytest_cache/*
 .tox/*
+env


### PR DESCRIPTION
Adds a configurable retry time for 429 rate limit responses. Allows 5 retry attempts before treating the same as other API errors. Needs testing before merging.