### PR TITLE
CI: Fix cross testing workflow 

### DIFF
--- a/.github/workflows/release-cross-repo-test.yml
+++ b/.github/workflows/release-cross-repo-test.yml
@@ -26,9 +26,6 @@ jobs:
         with:
           python-version: '3.10'
 
-      - name: Install linode_api4
-        run: make install
-
       - name: checkout repo
         uses: actions/checkout@v3
         with:
@@ -47,6 +44,9 @@ jobs:
         run: |
           cd .ansible/collections/ansible_collections/linode/cloud
           make install
+
+      - name: Install linode_api4 # Need to install from source after all ansible dependencies have been installed
+        run: make install
 
       - name: replace existing keys
         run: |


### PR DESCRIPTION
## 📝 Description

Fixing workflow overwriting `linode_api4` package during release cross test execution

Now it will install from source after all the dependencies have been installed which ensures the correct package
```
Building wheels for collected packages: linode_api4
  Building wheel for linode_api4 (pyproject.toml): started
  Building wheel for linode_api4 (pyproject.toml): finished with status 'done'
  Created wheel for linode_api4: filename=linode_api4-0.0.0.dev0-py3-none-any.whl size=113483 sha256=9883fa937af6a7d7f228540a07bf1662f6d110217a8cee9b3287314dd57f600d
  Stored in directory: /home/runner/.cache/pip/wheels/20/25/97/5485f6bece5006342ece1cb8b8d39f553e681d57c67c8af6[38](https://github.com/ykim-1/linode_api4-python/actions/runs/8741991035/job/23989509246#step:10:39)
Successfully built linode_api4
Installing collected packages: linode_api4
  Attempting uninstall: linode_api4
    Found existing installation: linode_api4 5.15.0
```

tested on forked - https://github.com/ykim-1/linode_api4-python/actions/runs/8741991035/job/23989509246

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**