### PR TITLE
Serialize `JSONObject` in `MappedObject`

### DIFF
--- a/linode_api4/objects/base.py
+++ b/linode_api4/objects/base.py
@@ -111,13 +111,15 @@ class MappedObject:
                 result[k] = [
                     (
                         item.dict
-                        if isinstance(item, cls)
+                        if isinstance(item, (cls, JSONObject))
                         else item._raw_json if isinstance(item, Base) else item
                     )
                     for item in v
                 ]
             elif isinstance(v, Base):
                 result[k] = v._raw_json
+            elif isinstance(v, JSONObject):
+                result[k] = v.dict
         return result
 
 

--- a/test/unit/objects/mapped_object_test.py
+++ b/test/unit/objects/mapped_object_test.py
@@ -1,6 +1,7 @@
+from dataclasses import dataclass
 from test.unit.base import ClientBaseCase
 
-from linode_api4.objects import Base, MappedObject, Property
+from linode_api4.objects import Base, JSONObject, MappedObject, Property
 
 
 class MappedObjectCase(ClientBaseCase):
@@ -20,7 +21,7 @@ class MappedObjectCase(ClientBaseCase):
         mapped_obj = MappedObject(**test_dict)
         self.assertEqual(mapped_obj.dict, test_dict)
 
-    def test_mapped_object_dict(self):
+    def test_base_objects_serialize(self):
         test_property_name = "bar"
         test_property_value = "bar"
 
@@ -33,6 +34,25 @@ class MappedObjectCase(ClientBaseCase):
 
         foo = Foo(self.client, test_property_value)
         foo._api_get()
+
+        expected_dict = {
+            "foo": {
+                test_property_name: test_property_value,
+            }
+        }
+
+        mapped_obj = MappedObject(foo=foo)
+        self.assertEqual(mapped_obj.dict, expected_dict)
+
+    def test_json_objects_serialize(self):
+        test_property_name = "bar"
+        test_property_value = "bar"
+
+        @dataclass
+        class Foo(JSONObject):
+            bar: str = ""
+
+        foo = Foo.from_json({test_property_name: test_property_value})
 
         expected_dict = {
             "foo": {

--- a/test/unit/objects/mapped_object_test.py
+++ b/test/unit/objects/mapped_object_test.py
@@ -21,7 +21,7 @@ class MappedObjectCase(ClientBaseCase):
         mapped_obj = MappedObject(**test_dict)
         self.assertEqual(mapped_obj.dict, test_dict)
 
-    def test_base_objects_serialize(self):
+    def test_serialize_base_objects(self):
         test_property_name = "bar"
         test_property_value = "bar"
 
@@ -44,7 +44,7 @@ class MappedObjectCase(ClientBaseCase):
         mapped_obj = MappedObject(foo=foo)
         self.assertEqual(mapped_obj.dict, expected_dict)
 
-    def test_json_objects_serialize(self):
+    def test_serialize_json_objects(self):
         test_property_name = "bar"
         test_property_value = "bar"
 


### PR DESCRIPTION
## 📝 Description

This is to fully serialize a `JSONObject` in `MappedObject`'s `dict` property.

## ✔️ How to Test

### Automated Testing

```bash
make testunit
```

### Manual Testing

```python
import os
from linode_api4 import LinodeClient


client = LinodeClient(os.getenv("LINODE_TOKEN"))

vpc = client.vpcs.create(
    "my-vpc",
    "us-mia",
    subnets=[{"label": "my-subnet", "ipv4": "10.0.0.0/24"}],
)

instance, _ = client.linode.instance_create(
    ltype="g6-nanode-1",
    region="us-mia",
    image="linode/ubuntu22.04",
    label="my-ubuntu-linode22",
    interfaces=[
        {
            "purpose": "vpc",
            "subnet_id": vpc.subnets[0].id,
        },
    ],
)

print(instance.ips.dict)

instance.delete()
vpc.delete()
```

Verify the `vpc` IP addresses list now contain valid dict, rather than a `JSONObject` object.