### PR TITLE
Remove deprecated `pkg_resources`; Drop Python 3.7 Support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7','3.8','3.9','3.10','3.11']
+        python-version: ['3.8','3.9','3.10','3.11']
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/linode_api4/linode_client.py
+++ b/linode_api4/linode_client.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import json
 import logging
+from importlib.metadata import version
 from typing import BinaryIO, Tuple
 from urllib import parse
 
-import pkg_resources
 import requests
 from requests.adapters import HTTPAdapter, Retry
 
@@ -36,7 +36,7 @@ from .common import SSH_KEY_TYPES, load_and_validate_keys
 from .paginated_list import PaginatedList
 from .util import drop_null_keys
 
-package_version = pkg_resources.require("linode_api4")[0].version
+package_version = version("linode_api4")
 
 logger = logging.getLogger(__name__)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ line_length = 80
 
 [tool.black]
 line-length = 80
-target-version = ["py37", "py38", "py39", "py310", "py311"]
+target-version = ["py37", "py38", "py39", "py310", "py311", "py312"]
 
 [tool.autoflake]
 expand-star-imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ line_length = 80
 
 [tool.black]
 line-length = 80
-target-version = ["py37", "py38", "py39", "py310", "py311", "py312"]
+target-version = ["py38", "py39", "py310", "py311", "py312"]
 
 [tool.autoflake]
 expand-star-imports = true

--- a/setup.py
+++ b/setup.py
@@ -103,11 +103,11 @@ setup(
         # that you indicate whether you support Python 2, Python 3 or both.
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
 
     # What does your project relate to?
@@ -118,7 +118,7 @@ setup(
     packages=find_packages(exclude=['contrib', 'docs', 'test', 'test.*']),
 
     # What do we need for this to run
-    python_requires=">=3.7",
+    python_requires=">=3.8",
 
     install_requires=[
         "requests",


### PR DESCRIPTION
## 📝 Description

`pkg_resources` has been removed in Python 3.12, which is the latest stable version of Python.


```
>>> import pkg_resources
<stdin>:1: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
>>> pkg_resources.require("requests")[0].version
'2.31.0'
>>> from importlib.metadata import version
>>> version("requests")
'2.31.0'
```