### PR TITLE
test: add release info to xml file before uploading to obj storage

### DIFF
--- a/.github/workflows/e2e-test-pr.yml
+++ b/.github/workflows/e2e-test-pr.yml
@@ -91,14 +91,11 @@ jobs:
         env:
           LINODE_TOKEN: ${{ secrets.LINODE_TOKEN }}
 
-      - name: Set release version env
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-
       - name: Add additional information to XML report
         run: |
           filename=$(ls | grep -E '^[0-9]{12}_sdk_test_report\.xml$') 
           python test/script/add_to_xml_test_report.py \
-          --branch_name "${{ env.RELEASE_VERSION }}" \
+          --branch_name "${GITHUB_REF#refs/*/}" \
           --gha_run_id "$GITHUB_RUN_ID" \
           --gha_run_number "$GITHUB_RUN_NUMBER" \
           --xmlfile "${filename}"

--- a/test/script/add_to_xml_test_report.py
+++ b/test/script/add_to_xml_test_report.py
@@ -1,16 +1,39 @@
 import argparse
 import xml.etree.ElementTree as ET
+import requests
+
+latest_release_url = "https://api.github.com/repos/linode/linode-cli/releases/latest"
+
+
+def get_release_version():
+    url = latest_release_url
+
+    try:
+        response = requests.get(url)
+        response.raise_for_status()  # Check for HTTP errors
+
+        release_info = response.json()
+        version = release_info["tag_name"]
+
+        # Remove 'v' prefix if it exists
+        if version.startswith("v"):
+            version = version[1:]
+
+        return str(version)
+
+    except requests.exceptions.RequestException as e:
+        print("Error:", e)
+    except KeyError:
+        print("Error: Unable to fetch release information from GitHub API.")
+
 
 # Parse command-line arguments
-parser = argparse.ArgumentParser(
-    description="Modify XML with workflow information"
-)
-parser.add_argument("--branch_name", required=True)
-parser.add_argument("--gha_run_id", required=True)
-parser.add_argument("--gha_run_number", required=True)
-parser.add_argument(
-    "--xmlfile", required=True
-)  # Added argument for XML file path
+parser = argparse.ArgumentParser(description='Modify XML with workflow information')
+parser.add_argument('--branch_name', required=True)
+parser.add_argument('--gha_run_id', required=True)
+parser.add_argument('--gha_run_number', required=True)
+parser.add_argument('--release_tag', required=False)
+parser.add_argument('--xmlfile', required=True)  # Added argument for XML file path
 
 args = parser.parse_args()
 
@@ -20,22 +43,26 @@ tree = ET.parse(xml_file_path)
 root = tree.getroot()
 
 # Create new elements for the information
-branch_name_element = ET.Element("branch_name")
+branch_name_element = ET.Element('branch_name')
 branch_name_element.text = args.branch_name
 
-gha_run_id_element = ET.Element("gha_run_id")
+gha_run_id_element = ET.Element('gha_run_id')
 gha_run_id_element.text = args.gha_run_id
 
-gha_run_number_element = ET.Element("gha_run_number")
+gha_run_number_element = ET.Element('gha_run_number')
 gha_run_number_element.text = args.gha_run_number
+
+gha_release_tag_element = ET.Element('release_tag')
+gha_release_tag_element.text = get_release_version()
 
 # Add the new elements to the root of the XML
 root.append(branch_name_element)
 root.append(gha_run_id_element)
 root.append(gha_run_number_element)
+root.append(gha_release_tag_element)
 
 # Save the modified XML
 modified_xml_file_path = xml_file_path  # Overwrite it
 tree.write(modified_xml_file_path)
 
-print(f"Modified XML saved to {modified_xml_file_path}")
+print(f'Modified XML saved to {modified_xml_file_path}')

--- a/test/script/add_to_xml_test_report.py
+++ b/test/script/add_to_xml_test_report.py
@@ -2,7 +2,7 @@ import argparse
 import xml.etree.ElementTree as ET
 import requests
 
-latest_release_url = "https://api.github.com/repos/linode/linode-cli/releases/latest"
+latest_release_url = "https://api.github.com/repos/linode/linode_api4-python/releases/latest"
 
 
 def get_release_version():

--- a/test/script/add_to_xml_test_report.py
+++ b/test/script/add_to_xml_test_report.py
@@ -1,8 +1,11 @@
 import argparse
 import xml.etree.ElementTree as ET
+
 import requests
 
-latest_release_url = "https://api.github.com/repos/linode/linode_api4-python/releases/latest"
+latest_release_url = (
+    "https://api.github.com/repos/linode/linode_api4-python/releases/latest"
+)
 
 
 def get_release_version():
@@ -28,12 +31,16 @@ def get_release_version():
 
 
 # Parse command-line arguments
-parser = argparse.ArgumentParser(description='Modify XML with workflow information')
-parser.add_argument('--branch_name', required=True)
-parser.add_argument('--gha_run_id', required=True)
-parser.add_argument('--gha_run_number', required=True)
-parser.add_argument('--release_tag', required=False)
-parser.add_argument('--xmlfile', required=True)  # Added argument for XML file path
+parser = argparse.ArgumentParser(
+    description="Modify XML with workflow information"
+)
+parser.add_argument("--branch_name", required=True)
+parser.add_argument("--gha_run_id", required=True)
+parser.add_argument("--gha_run_number", required=True)
+parser.add_argument("--release_tag", required=False)
+parser.add_argument(
+    "--xmlfile", required=True
+)  # Added argument for XML file path
 
 args = parser.parse_args()
 
@@ -43,16 +50,16 @@ tree = ET.parse(xml_file_path)
 root = tree.getroot()
 
 # Create new elements for the information
-branch_name_element = ET.Element('branch_name')
+branch_name_element = ET.Element("branch_name")
 branch_name_element.text = args.branch_name
 
-gha_run_id_element = ET.Element('gha_run_id')
+gha_run_id_element = ET.Element("gha_run_id")
 gha_run_id_element.text = args.gha_run_id
 
-gha_run_number_element = ET.Element('gha_run_number')
+gha_run_number_element = ET.Element("gha_run_number")
 gha_run_number_element.text = args.gha_run_number
 
-gha_release_tag_element = ET.Element('release_tag')
+gha_release_tag_element = ET.Element("release_tag")
 gha_release_tag_element.text = get_release_version()
 
 # Add the new elements to the root of the XML
@@ -65,4 +72,4 @@ root.append(gha_release_tag_element)
 modified_xml_file_path = xml_file_path  # Overwrite it
 tree.write(modified_xml_file_path)
 
-print(f'Modified XML saved to {modified_xml_file_path}')
+print(f"Modified XML saved to {modified_xml_file_path}")


### PR DESCRIPTION
## 📝 Description

Problem: For some context, the script that is used to upload test report from OBJ storage to TOD is currently calling GitHub API endpoints from ECP Test VM to get the release info for corresponding repository. However recently there has been a rate limiting issue that is causing an error calling endpoint from that particular VM. E.g.
Error: 403 Client Error: rate limit exceeded for url: https://api.github.com/repos/linode/terraform-provider-linode/releases/latest linode-terraform None

Fix: Use existing add_to_xml_report.py script to add the release information to the xml report before uploading it to Object Storage so we don't have to rely on calling any endpoints from the Test VM

## ✔️ How to Test

Monitor TOD after merged to dev

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**