### PR TITLE
fix: Make the `autoscaler`, `control_plane`, and `k8s_version` fields mutable

### DIFF
--- a/linode_api4/objects/lke.py
+++ b/linode_api4/objects/lke.py
@@ -73,7 +73,7 @@ class LKENodePool(DerivedBase):
         "nodes": Property(
             volatile=True
         ),  # this is formatted in _populate below
-        "autoscaler": Property(),
+        "autoscaler": Property(mutable=True),
         "tags": Property(mutable=True),
     }
 
@@ -119,9 +119,9 @@ class LKECluster(Base):
         "tags": Property(mutable=True),
         "updated": Property(is_datetime=True),
         "region": Property(slug_relationship=Region),
-        "k8s_version": Property(slug_relationship=KubeVersion),
+        "k8s_version": Property(slug_relationship=KubeVersion, mutable=True),
         "pools": Property(derived_class=LKENodePool),
-        "control_plane": Property(),
+        "control_plane": Property(mutable=True),
     }
 
     @property


### PR DESCRIPTION
## 📝 Description

This change makes the `autoscaler`, `control_plane`, and `k8s_version` fields mutable to reflect their status in the API.

## ✔️ How to Test

```
make testunit
```
