### PR TITLE
feature/retry-logic

### DIFF
--- a/linode_api4/linode_client.py
+++ b/linode_api4/linode_client.py
@@ -1151,7 +1151,7 @@ class LinodeClient:
         # make sure we got a sane backoff
         if self.retry_rate_limit_backoff is not None:
             if not isinstance(self.retry_rate_limit_backoff, int):
-                raise ValueError("retry_rate_limit_backoff must be an int!")
+                raise ValueError("retry_rate_limit_backoff must be an int")
             if self.retry_rate_limit_backoff < 1:
                 raise ValueError("retry_rate_limit_backoff must not be less than 1!")
 

--- a/linode_api4/linode_client.py
+++ b/linode_api4/linode_client.py
@@ -1153,7 +1153,7 @@ class LinodeClient:
             if not isinstance(self.retry_rate_limit_backoff, int):
                 raise ValueError("retry_rate_limit_backoff must be an int")
             if self.retry_rate_limit_backoff < 1:
-                raise ValueError("retry_rate_limit_backoff must not be less than 1!")
+                raise ValueError("retry_rate_limit_backoff must not be less than 1")
 
         #: Access methods related to Linodes - see :any:`LinodeGroup` for
         #: more information

--- a/test/linode_client_test.py
+++ b/test/linode_client_test.py
@@ -1,8 +1,10 @@
 from datetime import datetime
+from unittest import TestCase
+from unittest.mock import MagicMock
 
 from test.base import ClientBaseCase
 
-from linode_api4 import LongviewSubscription
+from linode_api4 import LongviewSubscription, LinodeClient, ApiError
 
 
 class LinodeClientGeneralTest(ClientBaseCase):
@@ -585,3 +587,125 @@ class NetworkingGroupTest(ClientBaseCase):
         firewall = f[0]
 
         self.assertEqual(firewall.id, 123)
+
+
+class LinodeClientRateLimitRetryTest(TestCase):
+    """
+    Tests for rate limiting errors.
+
+    .. warning::
+       This test class _does not_ follow normal testing conventions for this project,
+       as requests are not automatically mocked.  Only add tests to this class if they
+       pertain to the 429 retry logic, and make sure you mock the requests calls yourself
+       (or else they will make real requests and those won't work).
+    """
+    def setUp(self):
+        self.client = LinodeClient("testing", base_url="/", retry_rate_limit_backoff=1)
+        # sidestep the validation to do immediate retries so tests aren't slow
+        self.client.retry_rate_limit_backoff = 0.1
+
+    def _get_mock_response(self, response_code):
+        """
+        Helper function to return a mock response
+        """
+        ret = MagicMock()
+        ret.status_code = response_code
+        ret.json.return_value = {}
+
+        return ret
+
+    def test_retry_429s(self):
+        """
+        Tests that 429 responses are automatically retried
+        """
+        called = 0
+        def test_method(*args, **kwargs):
+            nonlocal called
+            called += 1
+            if called < 2:
+                return self._get_mock_response(429)
+            return self._get_mock_response(200)
+
+        response = self.client._api_call('/test', method=test_method)
+
+        # it retried once, got the empty object
+        assert called == 2
+        assert response == {}, response
+
+    def test_retry_max_attempts(self):
+        """
+        Tests that a request will fail after 5 429 responses in a row
+        """
+        called = 0
+        def test_method(*args, **kwargs):
+            nonlocal called
+            called += 1
+            return self._get_mock_response(429)
+
+        try:
+            response = self.client._api_call('/test', method=test_method)
+            assert False, "Unexpectedly did not raise ApiError!"
+        except ApiError as e:
+            assert e.status == 429
+
+        # it tried 5 times
+        assert called == 5
+
+    def test_api_error_with_retry(self):
+        """
+        Tests that a 300+ response still raises an ApiError even if retries are
+        enabled
+        """
+        called = 0
+        def test_method(*args, **kwargs):
+            nonlocal called
+            called += 1
+            return self._get_mock_response(400)
+
+        try:
+            response = self.client._api_call('/test', method=test_method)
+            assert False, "Unexpectedly did not raise ApiError!"
+        except ApiError as e:
+            assert e.status == 400
+
+        # it tried 5 times
+        assert called == 1
+
+    def test_api_error_on_retry(self):
+        """
+        Tests that we'll stop retrying and raise immediately if we get a 300+
+        response after a 429
+        """
+        called = 0
+        def test_method(*args, **kwargs):
+            nonlocal called
+            called += 1
+            if called < 2:
+                return self._get_mock_response(429)
+            return self._get_mock_response(400)
+
+        try:
+            response = self.client._api_call('/test', method=test_method)
+            assert False, "Unexpectedly did not raise ApiError!"
+        except ApiError as e:
+            assert e.status == 400
+
+        # it tried 5 times
+        assert called == 2
+
+    def test_works_first_time(self):
+        """
+        Tests that the response is handled correctly if we got a 200 on the first
+        try
+        """
+        called = 0
+        def test_method(*args, **kwargs):
+            nonlocal called
+            called += 1
+            return self._get_mock_response(200)
+
+        response = self.client._api_call('/test', method=test_method)
+
+        # it tried 5 times
+        assert called == 1
+        assert response == {}

--- a/test/linode_client_test.py
+++ b/test/linode_client_test.py
@@ -600,9 +600,9 @@ class LinodeClientRateLimitRetryTest(TestCase):
        (or else they will make real requests and those won't work).
     """
     def setUp(self):
-        self.client = LinodeClient("testing", base_url="/", retry_rate_limit_backoff=1)
+        self.client = LinodeClient("testing", base_url="/", retry_rate_limit_interval=1)
         # sidestep the validation to do immediate retries so tests aren't slow
-        self.client.retry_rate_limit_backoff = 0.1
+        self.client.retry_rate_limit_interval = 0.1
 
     def _get_mock_response(self, response_code):
         """


### PR DESCRIPTION
Retry logic for rate limit errors via `retry_rate_limit_backoff` parameter in the `LinodeClient` class. Allows up to 5 retires when the parameter value is greater than zero (seconds between retries) and response code is 429.