### PR TITLE
Replace `get_client` with `test_linode_client`

### DIFF
--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -275,14 +275,14 @@ def test_oauth_client(test_linode_client):
 
 
 @pytest.fixture(scope="session")
-def create_vpc(get_client):
-    client = get_client
+def create_vpc(test_linode_client):
+    client = test_linode_client
 
     timestamp = str(int(time.time()))
 
     vpc = client.vpcs.create(
         "pythonsdk-" + timestamp,
-        get_region(get_client, {"VPCs"}),
+        get_region(test_linode_client, {"VPCs"}),
         description="test description",
     )
     yield vpc
@@ -291,7 +291,7 @@ def create_vpc(get_client):
 
 
 @pytest.fixture(scope="session")
-def create_vpc_with_subnet(get_client, create_vpc):
+def create_vpc_with_subnet(test_linode_client, create_vpc):
     subnet = create_vpc.subnet_create("test-subnet", ipv4="10.0.0.0/24")
 
     yield create_vpc, subnet
@@ -300,13 +300,15 @@ def create_vpc_with_subnet(get_client, create_vpc):
 
 
 @pytest.fixture(scope="session")
-def create_vpc_with_subnet_and_linode(get_client, create_vpc_with_subnet):
+def create_vpc_with_subnet_and_linode(
+    test_linode_client, create_vpc_with_subnet
+):
     vpc, subnet = create_vpc_with_subnet
 
     timestamp = str(int(time.time()))
     label = "TestSDK-" + timestamp
 
-    instance, password = get_client.linode.instance_create(
+    instance, password = test_linode_client.linode.instance_create(
         "g5-standard-4", vpc.region, image="linode/debian11", label=label
     )
 
@@ -316,14 +318,14 @@ def create_vpc_with_subnet_and_linode(get_client, create_vpc_with_subnet):
 
 
 @pytest.fixture(scope="session")
-def create_vpc(get_client):
-    client = get_client
+def create_vpc(test_linode_client):
+    client = test_linode_client
 
     timestamp = str(int(time.time_ns() % 10**10))
 
     vpc = client.vpcs.create(
         "pythonsdk-" + timestamp,
-        get_region(get_client, {"VPCs"}),
+        get_region(test_linode_client, {"VPCs"}),
         description="test description",
     )
     yield vpc
@@ -332,8 +334,8 @@ def create_vpc(get_client):
 
 
 @pytest.fixture(scope="session")
-def create_multiple_vpcs(get_client):
-    client = get_client
+def create_multiple_vpcs(test_linode_client):
+    client = test_linode_client
 
     timestamp = str(int(time.time_ns() % 10**10))
 
@@ -341,13 +343,13 @@ def create_multiple_vpcs(get_client):
 
     vpc_1 = client.vpcs.create(
         "pythonsdk-" + timestamp,
-        get_region(get_client, {"VPCs"}),
+        get_region(test_linode_client, {"VPCs"}),
         description="test description",
     )
 
     vpc_2 = client.vpcs.create(
         "pythonsdk-" + timestamp_2,
-        get_region(get_client, {"VPCs"}),
+        get_region(test_linode_client, {"VPCs"}),
         description="test description",
     )
 

--- a/test/integration/models/test_vpc.py
+++ b/test/integration/models/test_vpc.py
@@ -5,13 +5,13 @@ import pytest
 from linode_api4 import VPC, ApiError, VPCSubnet
 
 
-def test_get_vpc(get_client, create_vpc):
-    vpc = get_client.load(VPC, create_vpc.id)
-    get_client.vpcs()
+def test_get_vpc(test_linode_client, create_vpc):
+    vpc = test_linode_client.load(VPC, create_vpc.id)
+    test_linode_client.vpcs()
     assert vpc.id == create_vpc.id
 
 
-def test_update_vpc(get_client, create_vpc):
+def test_update_vpc(test_linode_client, create_vpc):
     vpc = create_vpc
     new_label = create_vpc.label + "-updated"
     new_desc = "updated description"
@@ -20,46 +20,46 @@ def test_update_vpc(get_client, create_vpc):
     vpc.description = new_desc
     vpc.save()
 
-    vpc = get_client.load(VPC, create_vpc.id)
+    vpc = test_linode_client.load(VPC, create_vpc.id)
 
     assert vpc.label == new_label
     assert vpc.description == new_desc
 
 
-def test_get_subnet(get_client, create_vpc_with_subnet):
+def test_get_subnet(test_linode_client, create_vpc_with_subnet):
     vpc, subnet = create_vpc_with_subnet
-    loaded_subnet = get_client.load(VPCSubnet, subnet.id, vpc.id)
+    loaded_subnet = test_linode_client.load(VPCSubnet, subnet.id, vpc.id)
 
     assert loaded_subnet.id == subnet.id
 
 
-def test_update_subnet(get_client, create_vpc_with_subnet):
+def test_update_subnet(test_linode_client, create_vpc_with_subnet):
     vpc, subnet = create_vpc_with_subnet
     new_label = subnet.label + "-updated"
 
     subnet.label = new_label
     subnet.save()
 
-    subnet = get_client.load(VPCSubnet, subnet.id, vpc.id)
+    subnet = test_linode_client.load(VPCSubnet, subnet.id, vpc.id)
 
     assert subnet.label == new_label
 
 
-def test_fails_create_vpc_invalid_data(get_client):
+def test_fails_create_vpc_invalid_data(test_linode_client):
     with pytest.raises(ApiError) as excinfo:
-        get_client.vpcs.create(
+        test_linode_client.vpcs.create(
             label="invalid_label!!",
-            region=get_region(get_client, {"VPCs"}),
+            region=get_region(test_linode_client, {"VPCs"}),
             description="test description",
         )
     assert excinfo.value.status == 400
     assert "Label must include only ASCII" in str(excinfo.value.json)
 
 
-def test_get_all_vpcs(get_client, create_multiple_vpcs):
+def test_get_all_vpcs(test_linode_client, create_multiple_vpcs):
     vpc_1, vpc_2 = create_multiple_vpcs
 
-    all_vpcs = get_client.vpcs()
+    all_vpcs = test_linode_client.vpcs()
 
     assert str(vpc_1) in str(all_vpcs.lists)
     assert str(vpc_2) in str(all_vpcs.lists)


### PR DESCRIPTION
## 📝 Description

Test fixture `get_client` has been changed to `test_linode_client` in dev branch. This is to change it for VPC tests.

## ✔️ How to Test

`pytest test/integration/models/test_vpc.py`

GHA run: https://github.com/linode/linode_api4-python/actions/runs/6789530531