### PR TITLE
TPT 1880: Fixed issue with updating non-populated NodeBalancerNode

### DIFF
--- a/linode_api4/objects/base.py
+++ b/linode_api4/objects/base.py
@@ -220,7 +220,10 @@ class Base(object, metaclass=FilterableMetaclass):
             }
 
             for key, value in result.items():
-                if isinstance(value, ExplicitNullValue) or value == ExplicitNullValue:
+                if (
+                    isinstance(value, ExplicitNullValue)
+                    or value == ExplicitNullValue
+                ):
                     result[key] = None
 
             resp = self._client.put(

--- a/linode_api4/objects/base.py
+++ b/linode_api4/objects/base.py
@@ -210,29 +210,26 @@ class Base(object, metaclass=FilterableMetaclass):
         if not force and not self._changed:
             return False
 
+        data = None
         if not self._populated:
-            result = {
-                a: getattr(self, a)
+            data = {
+                a: object.__getattribute__(self, a)
                 for a in type(self).properties
                 if type(self).properties[a].mutable
                 and object.__getattribute__(self, a) is not None
-                and hasattr(self, a)
             }
 
-            for key, value in result.items():
+            for key, value in data.items():
                 if (
                     isinstance(value, ExplicitNullValue)
                     or value == ExplicitNullValue
                 ):
-                    result[key] = None
+                    data[key] = None
 
-            resp = self._client.put(
-                type(self).api_endpoint, model=self, data=result
-            )
         else:
-            resp = self._client.put(
-                type(self).api_endpoint, model=self, data=self._serialize()
-            )
+            data = self._serialize()
+
+        resp = self._client.put(type(self).api_endpoint, model=self, data=data)
 
         if "error" in resp:
             return False

--- a/linode_api4/objects/base.py
+++ b/linode_api4/objects/base.py
@@ -210,9 +210,23 @@ class Base(object, metaclass=FilterableMetaclass):
         if not force and not self._changed:
             return False
 
-        resp = self._client.put(
-            type(self).api_endpoint, model=self, data=self._serialize()
-        )
+        if not self._populated:
+            result = {
+                a: getattr(self, a)
+                for a in type(self).properties
+                if type(self).properties[a].mutable
+                and object.__getattribute__(self, a) is not None
+                and hasattr(self, a)
+            }
+            # pdb.set_trace()
+
+            resp = self._client.put(
+                type(self).api_endpoint, model=self, data=result
+            )
+        else:
+            resp = self._client.put(
+                type(self).api_endpoint, model=self, data=self._serialize()
+            )
 
         if "error" in resp:
             return False

--- a/linode_api4/objects/base.py
+++ b/linode_api4/objects/base.py
@@ -218,7 +218,10 @@ class Base(object, metaclass=FilterableMetaclass):
                 and object.__getattribute__(self, a) is not None
                 and hasattr(self, a)
             }
-            # pdb.set_trace()
+
+            for key, value in result.items():
+                if isinstance(value, ExplicitNullValue) or value == ExplicitNullValue:
+                    result[key] = None
 
             resp = self._client.put(
                 type(self).api_endpoint, model=self, data=result


### PR DESCRIPTION
## 📝 Description

Previously, attempting to update a non-populated NodeBalancerNode would result in the update actually updating the resource silently. This change fixes the issue.

## ✔️ How to Test

`pytest test`

Note: Since this change deals with making updates to real resources as opposed to fixtures, it cannot be tested using mocks and must therefore be tested manually. To do this, first create a NodeBalancerNode in your Linode account if one does not already exist, and then run this python script and verify that the weight of the node was actually updated.

```
#!/usr/bin/env python3

from linode_api4 import LinodeClient
from linode_api4.objects import  NodeBalancerNode

client = LinodeClient(<personal_access_token>)

node = NodeBalancerNode(client, <node_id>, <config_id>, <nodebalancer_id>)

node.weight = 60

node.save()
```

Resolves #97 