### PR TITLE
Add twine check in lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
           python-version: '3.x'
 
       - name: install dependencies
-        run: pip3 install -r requirements-dev.txt -r requirements.txt
+        run: make requirements
 
       - name: run linter
         run: make lint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,8 +16,8 @@ jobs:
       matrix:
         python-version: ['3.7','3.8','3.9','3.10','3.11']
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Run tests

--- a/Makefile
+++ b/Makefile
@@ -27,35 +27,36 @@ build: clean
 release: build
 	twine upload dist/*
 
-
+@PHONEY: install
 install: clean
 	python3 -m pip install .
 
-
+@PHONEY: requirements
 requirements:
 	pip install -r requirements.txt -r requirements-dev.txt
 
-
+@PHONEY: black
 black:
 	black linode_api4 test
 
-
+@PHONEY: isort
 isort:
 	isort linode_api4 test
 
-
+@PHONEY: autoflake
 autoflake:
 	autoflake linode_api4 test
 
-
+@PHONEY: format
 format: black isort autoflake
 
-
-lint:
+@PHONEY: lint
+lint: build
 	isort --check-only linode_api4 test
 	autoflake --check linode_api4 test
 	black --check --verbose linode_api4 test
 	pylint linode_api4
+	twine check dist/*
 
 @PHONEY: testint
 testint:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,3 +10,4 @@ sphinxcontrib-fulltoc>=1.2.0
 pytest>=7.3.1
 httpretty>=1.1.4
 build>=0.10.0
+twine>=4.0.2


### PR DESCRIPTION
## 📝 Description

`twine check` is necessary to ensure the package can be built and validated for publishing on PyPI.

## ✔️ How to Test
`make lint` or see the GHA run result.