### PR TITLE
new: Add support for Linode Disk Encryption

### DIFF
--- a/linode_api4/groups/linode.py
+++ b/linode_api4/groups/linode.py
@@ -1,8 +1,9 @@
 import base64
 import os
 from collections.abc import Iterable
+from typing import Optional, Union
 
-from linode_api4 import Profile
+from linode_api4 import InstanceDiskEncryptionType, Profile
 from linode_api4.common import SSH_KEY_TYPES, load_and_validate_keys
 from linode_api4.errors import UnexpectedResponseError
 from linode_api4.groups import Group
@@ -131,7 +132,15 @@ class LinodeGroup(Group):
 
     # create things
     def instance_create(
-        self, ltype, region, image=None, authorized_keys=None, **kwargs
+        self,
+        ltype,
+        region,
+        image=None,
+        authorized_keys=None,
+        disk_encryption: Optional[
+            Union[InstanceDiskEncryptionType, str]
+        ] = None,
+        **kwargs,
     ):
         """
         Creates a new Linode Instance. This function has several modes of operation:
@@ -266,6 +275,8 @@ class LinodeGroup(Group):
         :type metadata: dict
         :param firewall: The firewall to attach this Linode to.
         :type firewall: int or Firewall
+        :param disk_encryption: The disk encryption policy for this Linode.
+        :type disk_encryption: InstanceDiskEncryptionType or str
         :param interfaces: An array of Network Interfaces to add to this Linode’s Configuration Profile.
                            At least one and up to three Interface objects can exist in this array.
         :type interfaces: list[ConfigInterface] or list[dict[str, Any]]
@@ -325,6 +336,9 @@ class LinodeGroup(Group):
             ),
             "authorized_keys": authorized_keys,
         }
+
+        if disk_encryption is not None:
+            params["disk_encryption"] = str(disk_encryption)
 
         params.update(kwargs)
 

--- a/linode_api4/objects/linode.py
+++ b/linode_api4/objects/linode.py
@@ -127,6 +127,7 @@ class Disk(DerivedBase):
         "filesystem": Property(),
         "updated": Property(is_datetime=True),
         "linode_id": Property(identifier=True),
+        "disk_encryption": Property(),
     }
 
     def duplicate(self):
@@ -664,6 +665,7 @@ class Instance(Base):
         "watchdog_enabled": Property(mutable=True),
         "has_user_data": Property(),
         "disk_encryption": Property(),
+        "lke_cluster_id": Property(),
     }
 
     @property

--- a/linode_api4/objects/linode.py
+++ b/linode_api4/objects/linode.py
@@ -1714,6 +1714,20 @@ class Instance(Base):
             "{}/stats".format(Instance.api_endpoint), model=self
         )
 
+    @property
+    def lke_cluster(self) -> Optional["LKECluster"]:
+        """
+        Returns the LKE Cluster this Instance is a node of.
+
+        :returns: The LKE Cluster this Instance is a node of.
+        :rtype: Optional[LKECluster]
+        """
+
+        # Local import to prevent circular dependency
+        from linode_api4.objects.lke import LKECluster
+
+        return LKECluster(self._client, self.lke_cluster_id)
+
     def stats_for(self, dt):
         """
         Returns stats for the month containing the given datetime

--- a/linode_api4/objects/linode.py
+++ b/linode_api4/objects/linode.py
@@ -1359,7 +1359,16 @@ class Instance(Base):
         i = IPAddress(self._client, result["address"], result)
         return i
 
-    def rebuild(self, image, root_pass=None, authorized_keys=None, **kwargs):
+    def rebuild(
+        self,
+        image,
+        root_pass=None,
+        authorized_keys=None,
+        disk_encryption: Optional[
+            Union[InstanceDiskEncryptionType, str]
+        ] = None,
+        **kwargs,
+    ):
         """
         Rebuilding an Instance deletes all existing Disks and Configs and deploys
         a new :any:`Image` to it.  This can be used to reset an existing
@@ -1377,6 +1386,8 @@ class Instance(Base):
                                 be a single key, or a path to a file containing
                                 the key.
         :type authorized_keys: list or str
+        :param disk_encryption: The disk encryption policy for this Linode.
+        :type disk_encryption: InstanceDiskEncryptionType or str
 
         :returns: The newly generated password, if one was not provided
                   (otherwise True)
@@ -1394,6 +1405,10 @@ class Instance(Base):
             "root_pass": root_pass,
             "authorized_keys": authorized_keys,
         }
+
+        if disk_encryption is not None:
+            params["disk_encryption"] = str(disk_encryption)
+
         params.update(kwargs)
 
         result = self._client.post(

--- a/linode_api4/objects/linode.py
+++ b/linode_api4/objects/linode.py
@@ -1724,7 +1724,9 @@ class Instance(Base):
         """
 
         # Local import to prevent circular dependency
-        from linode_api4.objects.lke import LKECluster
+        from linode_api4.objects.lke import (  # pylint: disable=import-outside-toplevel
+            LKECluster,
+        )
 
         return LKECluster(self._client, self.lke_cluster_id)
 

--- a/linode_api4/objects/linode.py
+++ b/linode_api4/objects/linode.py
@@ -22,10 +22,23 @@ from linode_api4.objects import (
 from linode_api4.objects.base import MappedObject
 from linode_api4.objects.filtering import FilterableAttribute
 from linode_api4.objects.networking import IPAddress, IPv6Range, VPCIPAddress
+from linode_api4.objects.serializable import StrEnum
 from linode_api4.objects.vpc import VPC, VPCSubnet
 from linode_api4.paginated_list import PaginatedList
 
 PASSWORD_CHARS = string.ascii_letters + string.digits + string.punctuation
+
+
+class InstanceDiskEncryptionType(StrEnum):
+    """
+    InstanceDiskEncryptionType defines valid values for the
+    Instance(...).disk_encryption field.
+
+    API Documentation: TODO
+    """
+
+    enabled = "enabled"
+    disabled = "disabled"
 
 
 class Backup(DerivedBase):
@@ -650,6 +663,7 @@ class Instance(Base):
         "host_uuid": Property(),
         "watchdog_enabled": Property(mutable=True),
         "has_user_data": Property(),
+        "disk_encryption": Property(),
     }
 
     @property

--- a/linode_api4/objects/lke.py
+++ b/linode_api4/objects/lke.py
@@ -127,6 +127,7 @@ class LKENodePool(DerivedBase):
         "cluster_id": Property(identifier=True),
         "type": Property(slug_relationship=Type),
         "disks": Property(),
+        "disk_encryption": Property(),
         "count": Property(mutable=True),
         "nodes": Property(
             volatile=True

--- a/linode_api4/objects/serializable.py
+++ b/linode_api4/objects/serializable.py
@@ -1,5 +1,6 @@
 import inspect
 from dataclasses import dataclass
+from enum import Enum
 from types import SimpleNamespace
 from typing import (
     Any,
@@ -223,3 +224,22 @@ class JSONObject(metaclass=JSONFilterableMetaclass):
 
     def __len__(self):
         return len(vars(self))
+
+
+class StrEnum(str, Enum):
+    """
+    Used for enums that are of type string, which is necessary
+    for implicit JSON serialization.
+
+    NOTE: Replace this with StrEnum once Python 3.10 has been EOL'd.
+    See: https://docs.python.org/3/library/enum.html#enum.StrEnum
+    """
+
+    def __new__(cls, *values):
+        value = str(*values)
+        member = str.__new__(cls, value)
+        member._value_ = value
+        return member
+
+    def __str__(self):
+        return self._value_

--- a/test/fixtures/linode_instances.json
+++ b/test/fixtures/linode_instances.json
@@ -40,7 +40,9 @@
       "image": "linode/ubuntu17.04",
       "tags": ["something"],
       "host_uuid": "3a3ddd59d9a78bb8de041391075df44de62bfec8",
-      "watchdog_enabled": true
+      "watchdog_enabled": true,
+      "disk_encryption": "disabled",
+      "lke_cluster_id": null
     },
     {
       "group": "test",
@@ -79,7 +81,9 @@
       "image": "linode/debian9",
       "tags": [],
       "host_uuid": "3a3ddd59d9a78bb8de041391075df44de62bfec8",
-      "watchdog_enabled": false
+      "watchdog_enabled": false,
+      "disk_encryption": "enabled",
+      "lke_cluster_id": 12345
     }
   ]
 }

--- a/test/fixtures/linode_instances.json
+++ b/test/fixtures/linode_instances.json
@@ -83,7 +83,7 @@
       "host_uuid": "3a3ddd59d9a78bb8de041391075df44de62bfec8",
       "watchdog_enabled": false,
       "disk_encryption": "enabled",
-      "lke_cluster_id": 12345
+      "lke_cluster_id": 18881
     }
   ]
 }

--- a/test/fixtures/linode_instances_123_disks.json
+++ b/test/fixtures/linode_instances_123_disks.json
@@ -10,7 +10,8 @@
       "id": 12345,
       "updated": "2017-01-01T00:00:00",
       "label": "Ubuntu 17.04 Disk",
-      "created": "2017-01-01T00:00:00"
+      "created": "2017-01-01T00:00:00",
+      "disk_encryption": "disabled"
     },
     {
       "size": 512,
@@ -19,7 +20,8 @@
       "id": 12346,
       "updated": "2017-01-01T00:00:00",
       "label": "512 MB Swap Image",
-      "created": "2017-01-01T00:00:00"
+      "created": "2017-01-01T00:00:00",
+      "disk_encryption": "disabled"
     }
   ]
 }

--- a/test/fixtures/linode_instances_123_disks_12345_clone.json
+++ b/test/fixtures/linode_instances_123_disks_12345_clone.json
@@ -5,6 +5,7 @@
     "id": 12345,
     "updated": "2017-01-01T00:00:00",
     "label": "Ubuntu 17.04 Disk",
-    "created": "2017-01-01T00:00:00"
+    "created": "2017-01-01T00:00:00",
+    "disk_encryption": "disabled"
   }
   

--- a/test/fixtures/lke_clusters_18881_nodes_123456.json
+++ b/test/fixtures/lke_clusters_18881_nodes_123456.json
@@ -1,5 +1,5 @@
 {
     "id": "123456",
-    "instance_id": 123458,
+    "instance_id": 456,
     "status": "ready"
   }

--- a/test/fixtures/lke_clusters_18881_pools_456.json
+++ b/test/fixtures/lke_clusters_18881_pools_456.json
@@ -23,5 +23,6 @@
       "example tag",
       "another example"
     ],
-    "type": "g6-standard-4"
+    "type": "g6-standard-4",
+    "disk_encryption": "enabled"
   }

--- a/test/integration/helpers.py
+++ b/test/integration/helpers.py
@@ -79,12 +79,14 @@ def wait_for_condition(
 
 
 # Retry function to help in case of requests sending too quickly before instance is ready
-def retry_sending_request(retries: int, condition: Callable, *args) -> object:
+def retry_sending_request(
+    retries: int, condition: Callable, *args, **kwargs
+) -> object:
     curr_t = 0
     while curr_t < retries:
         try:
             curr_t += 1
-            res = condition(*args)
+            res = condition(*args, **kwargs)
             return res
         except ApiError:
             if curr_t >= retries:

--- a/test/integration/models/linode/test_linode.py
+++ b/test/integration/models/linode/test_linode.py
@@ -1,4 +1,5 @@
 import time
+from test.integration.conftest import get_region
 from test.integration.helpers import (
     get_test_label,
     retry_sending_request,
@@ -19,7 +20,7 @@ from linode_api4.objects import (
     Instance,
     Type,
 )
-from linode_api4.objects.linode import MigrationType
+from linode_api4.objects.linode import InstanceDiskEncryptionType, MigrationType
 
 
 @pytest.fixture(scope="session")
@@ -137,6 +138,30 @@ def create_linode_for_long_running_tests(test_linode_client):
     linode_instance.delete()
 
 
+@pytest.fixture(scope="function")
+def linode_with_disk_encryption(test_linode_client, request):
+    client = test_linode_client
+
+    target_region = get_region(client, {"Disk Encryption"})
+    timestamp = str(time.time_ns())
+    label = "TestSDK-" + timestamp
+
+    disk_encryption = request.param
+
+    linode_instance, password = client.linode.instance_create(
+        "g6-nanode-1",
+        target_region,
+        image="linode/ubuntu23.04",
+        label=label,
+        booted=False,
+        disk_encryption=disk_encryption,
+    )
+
+    yield linode_instance
+
+    linode_instance.delete()
+
+
 # Test helper
 def get_status(linode: Instance, status: str):
     return linode.status == status
@@ -165,8 +190,7 @@ def test_linode_transfer(test_linode_client, linode_with_volume_firewall):
 
 def test_linode_rebuild(test_linode_client):
     client = test_linode_client
-    available_regions = client.regions()
-    chosen_region = available_regions[4]
+    chosen_region = get_region(client, {"Disk Encryption"})
     label = get_test_label() + "_rebuild"
 
     linode, password = client.linode.instance_create(
@@ -175,12 +199,18 @@ def test_linode_rebuild(test_linode_client):
 
     wait_for_condition(10, 100, get_status, linode, "running")
 
-    retry_sending_request(3, linode.rebuild, "linode/debian10")
+    retry_sending_request(
+        3,
+        linode.rebuild,
+        "linode/debian10",
+        disk_encryption=InstanceDiskEncryptionType.disabled,
+    )
 
     wait_for_condition(10, 100, get_status, linode, "rebuilding")
 
     assert linode.status == "rebuilding"
     assert linode.image.id == "linode/debian10"
+    assert linode.disk_encryption == InstanceDiskEncryptionType.disabled
 
     wait_for_condition(10, 300, get_status, linode, "running")
 
@@ -381,6 +411,18 @@ def test_linode_volumes(linode_with_volume_firewall):
 
     assert len(volumes) > 0
     assert "test" in volumes[0].label
+
+
+@pytest.mark.parametrize(
+    "linode_with_disk_encryption", ["disabled"], indirect=True
+)
+def test_linode_with_disk_encryption_disabled(linode_with_disk_encryption):
+    linode = linode_with_disk_encryption
+
+    assert linode.disk_encryption == InstanceDiskEncryptionType.disabled
+    assert (
+        linode.disks[0].disk_encryption == InstanceDiskEncryptionType.disabled
+    )
 
 
 def wait_for_disk_status(disk: Disk, timeout):

--- a/test/unit/objects/linode_test.py
+++ b/test/unit/objects/linode_test.py
@@ -36,6 +36,8 @@ class LinodeTest(ClientBaseCase):
             linode.host_uuid, "3a3ddd59d9a78bb8de041391075df44de62bfec8"
         )
         self.assertEqual(linode.watchdog_enabled, True)
+        self.assertEqual(linode.disk_encryption, "disabled")
+        self.assertEqual(linode.lke_cluster_id, None)
 
         json = linode._raw_json
         self.assertIsNotNone(json)

--- a/test/unit/objects/linode_test.py
+++ b/test/unit/objects/linode_test.py
@@ -314,6 +314,15 @@ class LinodeTest(ClientBaseCase):
                 m.call_url, "/linode/instances/123/transfer/2023/4"
             )
 
+    def test_lke_cluster(self):
+        """
+        Tests that you can grab the parent LKE cluster from an instance node
+        """
+        linode = Instance(self.client, 456)
+
+        assert linode.lke_cluster_id == 18881
+        assert linode.lke_cluster.id == linode.lke_cluster_id
+
     def test_duplicate(self):
         """
         Tests that you can submit a correct disk clone api request

--- a/test/unit/objects/lke_test.py
+++ b/test/unit/objects/lke_test.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from test.unit.base import ClientBaseCase
 
+from linode_api4 import InstanceDiskEncryptionType
 from linode_api4.objects import (
     LKECluster,
     LKEClusterControlPlaneACLAddressesOptions,
@@ -47,6 +48,9 @@ class LKETest(ClientBaseCase):
         self.assertEqual(pool.id, 456)
         self.assertEqual(pool.cluster_id, 18881)
         self.assertEqual(pool.type.id, "g6-standard-4")
+        self.assertEqual(
+            pool.disk_encryption, InstanceDiskEncryptionType.enabled
+        )
         self.assertIsNotNone(pool.disks)
         self.assertIsNotNone(pool.nodes)
         self.assertIsNotNone(pool.autoscaler)

--- a/test/unit/objects/lke_test.py
+++ b/test/unit/objects/lke_test.py
@@ -88,7 +88,7 @@ class LKETest(ClientBaseCase):
             self.assertEqual(m.call_url, "/lke/clusters/18881/nodes/123456")
             self.assertIsNotNone(node)
             self.assertEqual(node.id, "123456")
-            self.assertEqual(node.instance_id, 123458)
+            self.assertEqual(node.instance_id, 456)
             self.assertEqual(node.status, "ready")
 
     def test_node_delete(self):


### PR DESCRIPTION
## 📝 Description

This pull request adds support for Linode Disk Encryption, including the following changes:

* New `InstanceDiskEncryptionType` enum
* New `disk_encryption` argument for the LinodeGroup(...).instance_create(...) and Instance(...).rebuild(...) methods
* New `disk_encryption` and `lke_cluster_id` attributes under the Instance class
* New `lke_cluster` property method under the Instance class
* New `disk_encryption` attribute under the Disk class
* New `disk_encryption` attribute under the LKENodePool class

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally and run `make install`. Additionally, your environment should be configured to point to an API instance where LDE is available:

```
export LINODE_API_URL=https://.../v4beta
export LINODE_API_CA=$PWD/cacert.pem
export LINODE_TOKEN=...
```

### Unit Testing

```
make testunit
```

### Integration Testing

```
make TEST_COMMAND=models/lketestint
make TEST_COMMAND=models/linode testint
```

### Manual Testing

#### Instance-related Changes

1. In a Python SDK sandbox environment (e.g. dx-devenv), run the following:

```python
import os

from linode_api4 import LinodeClient, InstanceDiskEncryptionType

client = LinodeClient(
    base_url=os.getenv("LINODE_API_URL"),
    ca_path=os.getenv("LINODE_API_CA"),
    token=os.getenv("LINODE_TOKEN"),
)

target_region = [v for v in client.regions() if "Disk Encryption" in v.capabilities][0]

instance, _ = client.linode.instance_create(
    "g6-nanode-1",
    target_region,
    image="linode/alpine3.19",
    booted=False,
    disk_encryption=InstanceDiskEncryptionType.enabled,
)

print("Instance Disk Encryption:", instance.disk_encryption)

client.polling.wait_for_entity_free("linode", instance.id)

instance, _ = instance.rebuild(
    image="linode/alpine3.19",
    booted=False,
    disk_encryption=InstanceDiskEncryptionType.disabled,
)

print("Rebuilt Instance Disk Encryption:", instance.disk_encryption)
```

2. Ensure the output matches the following:

```
Instance Disk Encryption: enabled
Rebuilt Instance Disk Encryption: disabled
```

### LKE-related Changes

1. In a Python SDK sandbox environment (e.g. dx-devenv), run the following:

```python
import os
import time

from linode_api4 import LinodeClient, InstanceDiskEncryptionType, Instance

client = LinodeClient(
    base_url=os.getenv("LINODE_API_URL"),
    ca_path=os.getenv("LINODE_API_CA"),
    token=os.getenv("LINODE_TOKEN"),
)

target_region = [
    v
    for v in client.regions()
    if set(v.capabilities).issuperset({"Kubernetes", "Disk Encryption"})
][0]

cluster = client.lke.cluster_create(
    target_region,
    "test-cluster",
    node_pools=client.lke.node_pool("g6-standard-1", 1),
    kube_version="1.29"
)

pool = cluster.pools[0]

print("Pool Disk Encryption:", pool.disk_encryption)

node_instance_id = None

# Wait for a node to have a corresponding instance ID
while node_instance_id is None:
    pool.invalidate()
    node_instance_id = pool.nodes[0].instance_id
    time.sleep(5)

inst = Instance(client, node_instance_id)

print("Underlying Node Instance:", inst)
print("LKE Cluster Backref:", inst.lke_cluster)
```

2. Ensure the output looks similar to the following:

```
Pool Disk Encryption: enabled
Underlying Node Instance: Instance: 25182862
LKE Cluster Backref: LKECluster: 7582
```