### PR TITLE
doc: Add .readthedocs.yaml config file 

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,10 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+sphinx:
+  configuration: docs/conf.py


### PR DESCRIPTION
## 📝 Description

This pull request adds a `.readthedocs.yaml` config file as described in the [readthedocs documentation](https://docs.readthedocs.io/en/stable/config-file/index.html). This should fix the failing documentation builds once merged 🙂 

## ✔️ How to Test

**N/A**
