### PR TITLE
Fix: Domain update issue when null properties are saved

### DIFF
--- a/linode_api4/objects/base.py
+++ b/linode_api4/objects/base.py
@@ -196,7 +196,7 @@ class Base(object, metaclass=FilterableMetaclass):
             elif isinstance(v,MappedObject):
                 result[k] = v.dict
 
-        return result
+        return {k: v for k, v in result.items() if v}
 
     def _api_get(self):
         """

--- a/test/objects/domain_test.py
+++ b/test/objects/domain_test.py
@@ -1,0 +1,28 @@
+from linode_api4.objects import Domain
+from test.base import ClientBaseCase
+
+class DomainGeneralTest(ClientBaseCase):
+    """
+    Tests methods of the Domain class.
+    """
+
+    def test_reproduce_error(self):
+
+        # domain = Domain(self.client, 12345)
+
+        # self.assertEqual(domain.domain, "example.org")
+        # self.assertEqual(domain.type, "master")
+
+        # params = {
+        #     "type": "slave",
+        #     "master_ips": ["127.0.0.1"]
+        # }
+
+        with self.mock_put('domains/12345') as m:
+            domain = self.client.load(Domain, 12345)
+
+            domain.type = "slave"
+            domain.master_ips = ["127.0.0.1"]
+            domain.save()
+
+        #result = domain._client.put(Domain.api_endpoint, model=domain, data=params)

--- a/test/objects/domain_test.py
+++ b/test/objects/domain_test.py
@@ -7,22 +7,9 @@ class DomainGeneralTest(ClientBaseCase):
     """
 
     def test_reproduce_error(self):
-
-        # domain = Domain(self.client, 12345)
-
-        # self.assertEqual(domain.domain, "example.org")
-        # self.assertEqual(domain.type, "master")
-
-        # params = {
-        #     "type": "slave",
-        #     "master_ips": ["127.0.0.1"]
-        # }
-
         with self.mock_put('domains/12345') as m:
             domain = self.client.load(Domain, 12345)
 
             domain.type = "slave"
             domain.master_ips = ["127.0.0.1"]
             domain.save()
-
-        #result = domain._client.put(Domain.api_endpoint, model=domain, data=params)

--- a/test/objects/domain_test.py
+++ b/test/objects/domain_test.py
@@ -6,10 +6,12 @@ class DomainGeneralTest(ClientBaseCase):
     Tests methods of the Domain class.
     """
 
-    def test_reproduce_error(self):
+    def test_save_null_values_excluded(self):
         with self.mock_put('domains/12345') as m:
             domain = self.client.load(Domain, 12345)
 
             domain.type = "slave"
             domain.master_ips = ["127.0.0.1"]
             domain.save()
+
+            self.assertTrue('group' not in m.call_data.keys())


### PR DESCRIPTION
## 📝 Description

Fixed issue when attempting to update Domain with some null values.

## ✔️ How to Test

Run `tox`.

Ticket: TPT-1871
Resolves #208 