### PR TITLE
doc: Add missing models and groups to documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@ sys.path.insert(0, os.path.abspath('..'))
 # -- Project information -----------------------------------------------------
 
 project = 'linode_api4'
-copyright = '2023, Linode'
+copyright = '2024, Linode'
 author = 'Linode'
 
 # The short X.Y version

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@ sys.path.insert(0, os.path.abspath('..'))
 # -- Project information -----------------------------------------------------
 
 project = 'linode_api4'
-copyright = '2024, Linode'
+copyright = '2024, Akamai Technologies Inc.'
 author = 'Linode'
 
 # The short X.Y version

--- a/docs/linode_api4/linode_client.rst
+++ b/docs/linode_api4/linode_client.rst
@@ -61,6 +61,15 @@ Includes methods for managing your account.
    :members:
    :special-members:
 
+BetaGroup
+^^^^^^^^^
+
+Includes methods for enrolling in beta programs.
+
+.. autoclass:: linode_api4.linode_client.BetaGroup
+   :members:
+   :special-members:
+
 DatabaseGroup
 ^^^^^^^^^^^^^
 
@@ -98,7 +107,7 @@ accessing and working with associated features.
    :members:
    :special-members:
 
-LKE Group
+LKEGroup
 ^^^^^^^^^
 
 Includes methods for interacting with Linode Kubernetes Engine.
@@ -197,5 +206,14 @@ VolumeGroup
 Includes methods for managing Linode Volumes.
 
 .. autoclass:: linode_api4.linode_client.VolumeGroup
+   :members:
+   :special-members:
+
+VPCGroup
+^^^^^^^^
+
+Includes methods for managing Linode VPCs.
+
+.. autoclass:: linode_api4.linode_client.VPCGroup
    :members:
    :special-members:

--- a/docs/linode_api4/objects/models.rst
+++ b/docs/linode_api4/objects/models.rst
@@ -14,6 +14,15 @@ Account Models
    :undoc-members:
    :inherited-members:
 
+Beta Models
+-----------
+
+.. automodule:: linode_api4.objects.beta
+   :members:
+   :exclude-members: api_endpoint, properties, derived_url_path, id_attribute, parent_id_name
+   :undoc-members:
+   :inherited-members:
+
 Database Models
 -------------
 
@@ -135,6 +144,15 @@ Volume Models
 -------------
 
 .. automodule:: linode_api4.objects.volume
+   :members:
+   :exclude-members: api_endpoint, properties, derived_url_path, id_attribute, parent_id_name
+   :undoc-members:
+   :inherited-members:
+
+VPC Models
+----------
+
+.. automodule:: linode_api4.objects.vpc
    :members:
    :exclude-members: api_endpoint, properties, derived_url_path, id_attribute, parent_id_name
    :undoc-members:


### PR DESCRIPTION
## 📝 Description

This change adds the following previously undocumented models and groups to this repo's Sphinx documentation.

This includes:
- Betas (model & group)
- VPCs (model & group)

Additionally, this change updates the copyright from `2023` to `2024` and from `Linode` to `Akamai Technologies Inc.`.

Build: https://readthedocs.org/projects/linode-api4/builds/23752391/
Preview: https://linode-api4--383.org.readthedocs.build/en/383/