### PR TITLE
doc: Add .readthedocs.yaml config file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,10 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+sphinx:
+  configuration: docs/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,3 +8,6 @@ build:
     python: "3.12"
 sphinx:
   configuration: docs/conf.py
+python:
+ install:
+   - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
 sphinxcontrib-fulltoc
+..

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
 sphinxcontrib-fulltoc
-..
+.


### PR DESCRIPTION
## 📝 Description

This pull request adds a `.readthedocs.yaml` config file as described in the [readthedocs documentation](https://docs.readthedocs.io/en/stable/config-file/index.html). This should fix the failing documentation builds once merged 🙂 

Rendered documentation: https://linode-api4--381.org.readthedocs.build/en/381/
Passing build: https://readthedocs.org/projects/linode-api4/builds/23742768/