### PR TITLE
new: Support `AccountAvailability`

### DIFF
--- a/linode_api4/groups/account.py
+++ b/linode_api4/groups/account.py
@@ -4,6 +4,7 @@ from linode_api4.errors import UnexpectedResponseError
 from linode_api4.groups import Group
 from linode_api4.objects import (
     Account,
+    AccountAvailability,
     AccountBetaProgram,
     AccountSettings,
     BetaProgram,
@@ -483,3 +484,15 @@ class AccountGroup(Group):
         )
 
         return True
+
+    def availabilities(self, *filters):
+        """
+        Returns a list of all available regions and the resources which are NOT available
+        to the account.
+
+        API doc: TBD
+
+        :returns: a list of region availability information.
+        :rtype: PaginatedList of AccountAvailability
+        """
+        return self.client._get_and_filter(AccountAvailability, *filters)

--- a/linode_api4/objects/account.py
+++ b/linode_api4/objects/account.py
@@ -654,3 +654,16 @@ class AccountBetaProgram(Base):
         "ended": Property(is_datetime=True),
         "enrolled": Property(is_datetime=True),
     }
+
+
+class AccountAvailability(Base):
+    """
+    The resources information in a region which are NOT available to an account.
+    """
+
+    api_endpoint = "/account/availability/{id}"
+
+    properties = {
+        "id": Property(identifier=True),
+        "unavailable": Property(),
+    }

--- a/test/fixtures/account_availability.json
+++ b/test/fixtures/account_availability.json
@@ -1,0 +1,16 @@
+{
+  "data":
+  [
+     {
+      "id": "us-east",
+       "unavailable": ["Linodes"]
+     },
+     {
+      "id": "im-adethisup",
+       "unavailable": ["Linodes", "Block Storage"]
+     }
+  ],
+  "page": 1,
+  "pages": 1,
+  "results": 2
+}

--- a/test/fixtures/account_availability_us-east.json
+++ b/test/fixtures/account_availability_us-east.json
@@ -1,0 +1,4 @@
+{
+  "id": "us-east",
+  "unavailable": ["Linodes"]
+}

--- a/test/unit/linode_client_test.py
+++ b/test/unit/linode_client_test.py
@@ -492,6 +492,18 @@ class AccountGroupTest(ClientBaseCase):
         self.assertEqual(transfer.region_transfers[0].quota, 5010)
         self.assertEqual(transfer.region_transfers[0].billable, 0)
 
+    def test_account_availabilities(self):
+        """
+        Tests that account availabilities can be retrieved
+        """
+        availabilities = self.client.account.availabilities()
+
+        self.assertEqual(len(availabilities), 2)
+        availability = availabilities[0]
+
+        self.assertEqual(availability.id, "us-east")
+        self.assertEqual(availability.unavailable, ["Linodes"])
+
 
 class BetaProgramGroupTest(ClientBaseCase):
     """

--- a/test/unit/objects/account_test.py
+++ b/test/unit/objects/account_test.py
@@ -3,6 +3,7 @@ from test.unit.base import ClientBaseCase
 
 from linode_api4.objects import (
     Account,
+    AccountAvailability,
     AccountBetaProgram,
     AccountSettings,
     Database,
@@ -260,3 +261,20 @@ class AccountBetaProgramTest(ClientBaseCase):
             self.assertEqual(beta.ended, datetime(2018, 1, 2, 3, 4, 5))
 
             self.assertEqual(m.call_url, account_beta_url)
+
+
+class AccountAvailabilityTest(ClientBaseCase):
+    """
+    Test methods of the AccountAvailability
+    """
+
+    def test_account_availability_api_get(self):
+        region_id = "us-east"
+        account_availability_url = "/account/availability/{}".format(region_id)
+
+        with self.mock_get(account_availability_url) as m:
+            availability = AccountAvailability(self.client, region_id)
+            self.assertEqual(availability.id, region_id)
+            self.assertEqual(availability.unavailable, ["Linodes"])
+
+            self.assertEqual(m.call_url, account_availability_url)


### PR DESCRIPTION
## 📝 Description

Normally, a customer can use any resource they want in an available region. However, when the region has limited capacity, some certain resources may not be available to all customers. `AccountAvailability` returns resources which are NOT available in a region to an account specifically. Customer can also call `account.availabilities()` to check the full list of availability information.

## ✔️ How to Test

Run unit tests: `tox`

Integration tests will be implemented once API in alpha is available.
