### PR TITLE
fix: Handle `null` values in `JSONObject` fields

### DIFF
--- a/linode_api4/objects/serializable.py
+++ b/linode_api4/objects/serializable.py
@@ -25,6 +25,8 @@ class JSONObject:
         """
         Creates an instance of this class from a JSON dict.
         """
+        if json is None:
+            return
         obj = cls()
 
         type_hints = get_type_hints(cls)


### PR DESCRIPTION
## 📝 Description

**What does this PR do and why is this change necessary?**

Handle null values for `JSONObject` fields

## ✔️ How to Test

**What are the steps to reproduce the issue or verify the changes?**

`pytest test/integration/models/test_networking.py`
