### PR TITLE
test: update legacy regions with new compute regions

### DIFF
--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -54,7 +54,7 @@ def run_long_tests():
 def create_linode(test_linode_client):
     client = test_linode_client
     available_regions = client.regions()
-    chosen_region = available_regions[0]
+    chosen_region = available_regions[4]
     timestamp = str(time.time_ns())
     label = "TestSDK-" + timestamp
 
@@ -71,7 +71,7 @@ def create_linode(test_linode_client):
 def create_linode_for_pass_reset(test_linode_client):
     client = test_linode_client
     available_regions = client.regions()
-    chosen_region = available_regions[0]
+    chosen_region = available_regions[4]
     timestamp = str(time.time_ns())
     label = "TestSDK-" + timestamp
 

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -155,7 +155,7 @@ def test_domain(test_linode_client):
 def test_volume(test_linode_client):
     client = test_linode_client
     timestamp = str(time.time_ns())
-    region = client.regions()[0]
+    region = client.regions()[4]
     label = "TestSDK-" + timestamp
 
     volume = client.volume_create(label=label, region=region)

--- a/test/integration/linode_client/test_linode_client.py
+++ b/test/integration/linode_client/test_linode_client.py
@@ -12,7 +12,7 @@ from linode_api4.objects import ObjectStorageKeys
 def setup_client_and_linode(test_linode_client):
     client = test_linode_client
     available_regions = client.regions()
-    chosen_region = available_regions[0]
+    chosen_region = available_regions[4]  # us-ord (Chicago)
     label = get_test_label()
 
     linode_instance, password = client.linode.instance_create(
@@ -32,9 +32,6 @@ def test_get_account(setup_client_and_linode):
     assert re.search("^$|[a-zA-Z]+", account.last_name)
     assert re.search(
         "^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$", account.email
-    )
-    assert re.search(
-        "^(\+\d{1,2}\s)?\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}$", account.phone
     )
     assert re.search("^$|[a-zA-Z0-9]+", account.address_1)
     assert re.search("^$|[a-zA-Z0-9]+", account.address_2)
@@ -212,7 +209,7 @@ def test_get_account_settings(test_linode_client):
 def test_create_linode_instance_without_image(test_linode_client):
     client = test_linode_client
     available_regions = client.regions()
-    chosen_region = available_regions[0]
+    chosen_region = available_regions[4]
     label = get_test_label()
 
     linode_instance = client.linode.instance_create(
@@ -297,7 +294,7 @@ def test_fails_to_create_cluster_with_invalid_version(test_linode_client):
 
     try:
         cluster = client.lke.cluster_create(
-            "ap-west",
+            "us-ord",
             "example-cluster",
             {"type": "g6-standard-1", "count": 3},
             invalid_version,

--- a/test/integration/models/test_account.py
+++ b/test/integration/models/test_account.py
@@ -64,7 +64,7 @@ def test_latest_get_event(test_linode_client):
     client = test_linode_client
 
     available_regions = client.regions()
-    chosen_region = available_regions[0]
+    chosen_region = available_regions[4]
     label = get_test_label()
 
     linode, password = client.linode.instance_create(

--- a/test/integration/models/test_database.py
+++ b/test/integration/models/test_database.py
@@ -40,7 +40,7 @@ def test_create_sql_db(test_linode_client):
     )
     client = test_linode_client
     label = get_test_label() + "-sqldb"
-    region = "us-east"
+    region = "us-ord"
     engine_id = get_db_engine_id(client, "mysql")
     dbtype = "g6-standard-1"
 
@@ -70,7 +70,7 @@ def test_create_postgres_db(test_linode_client):
     )
     client = test_linode_client
     label = get_test_label() + "-postgresqldb"
-    region = "us-east"
+    region = "us-ord"
     engine_id = get_db_engine_id(client, "postgresql")
     dbtype = "g6-standard-1"
 

--- a/test/integration/models/test_firewall.py
+++ b/test/integration/models/test_firewall.py
@@ -9,7 +9,7 @@ from linode_api4.objects import Firewall, FirewallDevice
 def linode_fw(test_linode_client):
     client = test_linode_client
     available_regions = client.regions()
-    chosen_region = available_regions[0]
+    chosen_region = available_regions[4]
     label = "linode_instance_fw_device"
 
     linode_instance, password = client.linode.instance_create(

--- a/test/integration/models/test_image.py
+++ b/test/integration/models/test_image.py
@@ -42,7 +42,7 @@ def test_image_create_upload(test_linode_client):
     label = get_test_label() + "_image"
     image = test_linode_client.image_upload(
         label,
-        "us-east",
+        "us-ord",
         BytesIO(test_image_content),
         description="integration test image upload",
     )

--- a/test/integration/models/test_linode.py
+++ b/test/integration/models/test_linode.py
@@ -24,7 +24,7 @@ from linode_api4.objects import (
 def linode_with_volume_firewall(test_linode_client):
     client = test_linode_client
     available_regions = client.regions()
-    chosen_region = available_regions[0]
+    chosen_region = available_regions[4]
     label = get_test_label()
 
     rules = {
@@ -70,7 +70,7 @@ def linode_with_volume_firewall(test_linode_client):
 def linode_for_network_interface_tests(test_linode_client):
     client = test_linode_client
     available_regions = client.regions()
-    chosen_region = available_regions[0]
+    chosen_region = available_regions[4]
     timestamp = str(time.time_ns())
     label = "TestSDK-" + timestamp
 
@@ -87,7 +87,7 @@ def linode_for_network_interface_tests(test_linode_client):
 def linode_for_disk_tests(test_linode_client):
     client = test_linode_client
     available_regions = client.regions()
-    chosen_region = available_regions[0]
+    chosen_region = available_regions[4]
     label = get_test_label()
 
     linode_instance, password = client.linode.instance_create(
@@ -118,7 +118,7 @@ def linode_for_disk_tests(test_linode_client):
 def create_linode_for_long_running_tests(test_linode_client):
     client = test_linode_client
     available_regions = client.regions()
-    chosen_region = available_regions[0]
+    chosen_region = available_regions[4]
     label = get_test_label()
 
     linode_instance, password = client.linode.instance_create(
@@ -158,7 +158,7 @@ def test_linode_transfer(test_linode_client, linode_with_volume_firewall):
 def test_linode_rebuild(test_linode_client):
     client = test_linode_client
     available_regions = client.regions()
-    chosen_region = available_regions[0]
+    chosen_region = available_regions[4]
     label = get_test_label() + "_rebuild"
 
     linode, password = client.linode.instance_create(
@@ -208,7 +208,7 @@ def test_update_linode(create_linode):
 def test_delete_linode(test_linode_client):
     client = test_linode_client
     available_regions = client.regions()
-    chosen_region = available_regions[0]
+    chosen_region = available_regions[4]
     label = get_test_label()
 
     linode_instance, password = client.linode.instance_create(
@@ -413,7 +413,7 @@ def test_linode_ips(create_linode):
 def test_linode_initate_migration(test_linode_client):
     client = test_linode_client
     available_regions = client.regions()
-    chosen_region = available_regions[0]
+    chosen_region = available_regions[4]
     label = get_test_label() + "_migration"
 
     linode, password = client.linode.instance_create(
@@ -424,7 +424,7 @@ def test_linode_initate_migration(test_linode_client):
     # Says it could take up to ~6 hrs for migration to fully complete
 
     send_request_when_resource_available(
-        300, linode.initiate_migration, "us-central"
+        300, linode.initiate_migration, "us-mia"
     )
 
     res = linode.delete()

--- a/test/integration/models/test_networking.py
+++ b/test/integration/models/test_networking.py
@@ -20,7 +20,7 @@ def test_get_networking_rules(test_linode_client, test_firewall):
 def create_linode(test_linode_client):
     client = test_linode_client
     available_regions = client.regions()
-    chosen_region = available_regions[0]
+    chosen_region = available_regions[4]
     label = get_rand_nanosec_test_label()
 
     linode_instance, _ = client.linode.instance_create(

--- a/test/integration/models/test_nodebalancer.py
+++ b/test/integration/models/test_nodebalancer.py
@@ -10,7 +10,7 @@ from linode_api4.objects import NodeBalancerConfig, NodeBalancerNode
 def linode_with_private_ip(test_linode_client):
     client = test_linode_client
     available_regions = client.regions()
-    chosen_region = available_regions[0]
+    chosen_region = available_regions[4]
     label = "linode_with_privateip"
 
     linode_instance, password = client.linode.instance_create(
@@ -30,7 +30,7 @@ def linode_with_private_ip(test_linode_client):
 def create_nb_config(test_linode_client):
     client = test_linode_client
     available_regions = client.regions()
-    chosen_region = available_regions[0]
+    chosen_region = available_regions[4]
     label = "nodebalancer_test"
 
     nb = client.nodebalancer_create(region=chosen_region, label=label)

--- a/test/integration/models/test_volume.py
+++ b/test/integration/models/test_volume.py
@@ -16,7 +16,7 @@ from linode_api4.objects import Volume
 def linode_for_volume(test_linode_client):
     client = test_linode_client
     available_regions = client.regions()
-    chosen_region = available_regions[0]
+    chosen_region = available_regions[4]
     timestamp = str(time.time_ns())
     label = "TestSDK-" + timestamp
 


### PR DESCRIPTION
## 📝 Description

Regions have been updated:
Legacy Compute sites are in Atlanta, Dallas, Frankfurt, Fremont, London, Mumbai, Newark, Singapore, Sydney, Tokyo, and Toronto

New Core Compute sites are in Amsterdam, Chennai, Chicago, Jakarta, Los Angeles, Madrid (coming soon!), Miami, Milan, Osaka, Paris, São Paulo, Seattle, Stockholm, and Washington, DC (and the list will continue to grow).

All integration test runs provision infrastructure only in New Core Compute sites (not Legacy Compute sites). For this repository, replacing all legacy regions with Chicago and Miami region

## ✔️ How to Test

make test

Build - https://github.com/linode/linode_api4-python/actions/runs/7133527217/job/19426412926


## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**