### PR TITLE
Added missing fields to `Volume` object

### DIFF
--- a/linode_api4/objects/volume.py
+++ b/linode_api4/objects/volume.py
@@ -15,6 +15,9 @@ class Volume(Base):
         'status': Property(filterable=True),
         'region': Property(slug_relationship=Region),
         'tags': Property(mutable=True),
+        'filesystem_path': Property(),
+        'hardware_type': Property(),
+        'linode_label': Property(),
     }
 
     def attach(self, to_linode, config=None):

--- a/test/fixtures/volumes.json
+++ b/test/fixtures/volumes.json
@@ -9,7 +9,10 @@
       "size": 40,
       "updated": "2017-08-04T04:00:00",
       "status": "active",
-      "tags": ["something"]
+      "tags": ["something"],
+      "filesystem_path": "this/is/a/file/path",
+      "hardware_type": "hdd",
+      "linode_label": null
     },
     {
       "id": 2,
@@ -20,7 +23,10 @@
       "size": 100,
       "updated": "2017-08-07T04:00:00",
       "status": "active",
-      "tags": []
+      "tags": [],
+      "filesystem_path": "this/is/a/file/path",
+      "hardware_type": "nvme",
+      "linode_label": null
     },
     {
       "id": 3,
@@ -31,7 +37,10 @@
       "size": 200,
       "updated": "2017-08-07T04:00:00",
       "status": "active",
-      "tags": ["attached"]
+      "tags": ["attached"],
+      "filesystem_path": "this/is/a/file/path",
+      "hardware_type": "nvme",
+      "linode_label": "some_label"
     }
   ],
   "results": 3,

--- a/test/linode_client_test.py
+++ b/test/linode_client_test.py
@@ -115,6 +115,12 @@ class LinodeClientGeneralTest(ClientBaseCase):
         self.assertEqual(v[1].size, 100)
         self.assertEqual(v[2].size, 200)
         self.assertEqual(v[2].label, 'block3')
+        self.assertEqual(v[0].filesystem_path, 'this/is/a/file/path')
+        self.assertEqual(v[0].hardware_type, 'hdd')
+        self.assertEqual(v[1].filesystem_path, 'this/is/a/file/path')
+        self.assertEqual(v[1].linode_label, None)
+        self.assertEqual(v[2].filesystem_path, 'this/is/a/file/path')
+        self.assertEqual(v[2].hardware_type, 'nvme')
 
         assert v[0].tags == ["something"]
         assert v[1].tags == []

--- a/test/objects/volume_test.py
+++ b/test/objects/volume_test.py
@@ -27,6 +27,10 @@ class VolumeTest(ClientBaseCase):
 
         assert volume.tags == ["something"]
 
+        self.assertEqual(volume.filesystem_path, 'this/is/a/file/path')
+        self.assertEqual(volume.hardware_type, 'hdd')
+        self.assertEqual(volume.linode_label, None)
+
     def test_update_volume_tags(self):
         """
         Tests that updating tags on an entity send the correct request


### PR DESCRIPTION
Added missing fields (`filesystem_path`, `hardware_type `, and `linode_label `) to `Volume` object.

Test by running `tox`.

Ticket: TPT-1897