### PR TITLE
new: Allow defining interfaces on Instance creation

### DIFF
--- a/linode_api4/groups/linode.py
+++ b/linode_api4/groups/linode.py
@@ -307,13 +307,10 @@ class LinodeGroup(Group):
             kwargs["firewall_id"] = fw.id if isinstance(fw, Firewall) else fw
 
         if "interfaces" in kwargs:
-            interfaces = kwargs.pop("interfaces")
-            param_interfaces = []
-            for interface in interfaces:
-                if isinstance(interface, ConfigInterface):
-                    interface = interface._serialize()
-                param_interfaces.append(interface)
-            kwargs["interfaces"] = param_interfaces
+            kwargs["interfaces"] = [
+                i._serialize() if isinstance(i, ConfigInterface) else i
+                for i in kwargs["interfaces"]
+            ]
 
         params = {
             "type": ltype.id if issubclass(type(ltype), Base) else ltype,

--- a/linode_api4/groups/linode.py
+++ b/linode_api4/groups/linode.py
@@ -265,6 +265,9 @@ class LinodeGroup(Group):
         :type metadata: dict
         :param firewall: The firewall to attach this Linode to.
         :type firewall: int or Firewall
+        :param interfaces: An array of Network Interfaces to add to this Linode’s Configuration Profile.
+                           At least one and up to three Interface objects can exist in this array.
+        :type interfaces: list[ConfigInterface] or list[dict[str, Any]]
 
         :returns: A new Instance object, or a tuple containing the new Instance and
                   the generated password.
@@ -302,6 +305,15 @@ class LinodeGroup(Group):
         if "firewall" in kwargs:
             fw = kwargs.pop("firewall")
             kwargs["firewall_id"] = fw.id if isinstance(fw, Firewall) else fw
+
+        if "interfaces" in kwargs:
+            interfaces = kwargs.pop("interfaces")
+            param_interfaces = []
+            for interface in interfaces:
+                if isinstance(interface, ConfigInterface):
+                    interface = interface._serialize()
+                param_interfaces.append(interface)
+            kwargs["interfaces"] = param_interfaces
 
         params = {
             "type": ltype.id if issubclass(type(ltype), Base) else ltype,

--- a/test/integration/linode_client/test_linode_client.py
+++ b/test/integration/linode_client/test_linode_client.py
@@ -5,7 +5,7 @@ from test.integration.helpers import get_test_label
 import pytest
 
 from linode_api4 import ApiError, LinodeClient
-from linode_api4.objects import ObjectStorageKeys
+from linode_api4.objects import ConfigInterface, ObjectStorageKeys
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -229,6 +229,38 @@ def test_create_linode_instance_with_image(setup_client_and_linode):
     linode = setup_client_and_linode[1]
 
     assert re.search("linode/debian10", str(linode.image))
+
+
+def test_create_linode_with_interfaces(test_linode_client):
+    client = test_linode_client
+    available_regions = client.regions()
+    chosen_region = available_regions[4]
+    label = get_test_label()
+
+    linode_instance, password = client.linode.instance_create(
+        "g6-nanode-1",
+        chosen_region,
+        label=label,
+        image="linode/debian10",
+        interfaces=[
+            {"purpose": "public"},
+            ConfigInterface(
+                purpose="vlan", label="cool-vlan", ipam_address="10.0.0.4/32"
+            ),
+        ],
+    )
+
+    assert len(linode_instance.configs[0].interfaces) == 2
+    assert linode_instance.configs[0].interfaces[0].purpose == "public"
+    assert linode_instance.configs[0].interfaces[1].purpose == "vlan"
+    assert linode_instance.configs[0].interfaces[1].label == "cool-vlan"
+    assert (
+        linode_instance.configs[0].interfaces[1].ipam_address == "10.0.0.4/32"
+    )
+
+    res = linode_instance.delete()
+
+    assert res
 
 
 # LongviewGroupTests

--- a/test/unit/objects/linode_test.py
+++ b/test/unit/objects/linode_test.py
@@ -421,6 +421,35 @@ class LinodeTest(ClientBaseCase):
                 },
             )
 
+    def test_instance_create_with_interfaces(self):
+        """
+        Tests that user can pass a list of interfaces on Linode create.
+        """
+        interfaces = [
+            {"purpose": "public"},
+            ConfigInterface(
+                purpose="vlan", label="cool-vlan", ipam_address="10.0.0.4/32"
+            ),
+        ]
+        with self.mock_post("linode/instances/123") as m:
+            self.client.linode.instance_create(
+                "us-southeast",
+                "g6-nanode-1",
+                interfaces=interfaces,
+            )
+
+            self.assertEqual(
+                m.call_data["interfaces"],
+                [
+                    {"purpose": "public"},
+                    {
+                        "purpose": "vlan",
+                        "label": "cool-vlan",
+                        "ipam_address": "10.0.0.4/32",
+                    },
+                ],
+            )
+
     def test_build_instance_metadata(self):
         """
         Tests that the metadata field is built correctly.


### PR DESCRIPTION
## 📝 Description

We allow user to explicitly pass a list of interfaces as ConfigInterface class or a dict when creating a Linode instance.

Addressed issue #350 

## ✔️ How to Test

**Unit test:**
`tox`

**Integration test:**
`make TEST_CASE=test_create_linode_with_interfaces testint`

**Manual test**
1. In a sandbox environment, run the following code:
```
from linode_api4 import LinodeClient
from linode_api4.objects import ConfigInterface

    client = LinodeClient(os.getenv("LINODE_TOKEN"))
    
    linode_instance, password = client.linode.instance_create(
        "g6-nanode-1",
        "us-east",
        label="test-instance",
        image="linode/debian10",
        interfaces=[
            {"purpose": "public"},
            ConfigInterface(
                purpose="vlan", label="cool-vlan", ipam_address="10.0.0.4/32"
            ),
        ],
    )
    
    print(linode_instance.configs[0].interfaces[0].purpose)
```
2. Observe the first interface's purpose is printed out correctly.