### PR TITLE
new: Annotate set/unordered fields as unordered

### DIFF
--- a/linode_api4/objects/account.py
+++ b/linode_api4/objects/account.py
@@ -43,7 +43,7 @@ class Account(Base):
         "zip": Property(mutable=True),
         "address_2": Property(mutable=True),
         "tax_id": Property(mutable=True),
-        "capabilities": Property(),
+        "capabilities": Property(unordered=True),
         "credit_card": Property(),
         "active_promotions": Property(),
         "active_since": Property(),
@@ -670,5 +670,5 @@ class AccountAvailability(Base):
 
     properties = {
         "region": Property(identifier=True),
-        "unavailable": Property(),
+        "unavailable": Property(unordered=True),
     }

--- a/linode_api4/objects/base.py
+++ b/linode_api4/objects/base.py
@@ -32,6 +32,7 @@ class Property:
         id_relationship=False,
         slug_relationship=False,
         nullable=False,
+        unordered=False,
         json_object=None,
     ):
         """
@@ -50,6 +51,10 @@ class Property:
             (This should be used on fields ending with '_id' only)
         slug_relationship - This property is a slug related for a given type.
         nullable - This property can be explicitly null on PUT requests.
+        unordered - The order of this property is not significant.
+                    NOTE: This field is currently only for annotations purposes
+                    and does not influence any update or decoding/encoding logic.
+        json_object - The JSONObject class this property should be decoded into.
         """
         self.mutable = mutable
         self.identifier = identifier
@@ -60,6 +65,7 @@ class Property:
         self.id_relationship = id_relationship
         self.slug_relationship = slug_relationship
         self.nullable = nullable
+        self.unordered = unordered
         self.json_class = json_object
 
 

--- a/linode_api4/objects/database.py
+++ b/linode_api4/objects/database.py
@@ -129,7 +129,7 @@ class MySQLDatabase(Base):
     properties = {
         "id": Property(identifier=True),
         "label": Property(mutable=True),
-        "allow_list": Property(mutable=True),
+        "allow_list": Property(mutable=True, unordered=True),
         "backups": Property(derived_class=MySQLDatabaseBackup),
         "cluster_size": Property(),
         "created": Property(is_datetime=True),
@@ -262,7 +262,7 @@ class PostgreSQLDatabase(Base):
     properties = {
         "id": Property(identifier=True),
         "label": Property(mutable=True),
-        "allow_list": Property(mutable=True),
+        "allow_list": Property(mutable=True, unordered=True),
         "backups": Property(derived_class=PostgreSQLDatabaseBackup),
         "cluster_size": Property(),
         "created": Property(is_datetime=True),
@@ -404,7 +404,7 @@ class Database(Base):
     properties = {
         "id": Property(),
         "label": Property(),
-        "allow_list": Property(),
+        "allow_list": Property(unordered=True),
         "cluster_size": Property(),
         "created": Property(),
         "encrypted": Property(),

--- a/linode_api4/objects/domain.py
+++ b/linode_api4/objects/domain.py
@@ -49,14 +49,14 @@ class Domain(Base):
         "status": Property(mutable=True),
         "soa_email": Property(mutable=True),
         "retry_sec": Property(mutable=True),
-        "master_ips": Property(mutable=True),
-        "axfr_ips": Property(mutable=True),
+        "master_ips": Property(mutable=True, unordered=True),
+        "axfr_ips": Property(mutable=True, unordered=True),
         "expire_sec": Property(mutable=True),
         "refresh_sec": Property(mutable=True),
         "ttl_sec": Property(mutable=True),
         "records": Property(derived_class=DomainRecord),
         "type": Property(mutable=True),
-        "tags": Property(mutable=True),
+        "tags": Property(mutable=True, unordered=True),
     }
 
     def record_create(self, record_type, **kwargs):

--- a/linode_api4/objects/image.py
+++ b/linode_api4/objects/image.py
@@ -25,5 +25,7 @@ class Image(Base):
         "vendor": Property(),
         "size": Property(),
         "deprecated": Property(),
-        "capabilities": Property(),
+        "capabilities": Property(
+            unordered=True,
+        ),
     }

--- a/linode_api4/objects/linode.py
+++ b/linode_api4/objects/linode.py
@@ -642,11 +642,11 @@ class Instance(Base):
         "configs": Property(derived_class=Config),
         "type": Property(slug_relationship=Type),
         "backups": Property(mutable=True),
-        "ipv4": Property(),
+        "ipv4": Property(unordered=True),
         "ipv6": Property(),
         "hypervisor": Property(),
         "specs": Property(),
-        "tags": Property(mutable=True),
+        "tags": Property(mutable=True, unordered=True),
         "host_uuid": Property(),
         "watchdog_enabled": Property(mutable=True),
         "has_user_data": Property(),
@@ -1745,7 +1745,9 @@ class StackScript(Base):
         "created": Property(is_datetime=True),
         "deployments_active": Property(),
         "script": Property(mutable=True),
-        "images": Property(mutable=True),  # TODO make slug_relationship
+        "images": Property(
+            mutable=True, unordered=True
+        ),  # TODO make slug_relationship
         "deployments_total": Property(),
         "description": Property(mutable=True),
         "updated": Property(is_datetime=True),

--- a/linode_api4/objects/lke.py
+++ b/linode_api4/objects/lke.py
@@ -74,7 +74,7 @@ class LKENodePool(DerivedBase):
             volatile=True
         ),  # this is formatted in _populate below
         "autoscaler": Property(mutable=True),
-        "tags": Property(mutable=True),
+        "tags": Property(mutable=True, unordered=True),
     }
 
     def _populate(self, json):
@@ -121,7 +121,7 @@ class LKECluster(Base):
         "id": Property(identifier=True),
         "created": Property(is_datetime=True),
         "label": Property(mutable=True),
-        "tags": Property(mutable=True),
+        "tags": Property(mutable=True, unordered=True),
         "updated": Property(is_datetime=True),
         "region": Property(slug_relationship=Region),
         "k8s_version": Property(slug_relationship=KubeVersion, mutable=True),

--- a/linode_api4/objects/networking.py
+++ b/linode_api4/objects/networking.py
@@ -34,7 +34,9 @@ class IPv6Range(Base):
         "region": Property(slug_relationship=Region),
         "prefix": Property(),
         "route_target": Property(),
-        "linodes": Property(),
+        "linodes": Property(
+            unordered=True,
+        ),
         "is_bgp": Property(),
     }
 
@@ -151,7 +153,7 @@ class VLAN(Base):
     properties = {
         "label": Property(identifier=True),
         "created": Property(is_datetime=True),
-        "linodes": Property(),
+        "linodes": Property(unordered=True),
         "region": Property(slug_relationship=Region),
     }
 
@@ -189,7 +191,7 @@ class Firewall(Base):
     properties = {
         "id": Property(identifier=True),
         "label": Property(mutable=True),
-        "tags": Property(mutable=True),
+        "tags": Property(mutable=True, unordered=True),
         "status": Property(mutable=True),
         "created": Property(is_datetime=True),
         "updated": Property(is_datetime=True),

--- a/linode_api4/objects/nodebalancer.py
+++ b/linode_api4/objects/nodebalancer.py
@@ -34,7 +34,7 @@ class NodeBalancerNode(DerivedBase):
         "weight": Property(mutable=True),
         "mode": Property(mutable=True),
         "status": Property(),
-        "tags": Property(mutable=True),
+        "tags": Property(mutable=True, unordered=True),
     }
 
     def __init__(self, client, id, parent_id, nodebalancer_id=None, json=None):
@@ -217,7 +217,7 @@ class NodeBalancer(Base):
         "region": Property(slug_relationship=Region),
         "configs": Property(derived_class=NodeBalancerConfig),
         "transfer": Property(),
-        "tags": Property(mutable=True),
+        "tags": Property(mutable=True, unordered=True),
     }
 
     # create derived objects

--- a/linode_api4/objects/region.py
+++ b/linode_api4/objects/region.py
@@ -18,7 +18,7 @@ class Region(Base):
     properties = {
         "id": Property(identifier=True),
         "country": Property(),
-        "capabilities": Property(),
+        "capabilities": Property(unordered=True),
         "status": Property(),
         "resolvers": Property(),
         "label": Property(),

--- a/linode_api4/objects/volume.py
+++ b/linode_api4/objects/volume.py
@@ -21,7 +21,7 @@ class Volume(Base):
         "size": Property(),
         "status": Property(),
         "region": Property(slug_relationship=Region),
-        "tags": Property(mutable=True),
+        "tags": Property(mutable=True, unordered=True),
         "filesystem_path": Property(),
         "hardware_type": Property(),
         "linode_label": Property(),

--- a/linode_api4/objects/vpc.py
+++ b/linode_api4/objects/vpc.py
@@ -33,7 +33,7 @@ class VPCSubnet(DerivedBase):
         "id": Property(identifier=True),
         "label": Property(mutable=True),
         "ipv4": Property(),
-        "linodes": Property(json_object=VPCSubnetLinode),
+        "linodes": Property(json_object=VPCSubnetLinode, unordered=True),
         "created": Property(is_datetime=True),
         "updated": Property(is_datetime=True),
     }


### PR DESCRIPTION
## 📝 Description

This change adds a new `unordered` property attribute and annotates unordered properties accordingly. 

**NOTE: This PR does not introduce any new encoding/decoding logic; these annotations are expected to be consumed by update logic in downstream projects (e.g. ansible_linode)**

I'm sure I missed some unordered properties so please let me know if you discover any 🙂 

## ✔️ How to Test

N/A