### PR TITLE
fix: Resolve issue loading Type using `LinodeClient.load(...)`

### DIFF
--- a/linode_api4/objects/linode.py
+++ b/linode_api4/objects/linode.py
@@ -256,9 +256,10 @@ class Type(Base):
         """
         Allows changing the name "class" in JSON to "type_class" in python
         """
+
         super()._populate(json)
 
-        if "class" in json:
+        if json is not None and "class" in json:
             setattr(self, "type_class", json["class"])
         else:
             setattr(self, "type_class", None)

--- a/test/fixtures/linode_types_g6-nanode-1.json
+++ b/test/fixtures/linode_types_g6-nanode-1.json
@@ -1,0 +1,48 @@
+{
+  "disk": 20480,
+  "memory": 1024,
+  "transfer": 1000,
+  "addons": {
+    "backups": {
+      "price": {
+        "hourly": 0.003,
+        "monthly": 2
+      },
+      "region_prices": [
+        {
+          "id": "ap-west",
+          "hourly": 0.02,
+          "monthly": 20
+        },
+        {
+          "id": "ap-northeast",
+          "hourly": 0.02,
+          "monthly": 20
+        }
+      ]
+    }
+  },
+  "class": "nanode",
+  "network_out": 1000,
+  "vcpus": 1,
+  "gpus": 0,
+  "id": "g5-nanode-1",
+  "label": "Linode 1024",
+  "price": {
+    "hourly": 0.0075,
+    "monthly": 5
+  },
+  "region_prices": [
+    {
+      "id": "us-east",
+      "hourly": 0.02,
+      "monthly": 20
+    },
+    {
+      "id": "ap-northeast",
+      "hourly": 0.02,
+      "monthly": 20
+    }
+  ],
+  "successor": null
+}

--- a/test/unit/objects/linode_test.py
+++ b/test/unit/objects/linode_test.py
@@ -580,6 +580,15 @@ class TypeTest(ClientBaseCase):
         self.assertEqual(t.gpus, 1)
         self.assertEqual(t._populated, True)
 
+    def test_load_type(self):
+        """
+        Tests that a type can be loaded using LinodeClient.load(...)
+        """
+
+        t = self.client.load(Type, "g6-nanode-1")
+        self.assertEqual(t._populated, True)
+        self.assertEqual(t.type_class, "nanode")
+
     def test_save_noforce(self):
         """
         Tests that a client will only save if changes are detected


### PR DESCRIPTION
## 📝 Description

This change addresses an issue that caused the following error when attempting to load a Linode Type using `LinodeClient.load(...)`:

```
TypeError: argument of type 'NoneType' is not iterable
```

Similar change: #359 

## ✔️ How to Test

The following test steps assume you have pulled this PR locally.

### Running Unit Tests

```
make testunit
```

### Manual Testing

1. In a linode_api4-python sandbox environment (e.g. dx-devenv), run the following script:

```python 
import os
from linode_api4 import LinodeClient, Type

client = LinodeClient(os.getenv("LINODE_TOKEN"))
print(client.load(Type, "g6-standard-2"))
```

2. Observe the type is printed to stdout and no error is raised.
