### PR TITLE
new: Add `ExplicitNullValue` class

### DIFF
--- a/linode_api4/objects/__init__.py
+++ b/linode_api4/objects/__init__.py
@@ -1,5 +1,5 @@
 # isort: skip_file
-from .base import Base, Property, MappedObject, DATE_FORMAT
+from .base import Base, Property, MappedObject, DATE_FORMAT, ExplicitNullValue
 from .dbase import DerivedBase
 from .filtering import and_, or_
 from .region import Region

--- a/linode_api4/objects/base.py
+++ b/linode_api4/objects/base.py
@@ -10,6 +10,14 @@ DATE_FORMAT = "%Y-%m-%dT%H:%M:%S"
 volatile_refresh_timeout = timedelta(seconds=15)
 
 
+class ExplicitNullValue:
+    """
+    An explicitly null value to set a property to.
+    Instances of `NullValue` differ from None as they will be explicitly
+    included in the resource PUT requests.
+    """
+
+
 class Property:
     def __init__(
         self,
@@ -22,6 +30,7 @@ class Property:
         filterable=False,
         id_relationship=False,
         slug_relationship=False,
+        nullable=False,
     ):
         """
         A Property is an attribute returned from the API, and defines metadata
@@ -39,6 +48,7 @@ class Property:
         id_relationship - This Property should create a relationship with this key as the ID
             (This should be used on fields ending with '_id' only)
         slug_relationship - This property is a slug related for a given type.
+        nullable - This property can be explicitly null on PUT requests.
         """
         self.mutable = mutable
         self.identifier = identifier
@@ -244,19 +254,33 @@ class Base(object, metaclass=FilterableMetaclass):
         A helper method to build a dict of all mutable Properties of
         this object
         """
-        result = {
-            a: getattr(self, a)
-            for a in type(self).properties
-            if type(self).properties[a].mutable
-        }
 
+        result = {}
+
+        # Aggregate mutable values into a dict
+        for k, v in type(self).properties.items():
+            if not v.mutable:
+                continue
+
+            value = getattr(self, k)
+
+            if not value:
+                continue
+
+            # Let's allow explicit null values
+            if isinstance(value, ExplicitNullValue):
+                value = None
+
+            result[k] = value
+
+        # Resolve the underlying IDs of results
         for k, v in result.items():
             if isinstance(v, Base):
                 result[k] = v.id
             elif isinstance(v, MappedObject):
                 result[k] = v.dict
 
-        return {k: v for k, v in result.items() if v}
+        return result
 
     def _api_get(self):
         """

--- a/linode_api4/objects/base.py
+++ b/linode_api4/objects/base.py
@@ -267,8 +267,11 @@ class Base(object, metaclass=FilterableMetaclass):
             if not value:
                 continue
 
-            # Let's allow explicit null values
-            if isinstance(value, ExplicitNullValue):
+            # Let's allow explicit null values as both classes and instances
+            if (
+                isinstance(value, ExplicitNullValue)
+                or value == ExplicitNullValue
+            ):
                 value = None
 
             result[k] = value

--- a/linode_api4/objects/networking.py
+++ b/linode_api4/objects/networking.py
@@ -41,7 +41,7 @@ class IPAddress(Base):
         ip.save()
 
         # Re-populate all attributes with new information from the API
-        ip._api_get()
+        ip.invalidate()
 
     API Documentation: https://www.linode.com/docs/api/networking/#ip-address-view
     """

--- a/linode_api4/objects/networking.py
+++ b/linode_api4/objects/networking.py
@@ -31,6 +31,19 @@ class IPv6Range(Base):
 class IPAddress(Base):
     """
     note:: This endpoint is in beta. This will only function if base_url is set to `https://api.linode.com/v4beta`.
+
+    Represents a Linode IP address object.
+
+    When attempting to reset the `rdns` field to default, consider using the ExplicitNullValue class::
+
+        ip = IPAddress(client, "127.0.0.1")
+        ip.rdns = ExplicitNullValue()
+        ip.save()
+
+        # Re-populate all attributes with new information from the API
+        ip._api_get()
+
+    API Documentation: https://www.linode.com/docs/api/networking/#ip-address-view
     """
 
     api_endpoint = "/networking/ips/{address}"

--- a/linode_api4/objects/networking.py
+++ b/linode_api4/objects/networking.py
@@ -37,7 +37,7 @@ class IPAddress(Base):
     When attempting to reset the `rdns` field to default, consider using the ExplicitNullValue class::
 
         ip = IPAddress(client, "127.0.0.1")
-        ip.rdns = ExplicitNullValue()
+        ip.rdns = ExplicitNullValue
         ip.save()
 
         # Re-populate all attributes with new information from the API

--- a/test/fixtures/networking_ips_127.0.0.1.json
+++ b/test/fixtures/networking_ips_127.0.0.1.json
@@ -1,0 +1,11 @@
+{
+  "address": "127.0.0.1",
+  "gateway": "127.0.0.1",
+  "linode_id": 123,
+  "prefix": 24,
+  "public": true,
+  "rdns": "test.example.org",
+  "region": "us-east",
+  "subnet_mask": "255.255.255.0",
+  "type": "ipv4"
+}

--- a/test/objects/networking_test.py
+++ b/test/objects/networking_test.py
@@ -61,3 +61,12 @@ class NetworkingTest(ClientBaseCase):
             # We need to assert of call_data_raw because
             # call_data drops keys with null values
             self.assertEqual(m.call_data_raw, '{"rdns": null}')
+
+        # Ensure that everything works as expected with a class reference
+        with self.mock_put("/networking/ips/127.0.0.1") as m:
+            ip.rdns = ExplicitNullValue
+            ip.save()
+
+            self.assertEqual(m.call_url, "/networking/ips/127.0.0.1")
+
+            self.assertEqual(m.call_data_raw, '{"rdns": null}')

--- a/test/objects/networking_test.py
+++ b/test/objects/networking_test.py
@@ -1,5 +1,6 @@
 from test.base import ClientBaseCase
 
+from linode_api4 import ExplicitNullValue
 from linode_api4.objects import Firewall, IPAddress, IPv6Pool, IPv6Range
 
 
@@ -43,3 +44,20 @@ class NetworkingTest(ClientBaseCase):
             self.assertEqual(result["outbound"], [])
             self.assertEqual(result["inbound_policy"], "DROP")
             self.assertEqual(result["outbound_policy"], "DROP")
+
+    def test_rdns_reset(self):
+        """
+        Tests that the RDNS of an IP and be reset using an explicit null value.
+        """
+
+        ip = IPAddress(self.client, "127.0.0.1")
+
+        with self.mock_put("/networking/ips/127.0.0.1") as m:
+            ip.rdns = ExplicitNullValue()
+            ip.save()
+
+            self.assertEqual(m.call_url, "/networking/ips/127.0.0.1")
+
+            # We need to assert of call_data_raw because
+            # call_data drops keys with null values
+            self.assertEqual(m.call_data_raw, '{"rdns": null}')


### PR DESCRIPTION
## 📝 Description

This change introduces an `ExplicitNullValue` class that can be used to specify null values that should explicitly be included in API put requests. 

For example, you can reset the RDNS for an IP address by explicitly specifying `rdns` as null when making a request to this endpoint: https://www.linode.com/docs/api/networking/#ip-address-rdns-update__request-body-schema

The corresponding implementation would look like this:

```python
 ip = IPAddress(client, "127.0.0.1")
 ip.rdns = ExplicitNullValue
 ip.save()
```


## ✔️ How to Test

```
tox
```
