### PR TITLE
new: List ips under a specific VPC

### DIFF
--- a/linode_api4/objects/vpc.py
+++ b/linode_api4/objects/vpc.py
@@ -111,8 +111,8 @@ class VPC(Base):
         """
 
         # need to avoid circular import
-        from linode_api4.objects import (
-            VPCIPAddress,  # pylint: disable=import-outside-toplevel
+        from linode_api4.objects import (  # pylint: disable=import-outside-toplevel
+            VPCIPAddress,
         )
 
         return self._client._get_and_filter(

--- a/linode_api4/objects/vpc.py
+++ b/linode_api4/objects/vpc.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 from linode_api4.errors import UnexpectedResponseError
 from linode_api4.objects import Base, DerivedBase, Property, Region
 from linode_api4.objects.serializable import JSONObject
+from linode_api4.paginated_list import PaginatedList
 
 
 @dataclass
@@ -97,3 +98,23 @@ class VPC(Base):
 
         d = VPCSubnet(self._client, result["id"], self.id, result)
         return d
+
+    @property
+    def ips(self, *filters) -> PaginatedList:
+        """
+        Get all the IP addresses under this VPC.
+
+        API Documentation: TODO
+
+        :returns: A list of VPCIPAddresses the acting user can access.
+        :rtype: PaginatedList of VPCIPAddress
+        """
+
+        # need to avoid circular import
+        from linode_api4.objects import (
+            VPCIPAddress,  # pylint: disable=import-outside-toplevel
+        )
+
+        return self._client._get_and_filter(
+            VPCIPAddress, *filters, endpoint="/vpcs/{}/ips".format(self.id)
+        )

--- a/test/fixtures/vpcs_123456_ips.json
+++ b/test/fixtures/vpcs_123456_ips.json
@@ -1,0 +1,34 @@
+{
+    "data": [
+        {
+            "address": "10.0.0.2",
+            "address_range": null,
+            "vpc_id": 123456,
+            "subnet_id": 654321,
+            "region": "us-ord",
+            "linode_id": 111,
+            "config_id": 222,
+            "interface_id": 333,
+            "active": true,
+            "nat_1_1": null,
+            "gateway": "10.0.0.1",
+            "prefix": 8,
+            "subnet_mask": "255.0.0.0"
+        },
+        {
+            "address": "10.0.0.3",
+            "address_range": null,
+            "vpc_id": 41220,
+            "subnet_id": 41184,
+            "region": "us-ord",
+            "linode_id": 56323949,
+            "config_id": 59467106,
+            "interface_id": 1248358,
+            "active": true,
+            "nat_1_1": null,
+            "gateway": "10.0.0.1",
+            "prefix": 8,
+            "subnet_mask": "255.0.0.0"
+        }
+    ]
+}

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -317,22 +317,6 @@ def create_vpc_with_subnet_and_linode(
 
 
 @pytest.fixture(scope="session")
-def create_vpc(test_linode_client):
-    client = test_linode_client
-
-    timestamp = str(int(time.time_ns() % 10**10))
-
-    vpc = client.vpcs.create(
-        "pythonsdk-" + timestamp,
-        get_region(test_linode_client, {"VPCs"}),
-        description="test description",
-    )
-    yield vpc
-
-    vpc.delete()
-
-
-@pytest.fixture(scope="session")
 def create_multiple_vpcs(test_linode_client):
     client = test_linode_client
 

--- a/test/integration/models/test_linode.py
+++ b/test/integration/models/test_linode.py
@@ -15,9 +15,9 @@ from linode_api4.objects import (
     ConfigInterface,
     ConfigInterfaceIPv4,
     Disk,
-    Image,
     Instance,
     Type,
+    VPC,
 )
 from linode_api4.objects.linode import MigrationType
 
@@ -642,6 +642,14 @@ class TestNetworkInterface:
             VPCIPAddress.filters.linode_id == linode.id
         )
         assert all_vpc_ips[0].dict == vpc_ip.dict
+
+        # Test getting the ips under this specific VPC
+        vpc_ips = VPC(test_linode_client, vpc.id).ips
+
+        assert len(vpc_ips) > 0
+        assert vpc_ips[0].vpc_id == vpc.id
+        assert vpc_ips[0].linode_id == linode.id
+        assert vpc_ips[0].nat_1_1 == linode.ips.ipv4.public[0].address
 
     def test_update_vpc(
         self,

--- a/test/integration/models/test_linode.py
+++ b/test/integration/models/test_linode.py
@@ -17,7 +17,6 @@ from linode_api4.objects import (
     Disk,
     Instance,
     Type,
-    VPC,
 )
 from linode_api4.objects.linode import MigrationType
 
@@ -644,7 +643,7 @@ class TestNetworkInterface:
         assert all_vpc_ips[0].dict == vpc_ip.dict
 
         # Test getting the ips under this specific VPC
-        vpc_ips = VPC(test_linode_client, vpc.id).ips
+        vpc_ips = vpc.ips
 
         assert len(vpc_ips) > 0
         assert vpc_ips[0].vpc_id == vpc.id

--- a/test/unit/objects/vpc_test.py
+++ b/test/unit/objects/vpc_test.py
@@ -173,3 +173,28 @@ class VPCTest(ClientBaseCase):
         self.assertEqual(subnet.linodes[0].id, 12345)
         self.assertEqual(subnet.created, expected_dt)
         self.assertEqual(subnet.updated, expected_dt)
+
+    def test_list_vpc_ips(self):
+        """
+        Test that the ips under a specific VPC can be listed.
+        """
+        vpc = VPC(self.client, 123456)
+        vpc_ips = vpc.ips
+
+        self.assertGreater(len(vpc_ips), 0)
+
+        vpc_ip = vpc_ips[0]
+
+        self.assertEqual(vpc_ip.vpc_id, vpc.id)
+        self.assertEqual(vpc_ip.address, "10.0.0.2")
+        self.assertEqual(vpc_ip.address_range, None)
+        self.assertEqual(vpc_ip.subnet_id, 654321)
+        self.assertEqual(vpc_ip.region, "us-ord")
+        self.assertEqual(vpc_ip.linode_id, 111)
+        self.assertEqual(vpc_ip.config_id, 222)
+        self.assertEqual(vpc_ip.interface_id, 333)
+        self.assertEqual(vpc_ip.active, True)
+        self.assertEqual(vpc_ip.nat_1_1, None)
+        self.assertEqual(vpc_ip.gateway, "10.0.0.1")
+        self.assertEqual(vpc_ip.prefix, 8)
+        self.assertEqual(vpc_ip.subnet_mask, "255.0.0.0")


### PR DESCRIPTION
## 📝 Description

This change supports the endpoint `GET /vpcs/{vpc_id}/ips` to list the ips under a specific VPC.

## ✔️ How to Test

`tox`
`make TEST_CASE=test_create_vpc testint`

**Manual Test:**

1. In a sandbox environment, run the following script
```python
import os

from linode_api4 import LinodeClient
from linode_api4.objects import ConfigInterface

def main():
    client = LinodeClient(os.getenv("LINODE_TOKEN"))

    vpc = client.vpcs.create(
        "pythonsdk-test-vpc-123",
        "us-mia",
        description="test description",
    )
    
    subnet = vpc.subnet_create("test-subnet", ipv4="10.0.0.0/24")
    
    linode1, _ = client.linode.instance_create(
        "g6-nanode-1",
        "us-mia",
        label="test-vpc-instance-1",
        image="linode/alpine3.19",
        interfaces=[
            ConfigInterface(
                purpose="vpc",
                subnet_id=subnet.id,
            )
        ]
    )
    
    linode2, _ = client.linode.instance_create(
        "g6-nanode-1",
        "us-mia",
        label="test-vpc-instance-2",
        image="linode/alpine3.19",
        interfaces=[
            ConfigInterface(
                purpose="vpc",
                subnet_id=subnet.id,
            )
        ]
    )

    vpc_ips = vpc.ips

    assert len(vpc_ips) > 0
    assert vpc_ips[0].vpc_id == vpc.id
    assert vpc_ips[0].subnet_id == subnet.id
    
    print(*vpc_ips)
    
    linode1.delete()
    linode2.delete()
    subnet.delete()
    vpc.delete()


if __name__ == "__main__":
    main()
```
2. Observe the the list of ips under this VPC is printed and no error is raised. 