### PR TITLE
new: Add `AccountBetaProgram` to support self serve beta

### DIFF
--- a/linode_api4/groups/account.py
+++ b/linode_api4/groups/account.py
@@ -4,6 +4,7 @@ from linode_api4.objects import (
     Account,
     AccountBetaProgram,
     AccountSettings,
+    Base,
     Event,
     Invoice,
     Login,
@@ -461,19 +462,19 @@ class AccountGroup(Group):
         """
         return self.client._get_and_filter(AccountBetaProgram, *filters)
 
-    def join_beta_program(self, id):
+    def join_beta_program(self, beta):
         """
         Enrolls an account into a beta program.
 
         API doc: TBD
 
-        :param id: The id of the beta program to join.
-        :type id: str
+        :param beta: The object or id of a beta program to join.
+        :type beta: BetaProgram or str
 
         :returns: The details of the beta program and enrollment.
         :rtype: bool
         """
 
-        self.client.post("/account/betas", data={"id": id})
+        self.client.post("/account/betas", data={"id": beta.id if issubclass(type(beta), Base) else beta})
 
         return True

--- a/linode_api4/groups/account.py
+++ b/linode_api4/groups/account.py
@@ -2,6 +2,7 @@ from linode_api4.errors import UnexpectedResponseError
 from linode_api4.groups import Group
 from linode_api4.objects import (
     Account,
+    AccountBetaProgram,
     AccountSettings,
     Event,
     Invoice,
@@ -448,3 +449,31 @@ class AccountGroup(Group):
 
         u = User(self.client, result["username"], result)
         return u
+
+    def enrolled_betas(self, *filters):
+        """
+        Returns a list of all Beta Programs an account is enrolled in.
+
+        API doc: TBD
+
+        :returns: a list of Beta Programs.
+        :rtype: MappedObject
+        """
+        return self.client._get_and_filter(AccountBetaProgram, *filters)
+
+    def join_beta_program(self, id):
+        """
+        Enrolls an account into a beta program.
+
+        API doc: TBD
+
+        :param id: The id of the beta program to join.
+        :type id: str
+
+        :returns: The details of the beta program and enrollment.
+        :rtype: AccountBetaProgram
+        """
+
+        self.client.post("/account/betas", data={"id": id})
+
+        return True

--- a/linode_api4/groups/account.py
+++ b/linode_api4/groups/account.py
@@ -471,7 +471,7 @@ class AccountGroup(Group):
         :param beta: The object or id of a beta program to join.
         :type beta: BetaProgram or str
 
-        :returns: The details of the beta program and enrollment.
+        :returns: A boolean indicating whether the account joined a beta program successfully.
         :rtype: bool
         """
 

--- a/linode_api4/groups/account.py
+++ b/linode_api4/groups/account.py
@@ -457,7 +457,7 @@ class AccountGroup(Group):
         API doc: TBD
 
         :returns: a list of Beta Programs.
-        :rtype: MappedObject
+        :rtype: PaginatedList of AccountBetaProgram
         """
         return self.client._get_and_filter(AccountBetaProgram, *filters)
 
@@ -471,7 +471,7 @@ class AccountGroup(Group):
         :type id: str
 
         :returns: The details of the beta program and enrollment.
-        :rtype: AccountBetaProgram
+        :rtype: bool
         """
 
         self.client.post("/account/betas", data={"id": id})

--- a/linode_api4/groups/account.py
+++ b/linode_api4/groups/account.py
@@ -475,6 +475,9 @@ class AccountGroup(Group):
         :rtype: bool
         """
 
-        self.client.post("/account/betas", data={"id": beta.id if issubclass(type(beta), Base) else beta})
+        self.client.post(
+            "/account/betas",
+            data={"id": beta.id if issubclass(type(beta), Base) else beta},
+        )
 
         return True

--- a/linode_api4/objects/account.py
+++ b/linode_api4/objects/account.py
@@ -637,3 +637,20 @@ class UserGrants:
         self._populate(result)
 
         return True
+
+
+class AccountBetaProgram(Base):
+    """
+    The details and enrollment information of a Beta program that an account is enrolled in.
+    """
+
+    api_endpoint = "/account/betas/{id}"
+
+    properties = {
+        "id": Property(identifier=True),
+        "label": Property(),
+        "description": Property(),
+        "started": Property(is_datetime=True),
+        "ended": Property(is_datetime=True),
+        "enrolled": Property(is_datetime=True),
+    }

--- a/test/fixtures/account_betas.json
+++ b/test/fixtures/account_betas.json
@@ -1,0 +1,15 @@
+{
+   "data": [
+        {
+            "id": "cool", 
+            "label": "\r\n\r\nRepellat consequatur sunt qui.", 
+            "enrolled": "2018-01-02T03:04:05",
+            "description": "Repellat consequatur sunt qui. Fugit eligendi ipsa et assumenda ea aspernatur esse. A itaque iste distinctio qui voluptas eum enim ipsa.", 
+            "started": "2018-01-02T03:04:05", 
+            "ended": "2018-01-02T03:04:05"
+        }
+   ],
+   "page": 1, 
+   "pages": 1, 
+   "results": 1
+}

--- a/test/fixtures/account_betas_cool.json
+++ b/test/fixtures/account_betas_cool.json
@@ -1,0 +1,8 @@
+{
+    "id": "cool", 
+    "label": "\r\n\r\nRepellat consequatur sunt qui.", 
+    "enrolled": "2018-01-02T03:04:05",
+    "description": "Repellat consequatur sunt qui. Fugit eligendi ipsa et assumenda ea aspernatur esse. A itaque iste distinctio qui voluptas eum enim ipsa.", 
+    "started": "2018-01-02T03:04:05", 
+    "ended": "2018-01-02T03:04:05"
+}

--- a/test/unit/linode_client_test.py
+++ b/test/unit/linode_client_test.py
@@ -440,10 +440,12 @@ class AccountGroupTest(ClientBaseCase):
                 },
             )
             self.assertEqual(m.call_url, join_beta_url)
-            
+
         # Test that user can join a beta program with an BetaProgram object
         with self.mock_post({}) as m:
-            self.client.account.join_beta_program(BetaProgram(self.client, "cool_beta"))
+            self.client.account.join_beta_program(
+                BetaProgram(self.client, "cool_beta")
+            )
             self.assertEqual(
                 m.call_data,
                 {
@@ -451,7 +453,6 @@ class AccountGroupTest(ClientBaseCase):
                 },
             )
             self.assertEqual(m.call_url, join_beta_url)
-        
 
 
 class BetaProgramGroupTest(ClientBaseCase):

--- a/test/unit/linode_client_test.py
+++ b/test/unit/linode_client_test.py
@@ -411,6 +411,35 @@ class AccountGroupTest(ClientBaseCase):
         self.assertEqual(payment.date, datetime(2015, 1, 1, 5, 1, 2))
         self.assertEqual(payment.usd, 1000)
 
+    def test_enrolled_betas(self):
+        """
+        Tests that enrolled beta programs can be retrieved
+        """
+        enrolled_betas = self.client.account.enrolled_betas()
+
+        self.assertEqual(len(enrolled_betas), 1)
+        beta = enrolled_betas[0]
+
+        self.assertEqual(beta.id, "cool")
+        self.assertEqual(beta.enrolled, datetime(2018, 1, 2, 3, 4, 5))
+        self.assertEqual(beta.started, datetime(2018, 1, 2, 3, 4, 5))
+        self.assertEqual(beta.ended, datetime(2018, 1, 2, 3, 4, 5))
+
+    def test_join_beta_program(self):
+        """
+        Tests that user can join a beta program
+        """
+        join_beta_url = "/account/betas"
+        with self.mock_post({}) as m:
+            self.client.account.join_beta_program("cool_beta")
+            self.assertEqual(
+                m.call_data,
+                {
+                    "id": "cool_beta",
+                },
+            )
+            self.assertEqual(m.call_url, join_beta_url)
+
 
 class LinodeGroupTest(ClientBaseCase):
     """

--- a/test/unit/linode_client_test.py
+++ b/test/unit/linode_client_test.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from test.unit.base import ClientBaseCase
 
 from linode_api4 import LongviewSubscription
+from linode_api4.objects.beta import BetaProgram
 from linode_api4.objects.linode import Instance
 from linode_api4.objects.networking import IPAddress
 from linode_api4.objects.object_storage import (
@@ -439,6 +440,18 @@ class AccountGroupTest(ClientBaseCase):
                 },
             )
             self.assertEqual(m.call_url, join_beta_url)
+            
+        # Test that user can join a beta program with an BetaProgram object
+        with self.mock_post({}) as m:
+            self.client.account.join_beta_program(BetaProgram(self.client, "cool_beta"))
+            self.assertEqual(
+                m.call_data,
+                {
+                    "id": "cool_beta",
+                },
+            )
+            self.assertEqual(m.call_url, join_beta_url)
+        
 
 
 class LinodeGroupTest(ClientBaseCase):

--- a/test/unit/objects/account_test.py
+++ b/test/unit/objects/account_test.py
@@ -3,6 +3,7 @@ from test.unit.base import ClientBaseCase
 
 from linode_api4.objects import (
     Account,
+    AccountBetaProgram,
     AccountSettings,
     Database,
     Domain,
@@ -240,3 +241,22 @@ class InvoiceTest(ClientBaseCase):
             self.assertEqual(
                 m.call_url, "/account/service-transfers/12345/accept"
             )
+
+
+class AccountBetaProgramTest(ClientBaseCase):
+    """
+    Tests methods of the AccountBetaProgram
+    """
+
+    def test_account_beta_program_api_get(self):
+        beta_id = "cool"
+        account_beta_url = "/account/betas/{}".format(beta_id)
+
+        with self.mock_get(account_beta_url) as m:
+            beta = AccountBetaProgram(self.client, beta_id)
+            self.assertEqual(beta.id, beta_id)
+            self.assertEqual(beta.enrolled, datetime(2018, 1, 2, 3, 4, 5))
+            self.assertEqual(beta.started, datetime(2018, 1, 2, 3, 4, 5))
+            self.assertEqual(beta.ended, datetime(2018, 1, 2, 3, 4, 5))
+
+            self.assertEqual(m.call_url, account_beta_url)


### PR DESCRIPTION
## 📝 Description

`AccountBetaProgram` object returns information about a beta program an account enrolled in, including the enrollment information. Customer can also check the list of all enrolled betas and join an active beta program under the account group. 

Endpoints implemented:

```
GET /account/betas
GET /account/betas/id
POST /account/betas
```

## ✔️ How to Test

`tox`
