### PR TITLE
Added missing `successor` field to `Type` object

### DIFF
--- a/linode_api4/objects/linode.py
+++ b/linode_api4/objects/linode.py
@@ -144,6 +144,7 @@ class Type(Base):
         'transfer': Property(filterable=True),
         'vcpus': Property(filterable=True),
         'gpus': Property(filterable=True),
+        'successor': Property(),
         # type_class is populated from the 'class' attribute of the returned JSON
     }
 

--- a/test/fixtures/linode_types.json
+++ b/test/fixtures/linode_types.json
@@ -24,7 +24,8 @@
       "price": {
         "hourly": 0.0075,
         "monthly": 5
-      }
+      },
+      "successor": null
     },
     {
       "disk": 20480,
@@ -47,7 +48,8 @@
       "price": {
         "hourly": 0.09,
         "monthly": 60
-      }
+      },
+      "successor": null
     },
     {
       "disk": 30720,
@@ -70,7 +72,8 @@
       "price": {
         "hourly": 0.015,
         "monthly": 10
-      }
+      },
+      "successor": null
     },
     {
       "disk": 49152,
@@ -93,7 +96,8 @@
       "price": {
         "hourly": 0.03,
         "monthly": 20
-      }
+      },
+      "successor": null
     }
   ]
 }

--- a/test/objects/linode_test.py
+++ b/test/objects/linode_test.py
@@ -326,6 +326,7 @@ class TypeTest(ClientBaseCase):
             self.assertIsNotNone(t.disk)
             self.assertIsNotNone(t.type_class)
             self.assertIsNotNone(t.gpus)
+            self.assertIsNone(t.successor)
 
     def test_get_type_by_id(self):
         """


### PR DESCRIPTION
Test with `tox`.

Ticket: TPT-1887