### PR TITLE
fix: Correct typo in LongviewSubscription API endpoint

### DIFF
--- a/linode_api4/objects/longview.py
+++ b/linode_api4/objects/longview.py
@@ -16,7 +16,8 @@ class LongviewClient(Base):
 
 
 class LongviewSubscription(Base):
-    api_endpoint = "longview/subscriptions/{id}"
+    api_endpoint = "/longview/subscriptions/{id}"
+
     properties = {
         "id": Property(identifier=True),
         "label": Property(),

--- a/test/linode_client_test.py
+++ b/test/linode_client_test.py
@@ -396,7 +396,10 @@ class LongviewGroupTest(ClientBaseCase):
         """
         Tests that Longview subscriptions can be retrieved
         """
-        r = self.client.longview.subscriptions()
+
+        with self.mock_get("longview/subscriptions") as m:
+            r = self.client.longview.subscriptions()
+            self.assertEqual(m.call_url, "/longview/subscriptions")
 
         self.assertEqual(len(r), 4)
 


### PR DESCRIPTION
## 📝 Description

This change corrects a small typo in the LongviewSubscription that would cause 404 errors to be returned from the API.

Resolves #116 

## ✔️ How to Test

```
tox
```
