### PR TITLE
Consistent Python binary in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,47 +25,47 @@ build: clean
 
 @PHONEY: release
 release: build
-	twine upload dist/*
+	$(PYTHON) -m twine upload dist/*
 
 @PHONEY: install
 install: clean requirements
-	python3 -m pip install .
+	$(PYTHON) -m pip install .
 
 @PHONEY: requirements
 requirements:
-	pip install -r requirements.txt -r requirements-dev.txt
+	$(PYTHON) -m pip install -r requirements.txt -r requirements-dev.txt
 
 @PHONEY: black
 black:
-	black linode_api4 test
+	$(PYTHON) -m black linode_api4 test
 
 @PHONEY: isort
 isort:
-	isort linode_api4 test
+	$(PYTHON) -m isort linode_api4 test
 
 @PHONEY: autoflake
 autoflake:
-	autoflake linode_api4 test
+	$(PYTHON) -m autoflake linode_api4 test
 
 @PHONEY: format
 format: black isort autoflake
 
 @PHONEY: lint
 lint: build
-	isort --check-only linode_api4 test
-	autoflake --check linode_api4 test
-	black --check --verbose linode_api4 test
-	pylint linode_api4
-	twine check dist/*
+	$(PYTHON) -m isort --check-only linode_api4 test
+	$(PYTHON) -m autoflake --check linode_api4 test
+	$(PYTHON) -m black --check --verbose linode_api4 test
+	$(PYTHON) -m pylint linode_api4
+	$(PYTHON) -m twine check dist/*
 
 @PHONEY: testint
 testint:
-	python3 -m pytest test/integration/${INTEGRATION_TEST_PATH}${MODEL_COMMAND} ${TEST_CASE_COMMAND}
+	$(PYTHON) -m pytest test/integration/${INTEGRATION_TEST_PATH}${MODEL_COMMAND} ${TEST_CASE_COMMAND}
 
 @PHONEY: testunit
 testunit:
-	python3 -m python test/unit
+	$(PYTHON) -m pytest test/unit
 
 @PHONEY: smoketest
 smoketest:
-	pytest -m smoke test/integration --disable-warnings
+	$(PYTHON) -m pytest -m smoke test/integration --disable-warnings


### PR DESCRIPTION
## 📝 Description

This PR is to make all commands from Python packages to be from a consistent binary of Python. For example, some environments, `pip install some_thing` and may be different than `python3 -m pip install some_thing` because `pip` may belong to a different Python version.

## ✔️ How to Test

You can randomly try any `Makefile` commands, e.g. `make lint`.
Note that there are some known issues in the tests which can cause some commands like `make smoketest` to fail. It's certainly unrelated with the changes done in this PR, and in order to ensure that, you can try the same command again against `dev` branch and compare the results.