### PR TITLE
Add warnings to deprecated OBJ API usage

### DIFF
--- a/linode_api4/groups/obj.py
+++ b/linode_api4/groups/obj.py
@@ -1,3 +1,5 @@
+from deprecated import deprecated
+
 from linode_api4.errors import UnexpectedResponseError
 from linode_api4.groups import Group
 from linode_api4.objects import Base, ObjectStorageCluster, ObjectStorageKeys
@@ -9,8 +11,14 @@ class ObjectStorageGroup(Group):
     available clusters and managing keys.
     """
 
+    @deprecated(
+        reason="deprecated to use regions list API for listing available OJB clusters"
+    )
     def clusters(self, *filters):
         """
+        This endpoint will be deprecated to use the regions list API to list available OBJ clusters,
+        and a new access key API will directly expose the S3 endpoint hostname.
+
         Returns a list of available Object Storage Clusters.  You may filter
         this query to return only Clusters that are available in a specific region::
 

--- a/linode_api4/groups/object_storage.py
+++ b/linode_api4/groups/object_storage.py
@@ -1,5 +1,7 @@
 from urllib import parse
 
+from deprecated import deprecated
+
 from linode_api4.errors import UnexpectedResponseError
 from linode_api4.groups import Group
 from linode_api4.objects import (
@@ -19,8 +21,14 @@ class ObjectStorageGroup(Group):
     available clusters, buckets, and managing keys and TLS/SSL certs, etc.
     """
 
+    @deprecated(
+        reason="deprecated to use regions list API for listing available OJB clusters"
+    )
     def clusters(self, *filters):
         """
+        This endpoint will be deprecated to use the regions list API to list available OBJ clusters,
+        and a new access key API will directly expose the S3 endpoint hostname.
+
         Returns a list of available Object Storage Clusters.  You may filter
         this query to return only Clusters that are available in a specific region::
 

--- a/linode_api4/objects/object_storage.py
+++ b/linode_api4/objects/object_storage.py
@@ -1,5 +1,7 @@
 from urllib import parse
 
+from deprecated import deprecated
+
 from linode_api4.errors import UnexpectedResponseError
 from linode_api4.objects import (
     Base,
@@ -463,8 +465,14 @@ class ObjectStorageBucket(DerivedBase):
         }
 
 
+@deprecated(
+    reason="deprecated to use regions list API for viewing available OJB clusters"
+)
 class ObjectStorageCluster(Base):
     """
+    This class will be deprecated to use the regions list to view available OBJ clusters,
+    and a new access key API will directly expose the S3 endpoint hostname.
+
     A cluster where Object Storage is available.
 
     API documentation: https://www.linode.com/docs/api/object-storage/#cluster-view

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
-dependencies = ["requests", "polling"]
+dependencies = ["requests", "polling", "deprecated"]
 dynamic = ["version"]
 
 [project.optional-dependencies]
@@ -53,7 +53,6 @@ dev = [
     "sphinxcontrib-fulltoc>=1.2.0",
     "build>=0.10.0",
     "twine>=4.0.2",
-    "deprecated"
 ]
 
 doc = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dev = [
     "sphinxcontrib-fulltoc>=1.2.0",
     "build>=0.10.0",
     "twine>=4.0.2",
+    "deprecated"
 ]
 
 doc = [


### PR DESCRIPTION
## 📝 Description

Add warnings in docs and to related functions to deprecate two endpoints: cluster-view and cluster-list.