### PR TITLE
TPT 1880: Fixed issue with updating non-populated NodeBalancerNode

### DIFF
--- a/linode_api4/groups/longview.py
+++ b/linode_api4/groups/longview.py
@@ -1,6 +1,10 @@
 from linode_api4.errors import UnexpectedResponseError
 from linode_api4.groups import Group
-from linode_api4.objects import LongviewClient, LongviewSubscription
+from linode_api4.objects import (
+    LongviewClient,
+    LongviewPlan,
+    LongviewSubscription,
+)
 
 
 class LongviewGroup(Group):
@@ -60,3 +64,37 @@ class LongviewGroup(Group):
         :rtype: PaginatedList of LongviewSubscription
         """
         return self.client._get_and_filter(LongviewSubscription, *filters)
+
+    def longview_plan_update(self, longview_subscription):
+        """
+        Update your Longview plan to that of the given subcription ID.
+
+        :param longview_subscription: The subscription ID for a particular Longview plan.
+                                      A value of null corresponds to Longview Free.
+        :type longview_subscription: : str
+        """
+
+        if longview_subscription not in [
+            "",
+            "longview-3",
+            "longview-10",
+            "longview-40",
+            "longview-100",
+        ]:
+            raise ValueError(
+                "Invalid longview plan subscription: {}".format(
+                    longview_subscription
+                )
+            )
+
+        params = {"longview_subscription": longview_subscription}
+
+        result = self.client.post(
+            LongviewPlan.api_endpoint, model=self, data=params
+        )
+
+        plan = LongviewPlan(self.client, result["id"], result)
+
+        plan.invalidate()
+
+        return plan

--- a/linode_api4/groups/longview.py
+++ b/linode_api4/groups/longview.py
@@ -72,6 +72,9 @@ class LongviewGroup(Group):
         :param longview_subscription: The subscription ID for a particular Longview plan.
                                       A value of null corresponds to Longview Free.
         :type longview_subscription: str
+
+        :returns: The updated Longview Plan
+        :rtype: LongviewPlan
         """
 
         if longview_subscription not in [

--- a/linode_api4/groups/longview.py
+++ b/linode_api4/groups/longview.py
@@ -71,7 +71,7 @@ class LongviewGroup(Group):
 
         :param longview_subscription: The subscription ID for a particular Longview plan.
                                       A value of null corresponds to Longview Free.
-        :type longview_subscription: : str
+        :type longview_subscription: str
         """
 
         if longview_subscription not in [

--- a/linode_api4/objects/base.py
+++ b/linode_api4/objects/base.py
@@ -203,9 +203,23 @@ class Base(object, metaclass=FilterableMetaclass):
         if not force and not self._changed:
             return False
 
-        resp = self._client.put(
-            type(self).api_endpoint, model=self, data=self._serialize()
-        )
+        if not self._populated:
+            result = {
+                a: getattr(self, a)
+                for a in type(self).properties
+                if type(self).properties[a].mutable
+                and object.__getattribute__(self, a) is not None
+                and hasattr(self, a)
+            }
+            # pdb.set_trace()
+
+            resp = self._client.put(
+                type(self).api_endpoint, model=self, data=result
+            )
+        else:
+            resp = self._client.put(
+                type(self).api_endpoint, model=self, data=self._serialize()
+            )
 
         if "error" in resp:
             return False

--- a/linode_api4/objects/longview.py
+++ b/linode_api4/objects/longview.py
@@ -41,34 +41,3 @@ class LongviewPlan(Base):
         "clients_included": Property(),
         "price": Property(),
     }
-
-    def longview_plan_update(self, longview_subscription):
-        """
-        Update your Longview plan to that of the given subcription ID.
-
-        :param longview_subscription: The subscription ID for a particular Longview plan.
-                                      A value of null corresponds to Longview Free.
-        :type longview_subscription: : str
-        """
-
-        if longview_subscription not in [
-            "",
-            "longview-3",
-            "longview-10",
-            "longview-40",
-            "longview-100",
-        ]:
-            raise ValueError(
-                "Invalid longview plan subscription: {}".format(
-                    longview_subscription
-                )
-            )
-
-        params = {"longview_subscription": longview_subscription}
-
-        result = self._client.post(
-            LongviewPlan.api_endpoint, model=self, data=params
-        )
-        self.invalidate()
-
-        return LongviewPlan(self._client, result["id"], result)

--- a/linode_api4/objects/longview.py
+++ b/linode_api4/objects/longview.py
@@ -27,6 +27,12 @@ class LongviewSubscription(Base):
 
 
 class LongviewPlan(Base):
+    """
+    The current Longview Plan an account is using.
+
+    API Documentation: https://www.linode.com/docs/api/longview/#longview-plan-view
+    """
+
     api_endpoint = "/longview/plan"
 
     properties = {

--- a/linode_api4/objects/longview.py
+++ b/linode_api4/objects/longview.py
@@ -24,3 +24,45 @@ class LongviewSubscription(Base):
         "clients_included": Property(),
         "price": Property(),
     }
+
+
+class LongviewPlan(Base):
+    api_endpoint = "/longview/plan"
+
+    properties = {
+        "id": Property(identifier=True),
+        "label": Property(),
+        "clients_included": Property(),
+        "price": Property(),
+    }
+
+    def longview_plan_update(self, longview_subscription):
+        """
+        Update your Longview plan to that of the given subcription ID.
+
+        :param longview_subscription: The subscription ID for a particular Longview plan.
+                                      A value of null corresponds to Longview Free.
+        :type longview_subscription: : str
+        """
+
+        if longview_subscription not in [
+            "",
+            "longview-3",
+            "longview-10",
+            "longview-40",
+            "longview-100",
+        ]:
+            raise ValueError(
+                "Invalid longview plan subscription: {}".format(
+                    longview_subscription
+                )
+            )
+
+        params = {"longview_subscription": longview_subscription}
+
+        result = self._client.post(
+            LongviewPlan.api_endpoint, model=self, data=params
+        )
+        self.invalidate()
+
+        return LongviewPlan(self._client, result["id"], result)

--- a/test/fixtures/longview_plan.json
+++ b/test/fixtures/longview_plan.json
@@ -1,0 +1,9 @@
+{
+    "clients_included": 10,
+    "id": "longview-10",
+    "label": "Longview Pro 10 pack",
+    "price": {
+      "hourly": 0.06,
+      "monthly": 40
+    }
+}

--- a/test/linode_client_test.py
+++ b/test/linode_client_test.py
@@ -502,6 +502,21 @@ class LongviewGroupTest(ClientBaseCase):
             self.assertEqual(m.call_url, "/longview/clients")
             self.assertEqual(m.call_data, {"label": "test_client_1"})
 
+    def test_update_plan(self):
+        """
+        Tests that you can submit a correct longview plan update api request
+        """
+        with self.mock_post("/longview/plan") as m:
+            result = self.client.longview.longview_plan_update("longview-100")
+            self.assertEqual(m.call_url, "/longview/plan")
+            self.assertEqual(
+                m.call_data["longview_subscription"], "longview-100"
+            )
+            self.assertEqual(result.id, "longview-10")
+            self.assertEqual(result.clients_included, 10)
+            self.assertEqual(result.label, "Longview Pro 10 pack")
+            self.assertIsNotNone(result.price)
+
     def test_get_subscriptions(self):
         """
         Tests that Longview subscriptions can be retrieved

--- a/test/objects/longview_test.py
+++ b/test/objects/longview_test.py
@@ -1,8 +1,46 @@
 from datetime import datetime
 from test.base import ClientBaseCase
 
-from linode_api4.objects import LongviewClient, LongviewSubscription
+from linode_api4.objects import (
+    LongviewClient,
+    LongviewPlan,
+    LongviewSubscription,
+)
 from linode_api4.objects.base import MappedObject
+
+
+class LongviewPlanTest(ClientBaseCase):
+    """
+    Tests methods of the LongviewPlan class
+    """
+
+    def test_get_plan(self):
+        """
+        Tests that a plan is loaded correctly
+        """
+        plan = LongviewPlan(self.client, "longview-10")
+
+        self.assertEqual(plan.id, "longview-10")
+        self.assertEqual(plan.clients_included, 10)
+        self.assertEqual(plan.label, "Longview Pro 10 pack")
+        self.assertIsNotNone(plan.price)
+
+    def test_update_plan(self):
+        """
+        Tests that you can submit a correct longview plan update api request
+        """
+        plan = LongviewPlan(self.client, "longview-10")
+
+        with self.mock_post("/longview/plan") as m:
+            result = plan.longview_plan_update("longview-100")
+            self.assertEqual(m.call_url, "/longview/plan")
+            self.assertEqual(
+                m.call_data["longview_subscription"], "longview-100"
+            )
+            self.assertEqual(result.id, "longview-10")
+            self.assertEqual(result.clients_included, 10)
+            self.assertEqual(result.label, "Longview Pro 10 pack")
+            self.assertIsNotNone(result.price)
 
 
 class LongviewClientTest(ClientBaseCase):

--- a/test/objects/longview_test.py
+++ b/test/objects/longview_test.py
@@ -25,23 +25,6 @@ class LongviewPlanTest(ClientBaseCase):
         self.assertEqual(plan.label, "Longview Pro 10 pack")
         self.assertIsNotNone(plan.price)
 
-    def test_update_plan(self):
-        """
-        Tests that you can submit a correct longview plan update api request
-        """
-        plan = LongviewPlan(self.client, "longview-10")
-
-        with self.mock_post("/longview/plan") as m:
-            result = plan.longview_plan_update("longview-100")
-            self.assertEqual(m.call_url, "/longview/plan")
-            self.assertEqual(
-                m.call_data["longview_subscription"], "longview-100"
-            )
-            self.assertEqual(result.id, "longview-10")
-            self.assertEqual(result.clients_included, 10)
-            self.assertEqual(result.label, "Longview Pro 10 pack")
-            self.assertIsNotNone(result.price)
-
 
 class LongviewClientTest(ClientBaseCase):
     """


### PR DESCRIPTION
## 📝 Description

Previously, attempting to update a non-populated NodeBalancerNode would result in the update actually updating the resource silently. This change fixes the issue.

## ✔️ How to Test

`pytest test`

Note: Since this change deals with making updates to real resources as opposed to fixtures, it cannot be tested using mocks and must therefore be tested manually. To do this, first create a NodeBalancerNode in your Linode account if one does not already exist, and then run this python script and verify that the weight of the node was actually updated.

```
#!/usr/bin/env python3

from linode_api4 import LinodeClient
from linode_api4.objects import  NodeBalancerNode

client = LinodeClient(<personal_access_token>)

node = NodeBalancerNode(client, <node_id>, <config_id>, <nodebalancer_id>)

node.weight = 60

node.save()
```

Resolves #97 