### PR TITLE
Cleanup docs, add type annotations, improved class ref

### DIFF
--- a/linode_api4/groups/object_storage.py
+++ b/linode_api4/groups/object_storage.py
@@ -1,3 +1,4 @@
+from typing import List, Optional, Union
 from urllib import parse
 
 from linode_api4.errors import UnexpectedResponseError
@@ -53,7 +54,11 @@ class ObjectStorageGroup(Group):
         """
         return self.client._get_and_filter(ObjectStorageKeys, *filters)
 
-    def keys_create(self, label, bucket_access=None):
+    def keys_create(
+        self,
+        label: str,
+        bucket_access: Optional[Union[dict, List[dict]]] = None,
+    ):
         """
         Creates a new Object Storage keypair that may be used to interact directly
         with Linode Object Storage in third-party applications.  This response is

--- a/linode_api4/objects/object_storage.py
+++ b/linode_api4/objects/object_storage.py
@@ -78,12 +78,6 @@ class ObjectStorageBucket(DerivedBase):
 
         API Documentation: https://www.linode.com/docs/api/object-storage/#object-storage-bucket-access-modify
 
-        :param cluster_id: The ID of the cluster this bucket exists in.
-        :type cluster_id: str
-
-        :param bucket: The bucket name.
-        :type bucket: str
-
         :param acl: The Access Control Level of the bucket using a canned ACL string.
                     For more fine-grained control of ACLs, use the S3 API directly.
         :type acl: str
@@ -126,12 +120,6 @@ class ObjectStorageBucket(DerivedBase):
 
         API Documentation: https://www.linode.com/docs/api/object-storage/#object-storage-bucket-access-update
 
-        :param cluster_id: The ID of the cluster this bucket exists in.
-        :type cluster_id: str
-
-        :param bucket: The bucket name.
-        :type bucket: str
-
         :param acl: The Access Control Level of the bucket using a canned ACL string.
                     For more fine-grained control of ACLs, use the S3 API directly.
         :type acl: str
@@ -168,12 +156,6 @@ class ObjectStorageBucket(DerivedBase):
 
         API Documentation: https://www.linode.com/docs/api/object-storage/#object-storage-tlsssl-cert-delete
 
-        :param cluster_id: The ID of the cluster this bucket exists in.
-        :type cluster_id: str
-
-        :param bucket: The bucket name.
-        :type bucket: str
-
         :returns: True if the TLS/SSL certificate and private key in the bucket were successfully deleted.
         :rtype: bool
         """
@@ -198,12 +180,6 @@ class ObjectStorageBucket(DerivedBase):
         was uploaded by an Account user.
 
         API Documentation: https://www.linode.com/docs/api/object-storage/#object-storage-tlsssl-cert-view
-
-        :param cluster_id: The ID of the cluster this bucket exists in.
-        :type cluster_id: str
-
-        :param bucket: The bucket name.
-        :type bucket: str
 
         :returns: A result object which has a bool field indicating if this Bucket has a corresponding
                   TLS/SSL certificate that was uploaded by an Account user.
@@ -233,12 +209,6 @@ class ObjectStorageBucket(DerivedBase):
         upload a new one.
 
         API Documentation: https://www.linode.com/docs/api/object-storage/#object-storage-tlsssl-cert-upload
-
-        :param cluster_id: The ID of the cluster this bucket exists in.
-        :type cluster_id: str
-
-        :param bucket: The bucket name.
-        :type bucket: str
 
         :param certificate: Your Base64 encoded and PEM formatted SSL certificate.
                             Line breaks must be represented as “\n” in the string
@@ -290,12 +260,6 @@ class ObjectStorageBucket(DerivedBase):
         It is recommended that instead you use the more fully-featured S3 API directly.
 
         API Documentation: https://www.linode.com/docs/api/object-storage/#object-storage-bucket-contents-list
-
-        :param cluster_id: The ID of the cluster this bucket exists in.
-        :type cluster_id: str
-
-        :param bucket: The bucket name.
-        :type bucket: str
 
         :param marker: The “marker” for this request, which can be used to paginate
                        through large buckets. Its value should be the value of the
@@ -357,12 +321,6 @@ class ObjectStorageBucket(DerivedBase):
 
         API Documentation: https://www.linode.com/docs/api/object-storage/#object-storage-object-acl-config-view
 
-        :param cluster_id: The ID of the cluster this bucket exists in.
-        :type cluster_id: str
-
-        :param bucket: The bucket name.
-        :type bucket: str
-
         :param name: The name of the object for which to retrieve its Access Control
                      List (ACL). Use the Object Storage Bucket Contents List endpoint
                      to access all object names in a bucket.
@@ -376,7 +334,7 @@ class ObjectStorageBucket(DerivedBase):
         }
 
         result = self._client.get(
-            f"{ObjectStorageBucket.api_endpoint}/object-acl",
+            f"{type(self).api_endpoint}/object-acl",
             model=self,
             data=drop_null_keys(params),
         )
@@ -400,12 +358,6 @@ class ObjectStorageBucket(DerivedBase):
 
         API Documentation: https://www.linode.com/docs/api/object-storage/#object-storage-object-acl-config-update
 
-        :param cluster_id: The ID of the cluster this bucket exists in.
-        :type cluster_id: str
-
-        :param bucket: The bucket name.
-        :type bucket: str
-
         :param acl: The Access Control Level of the bucket, as a canned ACL string.
                     For more fine-grained control of ACLs, use the S3 API directly.
         :type acl: str
@@ -425,7 +377,7 @@ class ObjectStorageBucket(DerivedBase):
         }
 
         result = self._client.put(
-            f"{ObjectStorageBucket.api_endpoint}/object-acl",
+            f"{type(self).api_endpoint}/object-acl",
             model=self,
             data=params,
         )


### PR DESCRIPTION
## 📝 Description

1. Cleanup docstring to remove unused parameters.
2. Add some type annotations.
3. Improve reference to self's class via `type(self)` to better support class inheritance.

## ✔️ How to Test

`make testunit`
`make testint`