### PR TITLE
Fixed wrong documentation links in `objects/linode.py`

### DIFF
--- a/linode_api4/objects/linode.py
+++ b/linode_api4/objects/linode.py
@@ -21,7 +21,7 @@ class Backup(DerivedBase):
     """
     A Backup of a Linode Instance.
 
-    View Endpoint: https://api.linode.com/v4/linode/instances/{linodeId}/backups/{backupId}
+    API Documentation: https://www.linode.com/docs/api/linode-instances/#backup-view
     """
 
     api_endpoint = "/linode/instances/{linode_id}/backups/{id}"
@@ -49,7 +49,7 @@ class Backup(DerivedBase):
         """
         Restores a Linode’s Backup to the specified Linode.
 
-        API Documentation: https://api.linode.com/v4/linode/instances/{linodeId}/backups/{backupId}/restore
+        API Documentation: https://www.linode.com/docs/api/linode-instances/#backup-restore
 
         :param linode: The id of the Instance or the Instance to share the IPAddresses with.
                        This Instance will be able to bring up the given addresses.
@@ -87,7 +87,7 @@ class Disk(DerivedBase):
     """
     A Disk for the storage space on a Compute Instance.
 
-    View Endpoint: https://api.linode.com/v4/linode/instances/{linodeId}/disks/{diskId}
+    API Documentation: https://www.linode.com/docs/api/linode-instances/#disk-view
     """
 
     api_endpoint = "/linode/instances/{linode_id}/disks/{id}"
@@ -129,7 +129,7 @@ class Disk(DerivedBase):
         """
         Resets the password of a Disk you have permission to read_write.
 
-        API Documentation: https://api.linode.com/v4/linode/instances/{linodeId}/disks/{diskId}/password
+        API Documentation: https://www.linode.com/docs/api/linode-instances/#disk-root-password-reset
 
         :param root_password: The new root password for the OS installed on this Disk. The password must meet the complexity
                               strength validation requirements for a strong password.
@@ -157,7 +157,7 @@ class Disk(DerivedBase):
         fit on the new disk size.  You may need to resize the filesystem on the
         disk first before performing this action.
 
-        API Documentation: https://api.linode.com/v4/linode/instances/{linodeId}/disks/{diskId}/resize
+        API Documentation: https://www.linode.com/docs/api/linode-instances/#disk-resize
 
         :param new_size: The intended new size of the disk, in MB
         :type new_size: int
@@ -197,7 +197,7 @@ class Kernel(Base):
           to compile the kernel from source than to download it from your package manager. For more
           information on custom compiled kernels, review our guides for Debian, Ubuntu, and CentOS.
 
-    View Endpoint: https://api.linode.com/v4/linode/kernels/{kernelId}
+    API Documentation: https://www.linode.com/docs/api/linode-instances/#kernel-view
     """
 
     api_endpoint = "/linode/kernels/{id}"
@@ -221,7 +221,7 @@ class Type(Base):
     """
     Linode Plan type to specify the resources available to a Linode Instance.
 
-    View Endpoint: https://api.linode.com/v4/linode/types/{typeId}
+    API Documentation: https://www.linode.com/docs/api/linode-types/#type-view
     """
 
     api_endpoint = "/linode/types/{id}"
@@ -298,7 +298,7 @@ class Config(DerivedBase):
     """
     A Configuration Profile for a Linode Instance.
 
-    View Endpoint: https://api.linode.com/v4/linode/instances/{linodeId}/configs/{configId}
+    API Documentation: https://www.linode.com/docs/api/linode-instances/#configuration-profile-view
     """
 
     api_endpoint = "/linode/instances/{linode_id}/configs/{id}"
@@ -386,7 +386,7 @@ class Instance(Base):
     """
     A Linode Instance.
 
-    View Endpoint: https://api.linode.com/v4/linode/instances/{linodeId}
+    API Documentation: https://www.linode.com/docs/api/linode-instances/#linode-view
     """
 
     api_endpoint = "/linode/instances/{id}"
@@ -419,7 +419,7 @@ class Instance(Base):
         The ips related collection is not normalized like the others, so we have to
         make an ad-hoc object to return for its response
 
-        API Documentation: https://api.linode.com/v4/linode/instances/{linodeId}/ips
+        API Documentation: https://www.linode.com/docs/api/linode-instances/#networking-information-list
 
         :returns: A List of the ips of the Linode Instance.
         :rtype: List[IPAddress]
@@ -492,7 +492,7 @@ class Instance(Base):
         """
         The backups response contains what backups are available to be restored.
 
-        API Documentation: https://api.linode.com/v4/linode/instances/{linodeId}/backups
+        API Documentation: https://www.linode.com/docs/api/linode-instances/#backups-list
 
         :returns: A List of the available backups for the Linode Instance.
         :rtype: List[Backup]
@@ -550,7 +550,7 @@ class Instance(Base):
         """
         Resets the root password for this Linode.
 
-        API Documentation: https://api.linode.com/v4/linode/instances/{linodeId}/password
+        API Documentation: https://www.linode.com/docs/api/linode-instances/#linode-root-password-reset
 
         :param root_password: The root user’s password on this Linode. Linode passwords must
                               meet a password strength score requirement that is calculated internally
@@ -574,7 +574,7 @@ class Instance(Base):
         """
         Get per-linode transfer for specified month
 
-        API Documentation: https://api.linode.com/v4/linode/instances/{linodeId}/transfer/{year}/{month}
+        API Documentation: https://www.linode.com/docs/api/linode-instances/#network-transfer-view-yearmonth
 
         :param year: Numeric value representing the year to look up.
         :type: year: int
@@ -598,7 +598,7 @@ class Instance(Base):
         """
         Get per-linode transfer
 
-        API Documentation: https://api.linode.com/v4/linode/instances/{linodeId}/transfer
+        API Documentation: https://www.linode.com/docs/api/linode-instances/#network-transfer-view
 
         :returns: The network transfer statistics for the current month.
         :rtype: MappedObject
@@ -652,7 +652,7 @@ class Instance(Base):
               (because the Linode was never booted or the last booted config was deleted)
               an error will be returned.
 
-        API Documentation: https://api.linode.com/v4/linode/instances/{linodeId}/boot
+        API Documentation: https://www.linode.com/docs/api/linode-instances/#linode-boot
 
         :param config: The Linode Config ID to boot into.
         :type: config: int
@@ -677,7 +677,7 @@ class Instance(Base):
         are currently running or queued, those actions must be completed
         first before you can initiate a shutdown.
 
-        API Documentation: https://api.linode.com/v4/linode/instances/{linodeId}/shutdown
+        API Documentation: https://www.linode.com/docs/api/linode-instances/#linode-shut-down
 
         :returns: True if the operation was successful.
         :rtype: bool
@@ -696,7 +696,7 @@ class Instance(Base):
         Reboots a Linode you have permission to modify. If any actions are currently running
         or queued, those actions must be completed first before you can initiate a reboot.
 
-        API Documentation: https://api.linode.com/v4/linode/instances/{linodeId}/reboot
+        API Documentation: https://www.linode.com/docs/api/linode-instances/#linode-reboot
 
         :returns: True if the operation was successful.
         :rtype: bool
@@ -722,7 +722,7 @@ class Instance(Base):
             - The Linode must not have more disk allocation than the new Type allows.
                 - In that situation, you must first delete or resize the disk to be smaller.
 
-        API Documentation: https://api.linode.com/v4/linode/instances/{linodeId}/resize
+        API Documentation: https://www.linode.com/docs/api/linode-instances/#linode-resize
 
         :param new_type: The Linode Type or the id representing it.
         :type: new_type: Type or int
@@ -784,6 +784,8 @@ class Instance(Base):
     ):
         """
         Creates a Linode Config with the given attributes.
+
+        API Documentation: https://www.linode.com/docs/api/linode-instances/#configuration-profile-create
 
         :param kernel: The kernel to boot with.
         :param label: The config label
@@ -889,6 +891,8 @@ class Instance(Base):
         """
         Creates a new Disk for this Instance.
 
+        API Documentation: https://www.linode.com/docs/api/linode-instances/#disk-create
+
         :param size: The size of the disk, in MB
         :param label: The label of the disk.  If not given, a default label will be generated.
         :param filesystem: The filesystem type for the disk.  If not given, the default
@@ -968,11 +972,9 @@ class Instance(Base):
         Enable Backups for this Instance.  When enabled, we will automatically
         backup your Instance's data so that it can be restored at a later date.
         For more information on Instance's Backups service and pricing, see our
-        `Backups Page`_
+        Backups Page: https://www.linode.com/backups
 
-        .. _Backups Page: https://www.linode.com/backups
-
-        API Documentation: https://api.linode.com/v4/linode/instances/{linodeId}/backups/enable
+        API Documentation: https://www.linode.com/docs/api/linode-instances/#backups-enable
 
         :returns: True if the operation was successful.
         :rtype: bool
@@ -989,7 +991,7 @@ class Instance(Base):
         including any snapshots that have been taken.  This cannot be undone,
         but Backups can be re-enabled at a later date.
 
-        API Documentation: https://api.linode.com/v4/linode/instances/{linodeId}/backups/cancel
+        API Documentation: https://www.linode.com/docs/api/linode-instances/#backups-cancel
 
         :returns: True if the operation was successful.
         :rtype: bool
@@ -1007,7 +1009,7 @@ class Instance(Base):
         Important: If you already have a snapshot of this Linode, this
         is a destructive action. The previous snapshot will be deleted.
 
-        API Documentation: https://api.linode.com/v4/linode/instances/{linodeId}/backups
+        API Documentation: https://www.linode.com/docs/api/linode-instances/#snapshot-create
 
         :param label: The label for the new snapshot.
         :type: label: str
@@ -1041,6 +1043,8 @@ class Instance(Base):
         before you can add one.  You may only have, at most, one private IP per
         Instance.
 
+        API Documentation: https://www.linode.com/docs/api/linode-instances/#ipv4-address-allocate
+
         :param public: If the new IP should be public or private.  Defaults to
                        private.
         :type public: bool
@@ -1070,6 +1074,8 @@ class Instance(Base):
         Rebuilding an Instance deletes all existing Disks and Configs and deploys
         a new :any:`Image` to it.  This can be used to reset an existing
         Instance or to install an Image on an empty Instance.
+
+        API Documentation: https://www.linode.com/docs/api/linode-instances/#linode-rebuild
 
         :param image: The Image to deploy to this Instance
         :type image: str or Image
@@ -1127,7 +1133,7 @@ class Instance(Base):
 
         Note that “sdh” is reserved and unavailable during rescue.
 
-        API Documentation: https://api.linode.com/v4/linode/instances/{linodeId}/rescue
+        API Documentation: https://www.linode.com/docs/api/linode-instances/#linode-boot-into-rescue-mode
 
         :param disks: Devices that are either Disks or Volumes
         :type: disks: dict
@@ -1167,7 +1173,7 @@ class Instance(Base):
         """
         Upgrades this Instance to the latest generation type
 
-        API Documentation: https://api.linode.com/v4/linode/instances/{linodeId}/mutate
+        API Documentation: https://www.linode.com/docs/api/linode-instances/#linode-upgrade
 
         :param allow_auto_disk_resize: Automatically resize disks when resizing a Linode.
                                        When resizing down to a smaller plan your Linode’s
@@ -1191,7 +1197,7 @@ class Instance(Base):
         Initiates a pending migration that is already scheduled for this Linode
         Instance
 
-        API Documentation: https://api.linode.com/v4/linode/instances/{linodeId}/migrate
+        API Documentation: https://www.linode.com/docs/api/linode-instances/#dc-migrationpending-host-migration-initiate
 
         :param region: The region to which the Linode will be migrated. Must be a valid region slug.
                        A list of regions can be viewed by using the GET /regions endpoint. A cross data
@@ -1223,7 +1229,7 @@ class Instance(Base):
         """
         View Firewall information for Firewalls associated with this Linode.
 
-        API Documentation: https://api.linode.com/v4/linode/instances/{linodeId}/firewalls
+        API Documentation: https://www.linode.com/docs/api/linode-instances/#firewalls-list
 
         :returns: A List of Firewalls of the Linode Instance.
         :rtype: List[Firewall]
@@ -1245,7 +1251,7 @@ class Instance(Base):
         """
         View a list of NodeBalancers that are assigned to this Linode and readable by the requesting User.
 
-        API Documentation: https://api.linode.com/v4/linode/instances/{linodeId}/nodebalancers
+        API Documentation: https://www.linode.com/docs/api/linode-instances/#linode-nodebalancers-view
 
         :returns: A List of Nodebalancers of the Linode Instance.
         :rtype: List[Nodebalancer]
@@ -1267,7 +1273,7 @@ class Instance(Base):
         """
         View Block Storage Volumes attached to this Linode.
 
-        API Documentation: https://api.linode.com/v4/linode/instances/{linodeId}/volumes
+        API Documentation: https://www.linode.com/docs/api/linode-instances/#linodes-volumes-list
 
         :returns: A List of Volumes of the Linode Instance.
         :rtype: List[Volume]
@@ -1296,7 +1302,7 @@ class Instance(Base):
         """
         Clones this linode into a new linode or into a new linode in the given region
 
-        API Documentation: https://api.linode.com/v4/linode/instances/{linodeId}/clone
+        API Documentation: https://www.linode.com/docs/api/linode-instances/#linode-clone
 
         :param to_linode: If an existing Linode is the target for the clone, the ID of that
                           Linode. The existing Linode must have enough resources to accept the clone.
@@ -1380,7 +1386,7 @@ class Instance(Base):
         """
         Returns the JSON stats for this Instance
 
-        API Documentation: https://api.linode.com/v4/linode/instances/{linodeId}/stats
+        API Documentation: https://www.linode.com/docs/api/linode-instances/#linode-statistics-view
 
         :returns: The JSON stats for this Instance
         :rtype: dict
@@ -1394,7 +1400,7 @@ class Instance(Base):
         """
         Returns stats for the month containing the given datetime
 
-        API Documentation: https://api.linode.com/v4/linode/instances/{linodeId}/stats/{year}/{month}
+        API Documentation: https://www.linode.com/docs/api/linode-instances/#statistics-view-yearmonth
 
         :param dt: A Datetime for which to return statistics
         :type: dt: Datetime
@@ -1436,7 +1442,7 @@ class StackScript(Base):
     A script allowing users to reproduce specific software configurations
     when deploying Compute Instances, with more user control than static system images.
 
-    View Endpoint: https://api.linode.com/v4/linode/stackscripts/{stackscriptId}
+    API Documentation: https://www.linode.com/docs/api/stackscripts/#stackscript-view
     """
 
     api_endpoint = "/linode/stackscripts/{id}"


### PR DESCRIPTION
## 📝 Description

Fixed wrong documentation links in `objects/linode.py`

## ✔️ How to Test

`pytest test`