### PR TITLE
Add build and certifi installation in the release workflow

### DIFF
--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -22,7 +22,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install Python deps
-        run: pip install wheel
+        run: pip install -U wheel build certifi
 
       - name: Install package requirements
         run: make requirements

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,3 +9,4 @@ sphinx-autobuild>=2021.3.14
 sphinxcontrib-fulltoc>=1.2.0
 pytest>=7.3.1
 httpretty>=1.1.4
+build>=0.10.0


### PR DESCRIPTION
## 📝 Description

`build` is necessary to build the package now.