### PR TITLE
test: Add Calico Inbound and Outbound policies to LKE nodes for E2E

### DIFF
--- a/.github/workflows/e2e-test-pr.yml
+++ b/.github/workflows/e2e-test-pr.yml
@@ -2,8 +2,8 @@ on:
   pull_request:
   workflow_dispatch:
     inputs:
-      test_path:
-        description: 'Enter specific test path. E.g. linode_client/test_linode_client.py, models/test_account.py'
+      test_suite:
+        description: 'Enter specific test suite. E.g. domain, linode_client'
         required: false
       sha:
         description: 'The hash value of the commit.'
@@ -26,7 +26,7 @@ jobs:
       - uses: actions-ecosystem/action-regex-match@v2
         id: validate-tests
         with:
-          text: ${{ inputs.test_path }}
+          text: ${{ inputs.test_suite }}
           regex: '[^a-z0-9-:.\/_]'  # Tests validation
           flags: gi
 
@@ -71,6 +71,14 @@ jobs:
       - name: Install Python deps
         run: pip install -U setuptools wheel boto3 certifi
 
+      - name: Download kubectl and calicoctl for LKE clusters
+        run: |
+          curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
+          curl -LO "https://github.com/projectcalico/calico/releases/download/v3.25.0/calicoctl-linux-amd64"
+          chmod +x calicoctl-linux-amd64 kubectl
+          mv calicoctl-linux-amd64 /usr/local/bin/calicoctl
+          mv kubectl /usr/local/bin/kubectl
+
       - name: Install Python SDK
         run: make dev-install
         env:
@@ -80,14 +88,19 @@ jobs:
         run: |
           timestamp=$(date +'%Y%m%d%H%M')
           report_filename="${timestamp}_sdk_test_report.xml"
-          status=0
-          if ! python3 -m pytest test/integration/${INTEGRATION_TEST_PATH} --disable-warnings --junitxml="${report_filename}"; then
-            echo "EXIT_STATUS=1" >> $GITHUB_ENV
-          fi
+          make testint TEST_ARGS="--junitxml=${report_filename}" TEST_SUITE="${{ github.event.inputs.test_suite }}"
         env:
           LINODE_TOKEN: ${{ secrets.LINODE_TOKEN }}
 
-      - name: Add additional information to XML report
+      - name: Apply Calico Rules to LKE
+        if: always()
+        run: |
+          cd scripts && ./lke_calico_rules_e2e.sh
+        env:
+          LINODE_TOKEN: ${{ secrets.LINODE_TOKEN }}
+
+      - name: Upload test results
+        if: always()
         run: |
           filename=$(ls | grep -E '^[0-9]{12}_sdk_test_report\.xml$') 
           python tod_scripts/add_to_xml_test_report.py \
@@ -95,11 +108,8 @@ jobs:
           --gha_run_id "$GITHUB_RUN_ID" \
           --gha_run_number "$GITHUB_RUN_NUMBER" \
           --xmlfile "${filename}"
-
-      - name: Upload test results
-        run: |
-          report_filename=$(ls | grep -E '^[0-9]{12}_sdk_test_report\.xml$')
-          python3 tod_scripts/test_report_upload_script.py "${report_filename}"
+          sync
+          python3 tod_scripts/test_report_upload_script.py "${filename}"
         env:
           LINODE_CLI_OBJ_ACCESS_KEY: ${{ secrets.LINODE_CLI_OBJ_ACCESS_KEY }}
           LINODE_CLI_OBJ_SECRET_KEY: ${{ secrets.LINODE_CLI_OBJ_SECRET_KEY }}
@@ -131,12 +141,3 @@ jobs:
               conclusion: process.env.conclusion
             });
             return result;
-
-      - name: Test Execution Status Handler
-        run: |
-          if [[ "$EXIT_STATUS" != 0 ]]; then
-            echo "Test execution contains failure(s)"
-            exit $EXIT_STATUS 
-          else
-            echo "Tests passed!"
-          fi

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -32,11 +32,26 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Download kubectl and calicoctl for LKE clusters
+        run: |
+          curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
+          curl -LO "https://github.com/projectcalico/calico/releases/download/v3.25.0/calicoctl-linux-amd64"
+          chmod +x calicoctl-linux-amd64 kubectl
+          mv calicoctl-linux-amd64 /usr/local/bin/calicoctl
+          mv kubectl /usr/local/bin/kubectl
+
       - name: Run Integration tests
         run: |
           timestamp=$(date +'%Y%m%d%H%M')
           report_filename="${timestamp}_sdk_test_report.xml"
           make testint TEST_ARGS="--junitxml=${report_filename}"
+        env:
+          LINODE_TOKEN: ${{ secrets.LINODE_TOKEN }}
+
+      - name: Apply Calico Rules to LKE
+        if: always()
+        run: |
+          cd scripts && ./lke_calico_rules_e2e.sh
         env:
           LINODE_TOKEN: ${{ secrets.LINODE_TOKEN }}
 

--- a/scripts/lke-policy.yaml
+++ b/scripts/lke-policy.yaml
@@ -1,0 +1,78 @@
+apiVersion: projectcalico.org/v3
+kind: GlobalNetworkPolicy
+metadata:
+  name: lke-rules
+spec:
+  preDNAT: true
+  applyOnForward: true
+  order: 100
+  # Remember to run calicoctl patch command for this to work
+  selector: ""
+  ingress:
+  # Allow ICMP
+  - action: Allow
+    protocol: ICMP
+  - action: Allow
+    protocol: ICMPv6
+
+  # Allow LKE-required ports
+  - action: Allow
+    protocol: TCP
+    destination:
+      nets:
+      - 192.168.128.0/17
+      - 10.0.0.0/8
+      ports:
+      - 10250
+      - 10256
+      - 179
+  - action: Allow
+    protocol: UDP
+    destination:
+      nets:
+      - 192.168.128.0/17
+      - 10.2.0.0/16
+      ports:
+      - 51820
+
+  # Allow NodeBalancer ingress to the Node Ports & Allow DNS
+  - action: Allow
+    protocol: TCP
+    source:
+      nets:
+      - 192.168.255.0/24
+      - 10.0.0.0/8
+    destination:
+      ports:
+      - 53
+      - 30000:32767
+  - action: Allow
+    protocol: UDP
+    source:
+      nets:
+      - 192.168.255.0/24
+      - 10.0.0.0/8
+    destination:
+      ports:
+      - 53
+      - 30000:32767
+
+  # Allow cluster internal communication
+  - action: Allow
+    destination:
+      nets:
+      - 10.0.0.0/8
+  - action: Allow
+    source:
+      nets:
+      - 10.0.0.0/8
+
+  # 127.0.0.1/32 is needed for kubectl exec and node-shell
+  - action: Allow
+    destination:
+      nets:
+      - 127.0.0.1/32
+
+  # Block everything else
+  - action: Deny
+  - action: Log

--- a/scripts/lke_calico_rules_e2e.sh
+++ b/scripts/lke_calico_rules_e2e.sh
@@ -27,7 +27,7 @@ CLUSTER_IDS=$(curl -s -H "Authorization: Bearer $LINODE_TOKEN" \
 
 # Check if CLUSTER_IDS is empty
 if [ -z "$CLUSTER_IDS" ]; then
-    echo "No clusters are present."
+    echo "All clusters have been cleaned and properly destroyed. No need to apply inbound or outbound rules"
     exit 0
 fi
 
@@ -46,7 +46,7 @@ for ID in $CLUSTER_IDS; do
     done
 
     if [[ $config_response == *"kubeconfig is not yet available"* ]]; then
-        echo "Cluster $ID not available after $RETRIES attempts. Skipping..."
+        echo "kubeconfig for cluster id:$ID not available after $RETRIES attempts, mostly likely it is an empty cluster. Skipping..."
     else
         # Export downloaded config file
         export KUBECONFIG="$(pwd)/${ID}_config.yaml"

--- a/scripts/lke_calico_rules_e2e.sh
+++ b/scripts/lke_calico_rules_e2e.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+RETRIES=3
+DELAY=30
+
+# Function to retry a command with exponential backoff
+retry_command() {
+    local retries=$1
+    local wait_time=60
+    shift
+    until "$@"; do
+        if ((retries == 0)); then
+            echo "Command failed after multiple retries. Exiting."
+            exit 1
+        fi
+        echo "Command failed. Retrying in $wait_time seconds..."
+        sleep $wait_time
+        ((retries--))
+        wait_time=$((wait_time * 2))
+    done
+}
+
+# Fetch the list of LKE cluster IDs
+CLUSTER_IDS=$(curl -s -H "Authorization: Bearer $LINODE_TOKEN" \
+    -H "Content-Type: application/json" \
+    "https://api.linode.com/v4/lke/clusters" | jq -r '.data[].id')
+
+# Check if CLUSTER_IDS is empty
+if [ -z "$CLUSTER_IDS" ]; then
+    echo "No clusters are present."
+    exit 0
+fi
+
+for ID in $CLUSTER_IDS; do
+    echo "Applying Calico rules to nodes in Cluster ID: $ID"
+
+    # Download cluster configuration file with retry
+    for ((i=1; i<=RETRIES; i++)); do
+        config_response=$(curl -sH "Authorization: Bearer $LINODE_TOKEN" "https://api.linode.com/v4/lke/clusters/$ID/kubeconfig")
+        if [[ $config_response != *"kubeconfig is not yet available"* ]]; then
+            echo $config_response | jq -r '.[] | @base64d' > "${ID}_config.yaml"
+            break
+        fi
+        echo "Attempt $i to download kubeconfig for cluster $ID failed. Retrying in $DELAY seconds..."
+        sleep $DELAY
+    done
+
+    if [[ $config_response == *"kubeconfig is not yet available"* ]]; then
+        echo "Cluster $ID not available after $RETRIES attempts. Skipping..."
+    else
+        # Export downloaded config file
+        export KUBECONFIG="$(pwd)/${ID}_config.yaml"
+
+        retry_command $RETRIES kubectl get nodes
+
+        retry_command $RETRIES calicoctl patch kubecontrollersconfiguration default --patch='{"spec": {"controllers": {"node": {"hostEndpoint": {"autoCreate": "Enabled"}}}}}'
+
+        retry_command $RETRIES calicoctl apply -f "$(pwd)/lke-policy.yaml"
+    fi
+done


### PR DESCRIPTION
## 📝 Description

A new script, `lke_calico_rules_e2e.sh`, has been added and is called in the E2E workflow file after the `Run the integration test suite step` in `e2e-suite.yml`

Key Points:
- `kubectl` and `calicoctl` binaries are required as pre-req which are downloed in the e2e worflow file
- The script retrieves all LKE clusters in the test account and applies Calico rules to the corresponding nodes. If no clusters exist, no action is taken. In most cases, clusters are cleaned and deleted properly after test execution
- Due to the delay in the availability of LKE cluster configurations and the provisioning times of node instances, it is challenging to apply Calico rules directly within the test framework. Therefore, the script is separated and executed independently in the workflow file`

## ✔️ How to Test

TBD: Will post forked execution and steps 

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**