### PR TITLE
test: additional integration tests for vpc

### DIFF
--- a/linode_api4/objects/serializable.py
+++ b/linode_api4/objects/serializable.py
@@ -1,6 +1,5 @@
-import copy
 import inspect
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from typing import Any, Dict, get_type_hints
 
 
@@ -53,13 +52,7 @@ class JSONObject:
         """
         Serializes this object into a JSON dict.
         """
-        results = copy.deepcopy(vars(self))
-
-        for k, v in results.items():
-            if issubclass(type(v), JSONObject):
-                results[k] = v._serialize()
-
-        return results
+        return asdict(self)
 
     @property
     def dict(self) -> Dict[str, Any]:

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -296,7 +296,7 @@ def create_vpc_with_subnet_and_linode(get_client, create_vpc_with_subnet):
 def create_vpc(get_client):
     client = get_client
 
-    timestamp = int(time.time_ns() % 10**10)
+    timestamp = str(int(time.time_ns() % 10**10))
 
     vpc = client.vpcs.create(
         "pythonsdk-" + timestamp,
@@ -312,9 +312,9 @@ def create_vpc(get_client):
 def create_multiple_vpcs(get_client):
     client = get_client
 
-    timestamp = int(time.time_ns() % 10**10)
+    timestamp = str(int(time.time_ns() % 10**10))
 
-    timestamp_2 = int(time.time_ns() % 10**10)
+    timestamp_2 = str(int(time.time_ns() % 10**10))
 
     vpc_1 = client.vpcs.create(
         "pythonsdk-" + timestamp,
@@ -332,4 +332,4 @@ def create_multiple_vpcs(get_client):
 
     vpc_1.delete()
 
-    vpc_1.delete()
+    vpc_2.delete()

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -290,3 +290,46 @@ def create_vpc_with_subnet_and_linode(get_client, create_vpc_with_subnet):
     yield vpc, subnet, instance, password
 
     instance.delete()
+
+
+@pytest.fixture(scope="session")
+def create_vpc(get_client):
+    client = get_client
+
+    timestamp = str(int(time.time()))
+
+    vpc = client.vpcs.create(
+        "pythonsdk-" + timestamp,
+        get_region(get_client, {"VPCs"}),
+        description="test description",
+    )
+    yield vpc
+
+    vpc.delete()
+
+
+@pytest.fixture(scope="session")
+def create_multiple_vpcs(get_client):
+    client = get_client
+
+    timestamp = str(int(time.time()) + random.randint)
+
+    timestamp_2 = str(int(time.time()) + random.randint)
+
+    vpc_1 = client.vpcs.create(
+        "pythonsdk-" + timestamp,
+        get_region(get_client, {"VPCs"}),
+        description="test description",
+    )
+
+    vpc_2 = client.vpcs.create(
+        "pythonsdk-" + timestamp_2,
+        get_region(get_client, {"VPCs"}),
+        description="test description",
+    )
+
+    yield vpc_1, vpc_2
+
+    vpc_1.delete()
+
+    vpc_1.delete()

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -296,7 +296,7 @@ def create_vpc_with_subnet_and_linode(get_client, create_vpc_with_subnet):
 def create_vpc(get_client):
     client = get_client
 
-    timestamp = str(int(time.time()))
+    timestamp = int(time.time_ns() % 10**10)
 
     vpc = client.vpcs.create(
         "pythonsdk-" + timestamp,
@@ -312,9 +312,9 @@ def create_vpc(get_client):
 def create_multiple_vpcs(get_client):
     client = get_client
 
-    timestamp = str(int(time.time()) + random.randint)
+    timestamp = int(time.time_ns() % 10**10)
 
-    timestamp_2 = str(int(time.time()) + random.randint)
+    timestamp_2 = int(time.time_ns() % 10**10)
 
     vpc_1 = client.vpcs.create(
         "pythonsdk-" + timestamp,

--- a/test/integration/models/test_linode.py
+++ b/test/integration/models/test_linode.py
@@ -584,7 +584,9 @@ class TestNetworkInterface:
             pub_interface.id,
         ]
 
-    def test_delete_interface_containing_vpc(self, create_vpc_with_subnet_and_linode):
+    def test_delete_interface_containing_vpc(
+        self, create_vpc_with_subnet_and_linode
+    ):
         vpc, subnet, linode, _ = create_vpc_with_subnet_and_linode
 
         config: Config = linode.configs[0]

--- a/test/integration/models/test_linode.py
+++ b/test/integration/models/test_linode.py
@@ -583,3 +583,22 @@ class TestNetworkInterface:
             vlan_interface.id,
             pub_interface.id,
         ]
+
+    def test_delete_interface_containing_vpc(self, create_vpc_with_subnet_and_linode):
+        vpc, subnet, linode, _ = create_vpc_with_subnet_and_linode
+
+        config: Config = linode.configs[0]
+
+        config.interfaces = []
+        config.save()
+
+        interface = config.interface_create_vpc(
+            subnet=subnet,
+            primary=True,
+            ip_ranges=["10.0.0.8/32"],
+        )
+
+        result = interface.delete()
+
+        # returns true when delete successful
+        assert result

--- a/test/integration/models/test_vpc.py
+++ b/test/integration/models/test_vpc.py
@@ -1,12 +1,10 @@
-import pytest
-
-from linode_api4 import VPC, LinodeClient, VPCSubnet
-from linode_api4.objects import Volume
+from linode_api4 import VPC, VPCSubnet, ApiError
+from test.integration.conftest import get_region
 
 
 def test_get_vpc(get_client, create_vpc):
     vpc = get_client.load(VPC, create_vpc.id)
-
+    get_client.vpc()
     assert vpc.id == create_vpc.id
 
 
@@ -42,3 +40,55 @@ def test_update_subnet(get_client, create_vpc_with_subnet):
     subnet = get_client.load(VPCSubnet, subnet.id, vpc.id)
 
     assert subnet.label == new_label
+
+
+def test_fails_create_vpc_invalid_data(get_client):
+    try:
+       get_client.vpcs.create(label="invalid_label!!", region=get_region(get_client, {"VPCs"}), description="test description")
+    except ApiError as e:
+        assert e.status == 400
+        assert 'Label must include only ASCII letters, numbers, and dashes' in str(e.json)
+
+
+def test_get_all_vpcs(get_client, create_multiple_vpcs):
+    vpc_1, vpc_2 = create_multiple_vpcs
+
+    all_vpcs = get_client.vpcs()
+
+    assert str(vpc_1) in str(all_vpcs.lists)
+    assert str(vpc_2) in str(all_vpcs.lists)
+
+
+def test_fails_update_vpc_invalid_data(create_vpc):
+    vpc = create_vpc
+
+    invalid_label = "invalid!!"
+
+    try:
+        vpc.label = invalid_label
+        vpc.save()
+    except ApiError as e:
+        assert e.status == 400
+        assert 'Label must include only ASCII letters, numbers, and dashes' in str(e.json)
+
+
+def test_fails_create_subnet_invalid_data(create_vpc):
+    invalid_ipv4 = "10.0.0.0"
+    try:
+        create_vpc.subnet_create("test-subnet", ipv4=invalid_ipv4)
+    except ApiError as e:
+        assert e.status == 400
+        assert 'ipv4 must be an IPv4 network with at least 8 addresses, but it had only 1' in str(e.json)
+
+
+def test_fails_update_subnet_invalid_data(create_vpc_with_subnet):
+    invalid_label = "invalid_subnet_label!!"
+    vpc, subnet = create_vpc_with_subnet
+    try:
+        subnet.label = invalid_label
+        subnet.save()
+    except ApiError as e:
+        assert e.status == 400
+        assert 'Label must include only ASCII letters, numbers, and dashes' in str(e.json)
+
+

--- a/test/integration/models/test_vpc.py
+++ b/test/integration/models/test_vpc.py
@@ -5,7 +5,7 @@ from linode_api4 import VPC, ApiError, VPCSubnet
 
 def test_get_vpc(get_client, create_vpc):
     vpc = get_client.load(VPC, create_vpc.id)
-    get_client.vpc()
+    get_client.vpcs()
     assert vpc.id == create_vpc.id
 
 
@@ -53,7 +53,7 @@ def test_fails_create_vpc_invalid_data(get_client):
     except ApiError as e:
         assert e.status == 400
         assert (
-            "Label must include only ASCII letters, numbers, and dashes"
+            "Label must include only ASCII"
             in str(e.json)
         )
 
@@ -78,7 +78,7 @@ def test_fails_update_vpc_invalid_data(create_vpc):
     except ApiError as e:
         assert e.status == 400
         assert (
-            "Label must include only ASCII letters, numbers, and dashes"
+            "Label must include only ASCII"
             in str(e.json)
         )
 
@@ -90,7 +90,7 @@ def test_fails_create_subnet_invalid_data(create_vpc):
     except ApiError as e:
         assert e.status == 400
         assert (
-            "ipv4 must be an IPv4 network with at least 8 addresses, but it had only 1"
+            "ipv4 must be an IPv4 network"
             in str(e.json)
         )
 
@@ -104,6 +104,6 @@ def test_fails_update_subnet_invalid_data(create_vpc_with_subnet):
     except ApiError as e:
         assert e.status == 400
         assert (
-            "Label must include only ASCII letters, numbers, and dashes"
+            "Label must include only ASCII"
             in str(e.json)
         )

--- a/test/integration/models/test_vpc.py
+++ b/test/integration/models/test_vpc.py
@@ -1,5 +1,6 @@
-from linode_api4 import VPC, VPCSubnet, ApiError
 from test.integration.conftest import get_region
+
+from linode_api4 import VPC, ApiError, VPCSubnet
 
 
 def test_get_vpc(get_client, create_vpc):
@@ -44,10 +45,17 @@ def test_update_subnet(get_client, create_vpc_with_subnet):
 
 def test_fails_create_vpc_invalid_data(get_client):
     try:
-       get_client.vpcs.create(label="invalid_label!!", region=get_region(get_client, {"VPCs"}), description="test description")
+        get_client.vpcs.create(
+            label="invalid_label!!",
+            region=get_region(get_client, {"VPCs"}),
+            description="test description",
+        )
     except ApiError as e:
         assert e.status == 400
-        assert 'Label must include only ASCII letters, numbers, and dashes' in str(e.json)
+        assert (
+            "Label must include only ASCII letters, numbers, and dashes"
+            in str(e.json)
+        )
 
 
 def test_get_all_vpcs(get_client, create_multiple_vpcs):
@@ -69,7 +77,10 @@ def test_fails_update_vpc_invalid_data(create_vpc):
         vpc.save()
     except ApiError as e:
         assert e.status == 400
-        assert 'Label must include only ASCII letters, numbers, and dashes' in str(e.json)
+        assert (
+            "Label must include only ASCII letters, numbers, and dashes"
+            in str(e.json)
+        )
 
 
 def test_fails_create_subnet_invalid_data(create_vpc):
@@ -78,7 +89,10 @@ def test_fails_create_subnet_invalid_data(create_vpc):
         create_vpc.subnet_create("test-subnet", ipv4=invalid_ipv4)
     except ApiError as e:
         assert e.status == 400
-        assert 'ipv4 must be an IPv4 network with at least 8 addresses, but it had only 1' in str(e.json)
+        assert (
+            "ipv4 must be an IPv4 network with at least 8 addresses, but it had only 1"
+            in str(e.json)
+        )
 
 
 def test_fails_update_subnet_invalid_data(create_vpc_with_subnet):
@@ -89,6 +103,7 @@ def test_fails_update_subnet_invalid_data(create_vpc_with_subnet):
         subnet.save()
     except ApiError as e:
         assert e.status == 400
-        assert 'Label must include only ASCII letters, numbers, and dashes' in str(e.json)
-
-
+        assert (
+            "Label must include only ASCII letters, numbers, and dashes"
+            in str(e.json)
+        )

--- a/test/integration/models/test_vpc.py
+++ b/test/integration/models/test_vpc.py
@@ -52,10 +52,7 @@ def test_fails_create_vpc_invalid_data(get_client):
         )
     except ApiError as e:
         assert e.status == 400
-        assert (
-            "Label must include only ASCII"
-            in str(e.json)
-        )
+        assert "Label must include only ASCII" in str(e.json)
 
 
 def test_get_all_vpcs(get_client, create_multiple_vpcs):
@@ -77,10 +74,7 @@ def test_fails_update_vpc_invalid_data(create_vpc):
         vpc.save()
     except ApiError as e:
         assert e.status == 400
-        assert (
-            "Label must include only ASCII"
-            in str(e.json)
-        )
+        assert "Label must include only ASCII" in str(e.json)
 
 
 def test_fails_create_subnet_invalid_data(create_vpc):
@@ -89,10 +83,7 @@ def test_fails_create_subnet_invalid_data(create_vpc):
         create_vpc.subnet_create("test-subnet", ipv4=invalid_ipv4)
     except ApiError as e:
         assert e.status == 400
-        assert (
-            "ipv4 must be an IPv4 network"
-            in str(e.json)
-        )
+        assert "ipv4 must be an IPv4 network" in str(e.json)
 
 
 def test_fails_update_subnet_invalid_data(create_vpc_with_subnet):
@@ -103,7 +94,4 @@ def test_fails_update_subnet_invalid_data(create_vpc_with_subnet):
         subnet.save()
     except ApiError as e:
         assert e.status == 400
-        assert (
-            "Label must include only ASCII"
-            in str(e.json)
-        )
+        assert "Label must include only ASCII" in str(e.json)


### PR DESCRIPTION
## 📝 Description

- Extending test coverage for VPC 

## ✔️ How to Test

1. Setup API token for alpha/beta environment and export it LINODE_TOKEN=mytoken

2. get cacert.pem (e.g. wget https://certurl.com/cacert.pem)

3. make slight modification to `def get_client()` in conftest.py
e.g. `client = LinodeClient(token, base_url='https://api.dev.linode.com/v4beta', ca_path='/Users/ykim/linode/ykim/linode_api4-python/cacert.pem')`

4. run test `pytest test/integration/models/test_vpc.py`


## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**