### PR TITLE
new: Add `beta` object and group

### DIFF
--- a/linode_api4/groups/__init__.py
+++ b/linode_api4/groups/__init__.py
@@ -2,6 +2,7 @@
 from .group import *  # isort: skip
 
 from .account import *
+from .beta import *
 from .database import *
 from .domain import *
 from .image import *

--- a/linode_api4/groups/beta.py
+++ b/linode_api4/groups/beta.py
@@ -1,0 +1,24 @@
+from linode_api4.groups import Group
+from linode_api4.objects import BetaProgram
+
+
+class BetaProgramGroup(Group):
+    """
+    This group encapsulates all endpoints under /betas, including viewing
+    available active beta programs.
+    """
+
+    def betas(self, *filters):
+        """
+        Returns a list of available active Beta Programs.
+
+        API Documentation: TBD
+
+        :param filters: Any number of filters to apply to this query.
+                        See :doc:`Filtering Collections</linode_api4/objects/filtering>`
+                        for more details on filtering.
+
+        :returns: A list of Beta Programs that matched the query.
+        :rtype: PaginatedList of BetaProgram
+        """
+        return self.client._get_and_filter(BetaProgram, *filters)

--- a/linode_api4/linode_client.py
+++ b/linode_api4/linode_client.py
@@ -12,6 +12,7 @@ from requests.adapters import HTTPAdapter, Retry
 from linode_api4.errors import ApiError, UnexpectedResponseError
 from linode_api4.groups import (
     AccountGroup,
+    BetaProgramGroup,
     DatabaseGroup,
     DomainGroup,
     ImageGroup,
@@ -187,6 +188,9 @@ class LinodeClient:
 
         #: Access methods related to Event polling - See :any:`PollingGroup` for more information.
         self.polling = PollingGroup(self)
+
+        #: Access methods related to Beta Program - See :any:`BetaProgramGroup` for more information.
+        self.beta = BetaProgramGroup(self)
 
     @property
     def _user_agent(self):

--- a/linode_api4/objects/__init__.py
+++ b/linode_api4/objects/__init__.py
@@ -17,3 +17,4 @@ from .tag import Tag
 from .object_storage import *
 from .lke import *
 from .database import *
+from .beta import *

--- a/linode_api4/objects/beta.py
+++ b/linode_api4/objects/beta.py
@@ -1,0 +1,22 @@
+from linode_api4.objects import Base, Property
+
+
+class BetaProgram(Base):
+    """
+    Beta program is a new product or service that's not generally available to all customers.
+    User with permissions can enroll into a beta program and access the functionalities.
+
+    API Documentation: TBD
+    """
+
+    api_endpoint = "/betas/{id}"
+
+    properties = {
+        "id": Property(identifier=True),
+        "label": Property(),
+        "description": Property(),
+        "started": Property(is_datetime=True),
+        "ended": Property(is_datetime=True),
+        "greenlight_only": Property(),
+        "more_info": Property(),
+    }

--- a/test/fixtures/betas.json
+++ b/test/fixtures/betas.json
@@ -1,0 +1,24 @@
+{
+    "data": [
+        {
+            "id": "active_closed", 
+            "label": "active closed beta", 
+            "description": "An active closed beta", 
+            "started": "2023-07-19T15:23:43", 
+            "ended": null, 
+            "greenlight_only": true, 
+            "more_info": "a link with even more info"
+        }, 
+        {
+            "id": "limited",
+            "label": "limited beta", 
+            "description": "An active limited beta", 
+            "started": "2023-07-19T15:23:43", 
+            "ended": null, "greenlight_only": false, 
+            "more_info": "a link with even more info"
+        }
+    ], 
+    "page": 1, 
+    "pages": 1, 
+    "results": 2
+}

--- a/test/fixtures/betas_active.json
+++ b/test/fixtures/betas_active.json
@@ -1,0 +1,9 @@
+{
+    "id": "active_closed", 
+    "label": "active closed beta", 
+    "description": "An active closed beta", 
+    "started": "2018-01-02T03:04:05", 
+    "ended": null, 
+    "greenlight_only": true, 
+    "more_info": "a link with even more info"
+}

--- a/test/fixtures/betas_active.json
+++ b/test/fixtures/betas_active.json
@@ -1,5 +1,5 @@
 {
-    "id": "active_closed", 
+    "id": "active", 
     "label": "active closed beta", 
     "description": "An active closed beta", 
     "started": "2018-01-02T03:04:05", 

--- a/test/unit/linode_client_test.py
+++ b/test/unit/linode_client_test.py
@@ -412,6 +412,27 @@ class AccountGroupTest(ClientBaseCase):
         self.assertEqual(payment.usd, 1000)
 
 
+class BetaProgramGroupTest(ClientBaseCase):
+    """
+    Tests methods of the BetaProgramGroup
+    """
+
+    def test_betas(self):
+        """
+        Test that available beta programs can be retrieved
+        """
+        betas = self.client.beta.betas()
+
+        self.assertEqual(len(betas), 2)
+        beta = betas[0]
+        self.assertEqual(beta.id, "active_closed")
+        self.assertEqual(beta.label, "active closed beta")
+        self.assertEqual(beta.started, datetime(2023, 7, 19, 15, 23, 43))
+        self.assertEqual(beta.ended, None)
+        self.assertEqual(beta.greenlight_only, True)
+        self.assertEqual(beta.more_info, "a link with even more info")
+
+
 class LinodeGroupTest(ClientBaseCase):
     """
     Tests methods of the LinodeGroup

--- a/test/unit/objects/beta_test.py
+++ b/test/unit/objects/beta_test.py
@@ -1,0 +1,30 @@
+from datetime import datetime
+from test.unit.base import ClientBaseCase
+
+from linode_api4.objects import BetaProgram
+
+
+class BetaProgramTest(ClientBaseCase):
+    """
+    Test the methods of the Beta Program.
+    """
+
+    def test_beta_program_api_get(self):
+        beta_id = "active"
+        beta_program_api_get_url = "/betas/{}".format(beta_id)
+
+        with self.mock_get(beta_program_api_get_url) as m:
+            beta_program = BetaProgram(self.client, beta_id)
+            self.assertEqual(beta_program.id, beta_id)
+            self.assertEqual(beta_program.label, "active closed beta")
+            self.assertEqual(beta_program.description, "An active closed beta")
+            self.assertEqual(
+                beta_program.started, datetime(2018, 1, 2, 3, 4, 5)
+            )
+            self.assertEqual(beta_program.ended, None)
+            self.assertEqual(beta_program.greenlight_only, True)
+            self.assertEqual(
+                beta_program.more_info, "a link with even more info"
+            )
+
+            self.assertEqual(m.call_url, beta_program_api_get_url)

--- a/test/unit/objects/linode_test.py
+++ b/test/unit/objects/linode_test.py
@@ -259,7 +259,7 @@ class LinodeTest(ClientBaseCase):
         with self.mock_get("/linode/instances/123/firewalls") as m:
             result = linode.firewalls()
             self.assertEqual(m.call_url, "/linode/instances/123/firewalls")
-            self.assertEquals(len(result), 1)
+            self.assertEqual(len(result), 1)
 
     def test_volumes(self):
         """
@@ -270,7 +270,7 @@ class LinodeTest(ClientBaseCase):
         with self.mock_get("/linode/instances/123/volumes") as m:
             result = linode.volumes()
             self.assertEqual(m.call_url, "/linode/instances/123/volumes")
-            self.assertEquals(len(result), 1)
+            self.assertEqual(len(result), 1)
 
     def test_nodebalancers(self):
         """
@@ -281,7 +281,7 @@ class LinodeTest(ClientBaseCase):
         with self.mock_get("/linode/instances/123/nodebalancers") as m:
             result = linode.nodebalancers()
             self.assertEqual(m.call_url, "/linode/instances/123/nodebalancers")
-            self.assertEquals(len(result), 1)
+            self.assertEqual(len(result), 1)
 
     def test_transfer_year_month(self):
         """


### PR DESCRIPTION
## 📝 Description

Implement self serve beta in python SDK. Create `beta` object and group to support existing beta program endpoints:

```
GET /betas/:id
GET /betas
```

## ✔️ How to Test

`tox`
