### PR TITLE
fix: Resolve error when attempting to parse global IPv6 ranges in Instance.ips

### DIFF
--- a/linode_api4/objects/linode.py
+++ b/linode_api4/objects/linode.py
@@ -11,7 +11,7 @@ from linode_api4.errors import UnexpectedResponseError
 from linode_api4.objects import Base, DerivedBase, Image, Property, Region
 from linode_api4.objects.base import MappedObject
 from linode_api4.objects.filtering import FilterableAttribute
-from linode_api4.objects.networking import IPAddress, IPv6Pool
+from linode_api4.objects.networking import IPAddress, IPv6Range
 from linode_api4.paginated_list import PaginatedList
 
 PASSWORD_CHARS = string.ascii_letters + string.digits + string.punctuation
@@ -465,7 +465,7 @@ class Instance(Base):
                 result["ipv6"]["link_local"],
             )
 
-            pools = [IPv6Pool(self._client, result["ipv6"]["global"]["range"])]
+            pools = [IPv6Range(self._client, r["range"]) for r in result["ipv6"]["global"]]
 
             ips = MappedObject(
                 **{

--- a/linode_api4/objects/linode.py
+++ b/linode_api4/objects/linode.py
@@ -465,7 +465,10 @@ class Instance(Base):
                 result["ipv6"]["link_local"],
             )
 
-            pools = [IPv6Range(self._client, r["range"]) for r in result["ipv6"]["global"]]
+            pools = [
+                IPv6Range(self._client, r["range"])
+                for r in result["ipv6"]["global"]
+            ]
 
             ips = MappedObject(
                 **{

--- a/test/fixtures/linode_instances_123_ips.json
+++ b/test/fixtures/linode_instances_123_ips.json
@@ -54,12 +54,14 @@
       ]
     },
     "ipv6": {
-      "global": {
-        "prefix": 124,
-        "range": "2600:3c01::2:5000:0",
-        "region": "us-east",
-        "route_target": "2600:3c01::2:5000:f"
-      },
+      "global": [
+        {
+          "prefix": 124,
+          "range": "2600:3c01::2:5000:0",
+          "region": "us-east",
+          "route_target": "2600:3c01::2:5000:f"
+        }
+      ],
       "link_local": {
         "address": "fe80::f03c:91ff:fe24:3a2f",
         "gateway": "fe80::1",


### PR DESCRIPTION
## 📝 Description

This change resolves and error that occurs when attempting to call `Instance.ips(...)`.

## ✔️ How to Test

```
tox
```
