### PR TITLE
Remove installation of package requirements in pypi publishing workflow

### DIFF
--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -24,9 +24,6 @@ jobs:
       - name: Install Python deps
         run: pip install -U wheel build certifi
 
-      - name: Install package requirements
-        run: make requirements
-
       - name: Build the package
         run: make build
         env:


### PR DESCRIPTION
## 📝 Description

Installation of package requirements is no longer necessary thanks to the isolated build environment feature of [the build tool](https://pypa-build.readthedocs.io/en/latest/index.html).

## ✔️ How to Test

I ran the workflow in my repo without the final publishing step and it succeed.
https://github.com/zliang-akamai/linode_api4-python/actions/runs/5382308695