### PR TITLE
fix: Always load object values when converting MappedObjects to dict

### DIFF
--- a/linode_api4/objects/base.py
+++ b/linode_api4/objects/base.py
@@ -158,7 +158,10 @@ class Base(object, metaclass=FilterableMetaclass):
         #: be updated on access.
         self._set("_raw_json", None)
 
-        for k in type(self).properties:
+        for k, v in type(self).properties.items():
+            if v.identifier:
+                continue
+
             self._set(k, None)
 
         self._set("id", id)

--- a/linode_api4/objects/dbase.py
+++ b/linode_api4/objects/dbase.py
@@ -12,9 +12,10 @@ class DerivedBase(Base):
     parent_id_name = "parent_id"  # override in child classes
 
     def __init__(self, client, id, parent_id, json={}):
+        self._set(type(self).parent_id_name, parent_id)
+
         Base.__init__(self, client, id, json=json)
 
-        self._set(type(self).parent_id_name, parent_id)
 
     @classmethod
     def _api_get_derived(cls, parent, client):

--- a/linode_api4/objects/dbase.py
+++ b/linode_api4/objects/dbase.py
@@ -16,7 +16,6 @@ class DerivedBase(Base):
 
         Base.__init__(self, client, id, json=json)
 
-
     @classmethod
     def _api_get_derived(cls, parent, client):
         base_url = "{}/{}".format(

--- a/linode_api4/objects/object_storage.py
+++ b/linode_api4/objects/object_storage.py
@@ -31,10 +31,10 @@ class ObjectStorageBucket(DerivedBase):
     id_attribute = "label"
 
     properties = {
-        "cluster": Property(),
+        "cluster": Property(identifier=True),
         "created": Property(is_datetime=True),
         "hostname": Property(),
-        "label": Property(),
+        "label": Property(identifier=True),
         "objects": Property(),
         "size": Property(),
     }

--- a/test/unit/objects/linode_test.py
+++ b/test/unit/objects/linode_test.py
@@ -554,6 +554,14 @@ class ConfigTest(ClientBaseCase):
         self.assertEqual(ipv4.vpc, "10.0.0.1")
         self.assertEqual(ipv4.nat_1_1, "any")
 
+    def test_config_devices_unwrap(self):
+        """
+        Tests that config devices can be successfully converted to a dict.
+        """
+
+        config = Config(self.client, 456789, 123)
+        assert config.devices.dict.get("sda").get("id") == 12345
+
 
 class StackScriptTest(ClientBaseCase):
     """

--- a/test/unit/objects/linode_test.py
+++ b/test/unit/objects/linode_test.py
@@ -559,8 +559,8 @@ class ConfigTest(ClientBaseCase):
         Tests that config devices can be successfully converted to a dict.
         """
 
-        config = Config(self.client, 456789, 123)
-        assert config.devices.dict.get("sda").get("id") == 12345
+        inst = Instance(self.client, 123)
+        assert inst.configs[0].devices.dict.get("sda").get("id") == 12345
 
 
 class StackScriptTest(ClientBaseCase):


### PR DESCRIPTION
## 📝 Description

This change resolves an issue that would cause unloaded objects to be serialized as `None` when converting a MappedObject to a dict. This works by explicitly refreshing the object if it has not already been populated.

Additionally, this change fixes a small bug that prevented parent IDs from being accessed in `_populate(...)` overrides.

This has been cross-tested against the Ansible `instance_config_disk` test with some minor changes in Ansible and everything passes as expected.

Blocks https://github.com/linode/ansible_linode/pull/495

## ✔️ How to Test

### Unit Testing

```
make testunit
```

### Manual Testing

1. In a linode_api4 sandbox environment (e.g. dx-devenv), run the following:

```python
import os

from linode_api4 import LinodeClient, EventPoller

client = LinodeClient(os.getenv("LINODE_TOKEN"))

poller = EventPoller(
    client,
    entity_type="linode",
    action="linode_create",
)

inst = client.linode.instance_create(
    "g6-nanode-1",
    "us-mia",
    image="linode/alpine3.19",
    root_pass="c00lr00tp4ssw0rd!!!!!1!!!"
)

poller.set_entity_id(inst.id)
poller.wait_for_next_event_finished()

print(inst.configs[0].devices.dict["sda"])
```

2. Ensure the output looks similar to the following:

```
{'id': 113268590, 'status': 'ready', 'label': 'Alpine 3.19 Disk', 'created': '2024-04-18T17:11:55', 'updated': '2024-04-18T17:12:12', 'filesystem': 'ext4', 'size': 25088}
```

This confirms the devices have been explicitly refreshed during the dict conversion.

