### PR TITLE
fix: Resolve issue that prevented LKENodePools from being loaded with LinodeClient.load(...)

### DIFF
--- a/linode_api4/objects/lke.py
+++ b/linode_api4/objects/lke.py
@@ -81,9 +81,11 @@ class LKENodePool(DerivedBase):
         """
         Parse Nodes into more useful LKENodePoolNode objects
         """
-        if json != {}:
+        if json is not None and json != {}:
             new_nodes = [
-                LKENodePoolNode(self._client, c) for c in json["nodes"]
+                LKENodePoolNode(self._client, c)
+                if not isinstance(c, dict) else c
+                for c in json["nodes"]
             ]
             json["nodes"] = new_nodes
 

--- a/linode_api4/objects/lke.py
+++ b/linode_api4/objects/lke.py
@@ -84,7 +84,8 @@ class LKENodePool(DerivedBase):
         if json is not None and json != {}:
             new_nodes = [
                 LKENodePoolNode(self._client, c)
-                if not isinstance(c, dict) else c
+                if not isinstance(c, dict)
+                else c
                 for c in json["nodes"]
             ]
             json["nodes"] = new_nodes

--- a/test/unit/objects/lke_test.py
+++ b/test/unit/objects/lke_test.py
@@ -132,3 +132,17 @@ class LKETest(ClientBaseCase):
         with self.mock_delete() as m:
             cluster.service_token_delete()
             self.assertEqual(m.call_url, "/lke/clusters/18881/servicetoken")
+
+    def test_load_node_pool(self):
+        """
+        Tests that an LKE Node Pool can be retrieved using LinodeClient.load(...)
+        """
+        pool = self.client.load(LKENodePool, 456, 18881)
+
+        self.assertEqual(pool.id, 456)
+        self.assertEqual(pool.cluster_id, 18881)
+        self.assertEqual(pool.type.id, "g6-standard-4")
+        self.assertIsNotNone(pool.disks)
+        self.assertIsNotNone(pool.nodes)
+        self.assertIsNotNone(pool.autoscaler)
+        self.assertIsNotNone(pool.tags)


### PR DESCRIPTION
## 📝 Description

This change resolves an issue that prevented LKENodePool objects from being loaded using the `LinodeClient.load(...)` method. Attempting to do so would previously raise the following error:

```
TypeError: 'NoneType' object is not subscriptable
```

## ✔️ How to Test

Running Unit Tests:

```
make testunit
```

Manual Testing:

1. In Cloud Manager, create an LKE cluster with one node pool of one node.
2. In a linode_api4-python sandbox environment (e.g. dx-devenv) run the following script, replacing the values for CLUSTER_ID and POOL_ID with the appropriate IDs for the newly created cluster:

```python
import os
from linode_api4 import LinodeClient, LKENodePool

CLUSTER_ID = 0
POOL_ID = 0

client = LinodeClient(os.getenv("LINODE_TOKEN"))
print(
    *[v.__dict__ for v in client.load(LKENodePool, POOL_ID, CLUSTER_ID).nodes]
)
```

3. Observe no error being raised.
