### PR TITLE
new: Add `force` keyword argument to `Base.save()` function

### DIFF
--- a/test/base.py
+++ b/test/base.py
@@ -98,7 +98,6 @@ class MethodMock:
         """
         return self.mock.call_args[1]['data']
 
-
     @property
     def call_url(self):
         """
@@ -125,6 +124,12 @@ class MethodMock:
         """
         return self.mock.call_args[1]['headers']
 
+    @property
+    def called(self):
+        """
+        A shortcut to check whether the mock function was called.
+        """
+        return self.mock.called
 
 class ClientBaseCase(TestCase):
     def setUp(self):

--- a/test/objects/linode_test.py
+++ b/test/objects/linode_test.py
@@ -350,3 +350,47 @@ class TypeTest(ClientBaseCase):
 
         self.assertEqual(t.gpus, 1)
         self.assertEqual(t._populated, True)
+
+    def test_save_noforce(self):
+        """
+        Tests that a client will only save if changes are detected
+        """
+        linode = Instance(self.client, 123)
+        self.assertEqual(linode._populated, False)
+
+        self.assertEqual(linode.label, "linode123")
+        self.assertEqual(linode.group, "test")
+
+        assert not linode._changed
+
+        with self.mock_put("linode/instances") as m:
+            linode.save(force=False)
+            assert not m.called
+
+        linode.label = "blah"
+        assert linode._changed
+
+        with self.mock_put("linode/instances") as m:
+            linode.save(force=False)
+            assert m.called
+            assert m.call_url == "/linode/instances/123"
+            assert m.call_data["label"] == "blah"
+
+        assert not linode._changed
+
+    def test_save_force(self):
+        """
+        Tests that a client will forcibly save by default
+        """
+        linode = Instance(self.client, 123)
+        self.assertEqual(linode._populated, False)
+
+        self.assertEqual(linode.label, "linode123")
+        self.assertEqual(linode.group, "test")
+
+        assert not linode._changed
+
+        with self.mock_put("linode/instances") as m:
+            linode.save()
+            assert m.called
+


### PR DESCRIPTION
## 📝 Description

This change adds an optional `force` argument to the `Base.save()` method. This was previously the default functionality, which could result in a large number of redundant PUT requests. 

## ✔️ How to Test

```
pytest test/objects/linode_test.py
```
