### PR TITLE
new: Add `available` field to AccountAvailability class

### DIFF
--- a/linode_api4/groups/account.py
+++ b/linode_api4/groups/account.py
@@ -487,10 +487,10 @@ class AccountGroup(Group):
 
     def availabilities(self, *filters):
         """
-        Returns a list of all available regions and the resources which are NOT available
+        Returns a list of all available regions and the resource types which are available
         to the account.
 
-        API doc: TBD
+        API doc: https://www.linode.com/docs/api/account/#region-service-availability
 
         :returns: a list of region availability information.
         :rtype: PaginatedList of AccountAvailability

--- a/linode_api4/objects/account.py
+++ b/linode_api4/objects/account.py
@@ -660,9 +660,10 @@ class AccountBetaProgram(Base):
 
 class AccountAvailability(Base):
     """
-    The resources information in a region which are NOT available to an account.
+    Contains information about the resources available for a region under the
+    current account.
 
-    API doc: TBD
+    API doc: https://www.linode.com/docs/api/account/#region-service-availability
     """
 
     api_endpoint = "/account/availability/{region}"

--- a/linode_api4/objects/account.py
+++ b/linode_api4/objects/account.py
@@ -671,4 +671,5 @@ class AccountAvailability(Base):
     properties = {
         "region": Property(identifier=True),
         "unavailable": Property(unordered=True),
+        "available": Property(unordered=True),
     }

--- a/test/fixtures/account_availability.json
+++ b/test/fixtures/account_availability.json
@@ -2,47 +2,58 @@
   "data": [
     {
       "region": "ap-west",
-      "unavailable": []
+      "unavailable": [],
+      "available": ["Linodes", "NodeBalancers"]
     },
     {
       "region": "ca-central",
-      "unavailable": []
+      "unavailable": [],
+      "available": ["Linodes", "NodeBalancers"]
     },
     {
       "region": "ap-southeast",
-      "unavailable": []
+      "unavailable": [],
+      "available": ["Linodes", "NodeBalancers"]
     },
     {
       "region": "us-central",
-      "unavailable": []
+      "unavailable": [],
+      "available": ["Linodes", "NodeBalancers"]
     },
     {
       "region": "us-west",
-      "unavailable": []
+      "unavailable": [],
+      "available": ["Linodes", "NodeBalancers"]
     },
     {
       "region": "us-southeast",
-      "unavailable": []
+      "unavailable": [],
+      "available": ["Linodes", "NodeBalancers"]
     },
     {
       "region": "us-east",
-      "unavailable": []
+      "unavailable": [],
+      "available": ["Linodes", "Kubernetes"]
     },
     {
       "region": "eu-west",
-      "unavailable": []
+      "unavailable": [],
+      "available": ["Linodes", "Cloud Firewall"]
     },
     {
       "region": "ap-south",
-      "unavailable": []
+      "unavailable": [],
+      "available": ["Linodes", "NodeBalancers"]
     },
     {
       "region": "eu-central",
-      "unavailable": []
+      "unavailable": [],
+      "available": ["Linodes", "NodeBalancers"]
     },
     {
       "region": "ap-northeast",
-      "unavailable": []
+      "unavailable": [],
+      "available": ["Linodes"]
     }
   ],
   "page": 1,

--- a/test/fixtures/account_availability_us-east.json
+++ b/test/fixtures/account_availability_us-east.json
@@ -1,4 +1,5 @@
 {
   "region": "us-east",
-  "unavailable": []
+  "unavailable": [],
+  "available": ["Linodes", "Kubernetes"]
 }

--- a/test/unit/objects/account_test.py
+++ b/test/unit/objects/account_test.py
@@ -268,6 +268,17 @@ class AccountAvailabilityTest(ClientBaseCase):
     Test methods of the AccountAvailability
     """
 
+    def test_account_availability_api_list(self):
+        with self.mock_get("/account/availability") as m:
+            availabilities = self.client.account.availabilities()
+
+            for avail in availabilities:
+                assert avail.region is not None
+                assert len(avail.unavailable) == 0
+                assert len(avail.available) > 0
+
+                self.assertEqual(m.call_url, "/account/availability")
+
     def test_account_availability_api_get(self):
         region_id = "us-east"
         account_availability_url = "/account/availability/{}".format(region_id)
@@ -276,5 +287,6 @@ class AccountAvailabilityTest(ClientBaseCase):
             availability = AccountAvailability(self.client, region_id)
             self.assertEqual(availability.region, region_id)
             self.assertEqual(availability.unavailable, [])
+            self.assertEqual(availability.available, ["Linodes", "Kubernetes"])
 
             self.assertEqual(m.call_url, account_availability_url)


### PR DESCRIPTION
## 📝 Description

This pull requests adds the new `available` field to the `AccountAvailability` class and adjusts the unit tests/fixtures accordingly.

## ✔️ How to Test

The following test steps assume you have pulled this PR locally and run `make install`.
### Unit Testing

```
make testunit
```

### Manual Testing

1. In a linode_api4 testing environment (e.g. dx-devenv), run the following:

```python
import argparse
import os

from linode_api4 import LinodeClient, Instance

client = LinodeClient(
    os.getenv("LINODE_TOKEN"),
    base_url="https://.../v4beta",
    ca_path="..."
)

for avail in client.account.availabilities():
    print(f"{avail.region} - {avail.available}")
```

**NOTE: Ensure the `base_url` kwarg is updated to point at the correct API environment.**

2. Ensure all regions and their corresponding availabilities are printed to the console with no errors.