### PR TITLE
new: Add integration test for `region_prices` Type field

### DIFF
--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -6,11 +6,22 @@ import pytest
 from linode_api4.linode_client import LinodeClient
 
 ENV_TOKEN_NAME = "LINODE_TOKEN"
+ENV_API_URL_NAME = "LINODE_API_URL"
+ENV_API_CA_NAME = "LINODE_API_CA"
 RUN_LONG_TESTS = "RUN_LONG_TESTS"
 
 
 def get_token():
     return os.environ.get(ENV_TOKEN_NAME, None)
+
+
+def get_api_url():
+    return os.environ.get(ENV_API_URL_NAME, "https://api.linode.com/v4beta")
+
+
+def get_api_ca_file():
+    result = os.environ.get(ENV_API_CA_NAME, None)
+    return result if result != "" else None
 
 
 def run_long_tests():
@@ -71,7 +82,13 @@ def ssh_key_gen():
 @pytest.fixture(scope="session")
 def get_client():
     token = get_token()
-    client = LinodeClient(token)
+    api_url = get_api_url()
+    api_ca_file = get_api_ca_file()
+    client = LinodeClient(
+        token,
+        base_url=api_url,
+        ca_path=api_ca_file,
+    )
     return client
 
 

--- a/test/integration/models/test_linode.py
+++ b/test/integration/models/test_linode.py
@@ -398,6 +398,22 @@ def test_get_linode_types(get_client):
     assert "g6-nanode-1" in ids
 
 
+def test_get_linode_types_overrides(get_client):
+    types = get_client.linode.types()
+
+    target_types = [
+        v
+        for v in types
+        if len(v.region_prices) > 0 and v.region_prices[0].hourly > 0
+    ]
+
+    assert len(target_types) > 0
+
+    for linode_type in target_types:
+        assert linode_type.region_prices[0].hourly >= 0
+        assert linode_type.region_prices[0].monthly >= 0
+
+
 def test_get_linode_type_by_id(get_client):
     pytest.skip(
         "Might need Type to match how other object models are behaving e.g. client.load(Type, 123)"


### PR DESCRIPTION
## 📝 Description

This change adds an integration test for the `region_prices` field user the `Type` class.

## ✔️ How to Test

```
export LINODE_API_URL="https://.../v4beta"
export LINODE_API_CA=$PWD/foobar.pem

make INTEGRATION_TEST_PATH="models/test_linode.py::test_get_linode_types_overrides" testint
```
