### PR TITLE
Make `ObjectStorageACL` a `StrEnum`

### DIFF
--- a/linode_api4/objects/object_storage.py
+++ b/linode_api4/objects/object_storage.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from urllib import parse
 
 from linode_api4.errors import UnexpectedResponseError
@@ -8,10 +9,11 @@ from linode_api4.objects import (
     Property,
     Region,
 )
+from linode_api4.objects.serializable import StrEnum
 from linode_api4.util import drop_null_keys
 
 
-class ObjectStorageACL:
+class ObjectStorageACL(StrEnum):
     PRIVATE = "private"
     PUBLIC_READ = "public-read"
     AUTHENTICATED_READ = "authenticated-read"
@@ -67,7 +69,7 @@ class ObjectStorageBucket(DerivedBase):
 
     def access_modify(
         self,
-        acl: ObjectStorageACL = None,
+        acl: Optional[ObjectStorageACL] = None,
         cors_enabled=None,
     ):
         """
@@ -115,7 +117,7 @@ class ObjectStorageBucket(DerivedBase):
 
     def access_update(
         self,
-        acl: ObjectStorageACL = None,
+        acl: Optional[ObjectStorageACL] = None,
         cors_enabled=None,
     ):
         """

--- a/linode_api4/objects/serializable.py
+++ b/linode_api4/objects/serializable.py
@@ -1,5 +1,6 @@
 import inspect
 from dataclasses import dataclass
+from enum import Enum
 from types import SimpleNamespace
 from typing import (
     Any,
@@ -223,3 +224,22 @@ class JSONObject(metaclass=JSONFilterableMetaclass):
 
     def __len__(self):
         return len(vars(self))
+
+
+class StrEnum(str, Enum):
+    """
+    Used for enums that are of type string, which is necessary
+    for implicit JSON serialization.
+
+    NOTE: Replace this with StrEnum once Python 3.10 has been EOL'd.
+    See: https://docs.python.org/3/library/enum.html#enum.StrEnum
+    """
+
+    def __new__(cls, *values):
+        value = str(*values)
+        member = str.__new__(cls, value)
+        member._value_ = value
+        return member
+
+    def __str__(self):
+        return self._value_


### PR DESCRIPTION
## 📝 Description

The `StrEnum` implementation was copied from https://github.com/linode/linode_api4-python/pull/413, authored by @lgarber-akamai 

This is to make `ObjectStorageACL` to be a `StrEnum`.

## ✔️ How to Test
`make testunit`

```python
from linode_api4.objects import ObjectStorageACL

client = LinodeClient(os.getenv("LINODE_TOKEN"))

bucket1 = client.object_storage.bucket_create(
    "us-mia-1",
    "test-python-sdk-bucket",
    ObjectStorageACL.PRIVATE,
)

print(bucket1._raw_json)
bucket1.delete()
```