### PR TITLE
new: Support configuring a custom CA file path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,10 @@ lint: build
 testint:
 	python3 -m pytest test/integration/${INTEGRATION_TEST_PATH}${MODEL_COMMAND} ${TEST_CASE_COMMAND}
 
+@PHONEY: testunit
+testunit:
+	python3 -m python test/unit
+
 @PHONEY: smoketest
 smoketest:
 	pytest -m smoke test/integration --disable-warnings

--- a/linode_api4/linode_client.py
+++ b/linode_api4/linode_client.py
@@ -62,6 +62,7 @@ class LinodeClient:
         retry_rate_limit_interval=1.0,
         retry_max=5,
         retry_statuses=None,
+        ca_path=None,
     ):
         """
         The main interface to the Linode API.
@@ -96,11 +97,14 @@ class LinodeClient:
         :param retry_statuses: Additional HTTP response statuses to retry on.
                                By default, the client will retry on 408, 429, and 502
                                responses.
+        :param ca_path: The path to a CA file to use for API requests in this client.
+        :type ca_path: str
         """
         self.base_url = base_url
         self._add_user_agent = user_agent
         self.token = token
         self.page_size = page_size
+        self.ca_path = ca_path
 
         retry_forcelist = [408, 429, 502]
 
@@ -267,7 +271,9 @@ class LinodeClient:
         if data is not None:
             body = json.dumps(data)
 
-        response = method(url, headers=headers, data=body)
+        response = method(
+            url, headers=headers, data=body, verify=self.ca_path or True
+        )
 
         warning = response.headers.get("Warning", None)
         if warning:

--- a/linode_api4/login_client.py
+++ b/linode_api4/login_client.py
@@ -324,7 +324,11 @@ class OAuthScopes:
 
 class LinodeLoginClient:
     def __init__(
-        self, client_id, client_secret, base_url="https://login.linode.com"
+        self,
+        client_id,
+        client_secret,
+        base_url="https://login.linode.com",
+        ca_path=None,
     ):
         """
         Create a new LinodeLoginClient.  These clients do not make any requests
@@ -339,10 +343,13 @@ class LinodeLoginClient:
         :param base_url: The URL for Linode's OAuth server.  This should not be
                          changed.
         :type base_url: str
+        :param ca_path: The path to the CA file to use for requests run by this client.
+        :type ca_path: str
         """
         self.base_url = base_url
         self.client_id = client_id
         self.client_secret = client_secret
+        self.ca_path = ca_path
 
     def _login_uri(self, path):
         return "{}{}".format(self.base_url, path)
@@ -423,6 +430,7 @@ class LinodeLoginClient:
                 "client_id": self.client_id,
                 "client_secret": self.client_secret,
             },
+            verify=self.ca_path or True,
         )
 
         if r.status_code != 200:
@@ -467,6 +475,7 @@ class LinodeLoginClient:
                 "client_secret": self.client_secret,
                 "refresh_token": refresh_token,
             },
+            verify=self.ca_path or True,
         )
 
         if r.status_code != 200:
@@ -501,6 +510,7 @@ class LinodeLoginClient:
                 "client_secret": self.client_secret,
                 "token": token,
             },
+            verify=self.ca_path or True,
         )
 
         if r.status_code != 200:

--- a/test/unit/base.py
+++ b/test/unit/base.py
@@ -36,7 +36,7 @@ def load_json(url):
     return FIXTURES.get_fixture(formatted_url)
 
 
-def mock_get(url, headers=None, data=None):
+def mock_get(url, headers=None, data=None, **kwargs):
     """
     Loads the response from a JSON file
     """

--- a/test/unit/linode_client_test.py
+++ b/test/unit/linode_client_test.py
@@ -258,6 +258,28 @@ class LinodeClientGeneralTest(ClientBaseCase):
                 },
             )
 
+    def test_override_ca(self):
+        """
+        Tests that the CA file used for API requests can be overridden.
+        """
+        self.client.ca_path = "foobar"
+
+        called = False
+
+        old_get = self.client.session.get
+
+        def get_mock(*params, verify=True, **kwargs):
+            nonlocal called
+            called = True
+            assert verify == "foobar"
+            return old_get(*params, **kwargs)
+
+        self.client.session.get = get_mock
+
+        self.client.linode.instances()
+
+        assert called
+
 
 class AccountGroupTest(ClientBaseCase):
     """


### PR DESCRIPTION
## 📝 Description

This change allows users to specify a custom CA file to be used for API requests made by the `LinodeClient` and `LinodeLoginClient` classes. This is useful for testing in alternate API environments.

## ✔️ How to Test

```
make testunit
```
