### PR TITLE
fix: Add missing fields to `IPv6Range`

### DIFF
--- a/linode_api4/objects/networking.py
+++ b/linode_api4/objects/networking.py
@@ -31,6 +31,8 @@ class IPv6Range(Base):
         "region": Property(slug_relationship=Region),
         "prefix": Property(),
         "route_target": Property(),
+        "linodes": Property(),
+        "is_bgp": Property(),
     }
 
 

--- a/test/unit/objects/networking_test.py
+++ b/test/unit/objects/networking_test.py
@@ -20,6 +20,8 @@ class NetworkingTest(ClientBaseCase):
         self.assertEqual(ipv6Range.range, "2600:3c01::")
         self.assertEqual(ipv6Range.prefix, 64)
         self.assertEqual(ipv6Range.region.id, "us-east")
+        self.assertEqual(ipv6Range.linodes[0], 123)
+        self.assertEqual(ipv6Range.is_bgp, False)
 
         ranges = self.client.networking.ipv6_ranges()
 


### PR DESCRIPTION
## 📝 Description

[IPv6 range view](https://www.linode.com/docs/api/networking/#ipv6-range-view__responses) and [IPv6 range list](https://www.linode.com/docs/api/networking/#ipv6-ranges-list__responses) actually share different response structures. The current `IPv6Range` object has been built based on the structure of IPv6 range list, so fields `linodes` and `is_bgp` are missing. To quickly fix it, I think simply adding these two fields to the `IPv6Range` object properties makes sense without introducing any breaking change. Otherwise we may consider create two separated objects for returning a single object and list, which is probably confusing for customers to use and more complicated for us to maintain. Any different idea is appreciated. 

## ✔️ How to Test

`tox`