### PR TITLE
new: Add support for the `/vpcs/ips` endpoint

### DIFF
--- a/linode_api4/groups/vpc.py
+++ b/linode_api4/groups/vpc.py
@@ -1,9 +1,8 @@
 from typing import Any, Dict, List, Optional, Union
 
-from linode_api4 import VPCSubnet
 from linode_api4.errors import UnexpectedResponseError
 from linode_api4.groups import Group
-from linode_api4.objects import VPC, Base, Region
+from linode_api4.objects import VPC, Region, VPCIPAddress
 from linode_api4.paginated_list import PaginatedList
 
 
@@ -81,3 +80,25 @@ class VPCGroup(Group):
 
         d = VPC(self.client, result["id"], result)
         return d
+
+    def ips(self, *filters) -> PaginatedList:
+        """
+        Retrieves all of the VPC IP addresses for the current account matching the given filters.
+
+        This is intended to be called from the :any:`LinodeClient`
+        class, like this::
+
+           vpc_ips = client.vpcs.ips()
+
+        API Documentation: TODO
+
+        :param filters: Any number of filters to apply to this query.
+                        See :doc:`Filtering Collections</linode_api4/objects/filtering>`
+                        for more details on filtering.
+
+        :returns: A list of VPCIPAddresses the acting user can access.
+        :rtype: PaginatedList of VPCIPAddress
+        """
+        return self.client._get_and_filter(
+            VPCIPAddress, *filters, endpoint="/vpcs/ips"
+        )

--- a/test/fixtures/vpcs_ips.json
+++ b/test/fixtures/vpcs_ips.json
@@ -1,0 +1,22 @@
+{
+  "data": [
+    {
+      "address": "10.0.0.2",
+      "address_range": null,
+      "vpc_id": 123,
+      "subnet_id": 456,
+      "region": "us-mia",
+      "linode_id": 123,
+      "config_id": 456,
+      "interface_id": 789,
+      "active": true,
+      "nat_1_1": "172.233.179.133",
+      "gateway": "10.0.0.1",
+      "prefix": 24,
+      "subnet_mask": "255.255.255.0"
+    }
+  ],
+  "page": 1,
+  "pages": 1,
+  "results": 1
+}

--- a/test/integration/models/test_linode.py
+++ b/test/integration/models/test_linode.py
@@ -8,6 +8,7 @@ from test.integration.helpers import (
 
 import pytest
 
+from linode_api4 import VPCIPAddress
 from linode_api4.errors import ApiError
 from linode_api4.objects import (
     Config,
@@ -595,6 +596,7 @@ class TestNetworkInterface:
 
     def test_create_vpc(
         self,
+        test_linode_client,
         linode_for_network_interface_tests,
         create_vpc_with_subnet_and_linode,
     ):
@@ -634,6 +636,12 @@ class TestNetworkInterface:
 
         assert vpc_range_ip.address_range == "10.0.0.5/32"
         assert not vpc_range_ip.active
+
+        # Attempt to resolve the IP from /vpcs/ips
+        all_vpc_ips = test_linode_client.vpcs.ips(
+            VPCIPAddress.filters.linode_id == linode.id
+        )
+        assert all_vpc_ips[0].dict == vpc_ip.dict
 
     def test_update_vpc(
         self,

--- a/test/unit/objects/vpc_test.py
+++ b/test/unit/objects/vpc_test.py
@@ -126,6 +126,32 @@ class VPCTest(ClientBaseCase):
 
             self.validate_vpc_subnet_789(subnet)
 
+    def test_list_ips(self):
+        """
+        Validates that all VPC IPs can be listed.
+        """
+
+        with self.mock_get("/vpcs/ips") as m:
+            result = self.client.vpcs.ips()
+
+        assert m.call_url == "/vpcs/ips"
+        assert len(result) == 1
+
+        ip = result[0]
+        assert ip.address == "10.0.0.2"
+        assert ip.address_range == None
+        assert ip.vpc_id == 123
+        assert ip.subnet_id == 456
+        assert ip.region == "us-mia"
+        assert ip.linode_id == 123
+        assert ip.config_id == 456
+        assert ip.interface_id == 789
+        assert ip.active
+        assert ip.nat_1_1 == "172.233.179.133"
+        assert ip.gateway == "10.0.0.1"
+        assert ip.prefix == 24
+        assert ip.subnet_mask == "255.255.255.0"
+
     def validate_vpc_123456(self, vpc: VPC):
         expected_dt = datetime.datetime.strptime(
             "2018-01-01T00:01:01", DATE_FORMAT


### PR DESCRIPTION
## 📝 Description

This change adds support for the `/vpcs/ips` endpoint through the `LinodeClient(...).vpcs.ips()` method.

## ✔️ How to Test

The following test steps assume you have pulled this code locally and run `make install`.

### Unit Testing

```
make testunit
```

### Integration Testing

```
make INTEGRATION_TEST_PATH=models/test_linode.py::TestNetworkInterface::test_create_vpc testint
```

### Manual Testing

1. In a linode_api4-python sandbox environment (e.g. dx-devenv), run the following:

```python
import os

from linode_api4 import LinodeClient, VPCIPAddress
from linode_api4.objects import ConfigInterface

client = LinodeClient(os.getenv("LINODE_TOKEN"))

vpc = client.vpcs.create(
    "test-vpc",
    "us-mia",
)

subnet = vpc.subnet_create(
    "test-subnet",
    ipv4="10.0.0.0/24"
)

inst, _ = client.linode.instance_create(
    "g6-nanode-1",
    "us-mia",
    label="test-instance",
    image="linode/alpine3.19",
    interfaces=[
        ConfigInterface(
            purpose="vpc",
            subnet_id=subnet.id,
        )
    ]
)

result = client.vpcs.ips(VPCIPAddress.filters.linode_id == inst.id)

print(*result)
```

2. Ensure the output contains the expected VPC IP addresses for the newly created instance.

