### PR TITLE
Remove directly call to setup.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,7 @@ clean:
 
 @PHONEY: build
 build: clean
-	$(PYTHON) setup.py sdist
-	$(PYTHON) setup.py bdist_wheel
+	$(PYTHON) -m build  --wheel --sdist
 
 
 @PHONEY: release
@@ -30,7 +29,7 @@ release: build
 
 
 install: clean
-	python3 setup.py install
+	python3 -m pip install .
 
 
 requirements:

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ Building from Source
 To build and install this package:
 
 - Clone this repository
-- ``./setup.py install``
+- ``python3 -m pip install .``
 
 Usage
 =====

--- a/docs/guides/getting_started.rst
+++ b/docs/guides/getting_started.rst
@@ -18,7 +18,7 @@ If you prefer, you can clone the package from github_ and install it from source
 
    git clone git@github.com:Linode/linode_api4-python
    cd linode_api4
-   python -m pip instal .
+   python -m pip install .
 
 Authentication
 --------------

--- a/docs/guides/getting_started.rst
+++ b/docs/guides/getting_started.rst
@@ -18,7 +18,7 @@ If you prefer, you can clone the package from github_ and install it from source
 
    git clone git@github.com:Linode/linode_api4-python
    cd linode_api4
-   python setup.py install
+   python -m pip instal .
 
 Authentication
 --------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,7 +19,7 @@ To install from source::
 
   git clone https://github.com/linode/linode_api4-python
   cd linode_api4
-  python -m pip instal .
+  python -m pip install .
 
 For more information, see our :doc:`Getting Started<guides/getting_started>`
 guide.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,7 +19,7 @@ To install from source::
 
   git clone https://github.com/linode/linode_api4-python
   cd linode_api4
-  python setup.py install
+  python -m pip instal .
 
 For more information, see our :doc:`Getting Started<guides/getting_started>`
 guide.

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ deps =
     pylint
     httpretty
 commands =
-    python -m pip instal .
+    python -m pip install .
     coverage run --source linode_api4 -m pytest test/unit
     coverage report
     pylint linode_api4

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ deps =
     pylint
     httpretty
 commands =
-    python setup.py install
+    python -m pip instal .
     coverage run --source linode_api4 -m pytest test/unit
     coverage report
     pylint linode_api4


### PR DESCRIPTION
## 📝 Description

Calling `setup.py` is deprecated.
https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html

