### PR TITLE
fix: Make NodeBalancer.tags mutable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ build: clean create-version
 
 .PHONY: create-version
 create-version:
-	@echo -e "${VERSION_MODULE_DOCSTRING}__version__ = \"${LINODE_SDK_VERSION}\"" > $(VERSION_FILE)
+	@printf "${VERSION_MODULE_DOCSTRING}__version__ = \"${LINODE_SDK_VERSION}\"\n" > $(VERSION_FILE)
 
 .PHONY: release
 release: build

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ build: clean create-version
 
 .PHONY: create-version
 create-version:
-	@echo "${VERSION_MODULE_DOCSTRING}__version__ = \"${LINODE_SDK_VERSION}\"" > $(VERSION_FILE)
+	@echo -e "${VERSION_MODULE_DOCSTRING}__version__ = \"${LINODE_SDK_VERSION}\"" > $(VERSION_FILE)
 
 .PHONY: release
 release: build

--- a/linode_api4/objects/nodebalancer.py
+++ b/linode_api4/objects/nodebalancer.py
@@ -217,7 +217,7 @@ class NodeBalancer(Base):
         "region": Property(slug_relationship=Region),
         "configs": Property(derived_class=NodeBalancerConfig),
         "transfer": Property(),
-        "tags": Property(),
+        "tags": Property(mutable=True),
     }
 
     # create derived objects

--- a/linode_api4/objects/volume.py
+++ b/linode_api4/objects/volume.py
@@ -53,7 +53,9 @@ class Volume(Base):
                 "config": (
                     None
                     if not config
-                    else config.id if issubclass(type(config), Base) else config
+                    else config.id
+                    if issubclass(type(config), Base)
+                    else config
                 ),
             },
         )

--- a/linode_api4/objects/volume.py
+++ b/linode_api4/objects/volume.py
@@ -53,9 +53,7 @@ class Volume(Base):
                 "config": (
                     None
                     if not config
-                    else config.id
-                    if issubclass(type(config), Base)
-                    else config
+                    else config.id if issubclass(type(config), Base) else config
                 ),
             },
         )

--- a/test/fixtures/nodebalancers_123456.json
+++ b/test/fixtures/nodebalancers_123456.json
@@ -1,0 +1,14 @@
+{
+  "created": "2018-01-01T00:01:01",
+  "ipv6": "c001:d00d:b01::1:abcd:1234",
+  "region": "us-east-1a",
+  "ipv4": "12.34.56.789",
+  "hostname": "nb-12-34-56-789.newark.nodebalancer.linode.com",
+  "id": 123456,
+  "updated": "2018-01-01T00:01:01",
+  "label": "balancer123456",
+  "client_conn_throttle": 0,
+  "tags": [
+    "something"
+  ]
+}

--- a/test/unit/objects/nodebalancers_test.py
+++ b/test/unit/objects/nodebalancers_test.py
@@ -132,6 +132,41 @@ class NodeBalancerNodeTest(ClientBaseCase):
                 m.call_url, "/nodebalancers/123456/configs/65432/nodes/54321"
             )
 
+
+class NodeBalancerTest(ClientBaseCase):
+    def test_update(self):
+        """
+        Test that you can update a NodeBalancer.
+        """
+        nb = NodeBalancer(self.client, 123456)
+        nb.label = "updated-label"
+        nb.client_conn_throttle = 7
+        nb.tags = ["foo", "bar"]
+
+        with self.mock_put("nodebalancers/123456") as m:
+            nb.save()
+            self.assertEqual(m.call_url, "/nodebalancers/123456")
+            self.assertEqual(
+                m.call_data,
+                {
+                    "label": "updated-label",
+                    "client_conn_throttle": 7,
+                    "tags": ["foo", "bar"],
+                },
+            )
+
+    def test_firewalls(self):
+        """
+        Test that you can get the firewalls for the requested NodeBalancer.
+        """
+        nb = NodeBalancer(self.client, 12345)
+        firewalls_url = "/nodebalancers/12345/firewalls"
+
+        with self.mock_get(firewalls_url) as m:
+            result = nb.firewalls()
+            self.assertEqual(m.call_url, firewalls_url)
+            self.assertEqual(len(result), 1)
+
     def test_config_rebuild(self):
         """
         Test that you can rebuild the cofig of a node balancer.
@@ -193,15 +228,3 @@ class NodeBalancerNodeTest(ClientBaseCase):
                 "linode.com - balancer12345 (12345) - day (5 min avg)",
             )
             self.assertEqual(m.call_url, statistics_url)
-
-    def test_firewalls(self):
-        """
-        Test that you can get the firewalls for the requested NodeBalancer.
-        """
-        nb = NodeBalancer(self.client, 12345)
-        firewalls_url = "/nodebalancers/12345/firewalls"
-
-        with self.mock_get(firewalls_url) as m:
-            result = nb.firewalls()
-            self.assertEqual(m.call_url, firewalls_url)
-            self.assertEqual(len(result), 1)


### PR DESCRIPTION
## 📝 Description

This change makes the `NodeBalancer.tags` attribute mutable to match the PUT /nodebalancers/{id} endpoint documentation.

Additionally, this change alters the `create-version` Makefile target to address minor differences between how the echo command handles escape characters on different systems.

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally.

### Unit Testing

```bash
make testunit
```

### Manual Testing

1. In a Python SDK sandbox environment (e.g. dx-devenv), run the following:

```python
import os

from linode_api4 import LinodeClient

client = LinodeClient(token=os.getenv("LINODE_TOKEN"))

nb = client.nodebalancers.create(
    "us-mia",
    label="test-nb",
    tags=["cool"]
)

print("Original tags:", nb.tags)

nb.tags = ["foo", "bar"]
nb.label = "test-nb-updated"
nb.save()

nb.invalidate()

print("Updated & refreshed tags:", nb.tags)
```

2. Ensure the output matches the following:

```bash
Original tags: ['cool']
Updated & refreshed tags: ['bar', 'foo']
```

3. Navigate to the newly created NodeBalancer in Cloud Manager and ensure it has the tags `bar` and `foo`.
