### PR TITLE
fix: update filter when creating nb node with private ip

### DIFF
--- a/test/integration/models/test_nodebalancer.py
+++ b/test/integration/models/test_nodebalancer.py
@@ -61,7 +61,7 @@ def test_create_nb_node(
         create_nb_config.nodebalancer_id,
     )
     linode = create_linode_with_private_ip
-    address = [a for a in linode.ipv4 if re.search("192.+", a)][0]
+    address = [a for a in linode.ipv4 if re.search("192.168.+", a)][0]
     node = config.node_create(
         "node_test", address + ":80", weight=50, mode="accept"
     )


### PR DESCRIPTION
## 📝 Description

Fixing one of intermittent failure in smoke tests : test_create_nb_node
- Update filter to start from 192.168 since it sometimes picks up public ip if it filters only 192

## ✔️ How to Test

make smoketest

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**