### PR TITLE
Using `api_endpoint` as the URL Path for Methods in `ObjectStorageBucket`

### DIFF
--- a/linode_api4/objects/object_storage.py
+++ b/linode_api4/objects/object_storage.py
@@ -94,10 +94,9 @@ class ObjectStorageBucket(DerivedBase):
         }
 
         resp = self._client.post(
-            "/object-storage/buckets/{}/{}/access".format(
-                parse.quote(str(self.cluster)), parse.quote(str(self.id))
-            ),
+            f"{self.api_endpoint}/access",
             data=drop_null_keys(params),
+            model=self,
         )
 
         if "errors" in resp:
@@ -136,10 +135,9 @@ class ObjectStorageBucket(DerivedBase):
         }
 
         resp = self._client.put(
-            "/object-storage/buckets/{}/{}/access".format(
-                parse.quote(str(self.cluster)), parse.quote(str(self.id))
-            ),
+            f"{self.api_endpoint}/access",
             data=drop_null_keys(params),
+            model=self,
         )
 
         if "errors" in resp:
@@ -161,9 +159,8 @@ class ObjectStorageBucket(DerivedBase):
         """
 
         resp = self._client.delete(
-            "/object-storage/buckets/{}/{}/ssl".format(
-                parse.quote(str(self.cluster)), parse.quote(str(self.id))
-            )
+            f"{self.api_endpoint}/ssl",
+            model=self,
         )
 
         if "error" in resp:
@@ -186,9 +183,8 @@ class ObjectStorageBucket(DerivedBase):
         :rtype: MappedObject
         """
         result = self._client.get(
-            "/object-storage/buckets/{}/{}/ssl".format(
-                parse.quote(str(self.cluster)), parse.quote(str(self.id))
-            )
+            f"{self.api_endpoint}/ssl",
+            model=self,
         )
 
         if not "ssl" in result:
@@ -229,10 +225,9 @@ class ObjectStorageBucket(DerivedBase):
             "private_key": private_key,
         }
         result = self._client.post(
-            "/object-storage/buckets/{}/{}/ssl".format(
-                parse.quote(str(self.cluster)), parse.quote(str(self.id))
-            ),
+            f"{self.api_endpoint}/ssl",
             data=params,
+            model=self,
         )
 
         if not "ssl" in result:
@@ -296,10 +291,9 @@ class ObjectStorageBucket(DerivedBase):
             "page_size": page_size,
         }
         result = self._client.get(
-            "/object-storage/buckets/{}/{}/object-list".format(
-                parse.quote(str(self.cluster)), parse.quote(str(self.id))
-            ),
+            f"{self.api_endpoint}/object-list",
             data=drop_null_keys(params),
+            model=self,
         )
 
         if not "data" in result:


### PR DESCRIPTION
## 📝 Description

Following the pattern in other classes, using `api_endpoint` as the API path.

## ✔️ How to Test
```bash
make testunit
```

```python
import os

from linode_api4 import LinodeClient
from linode_api4.objects import ObjectStorageACL

client = LinodeClient(os.getenv("LINODE_TOKEN"))


bucket1 = client.object_storage.bucket_create(
    "us-mia-1",
    "test-python-sdk-bucket",
    ObjectStorageACL.PRIVATE,
)

print(bucket1._raw_json)

bucket1.access_modify(ObjectStorageACL.PRIVATE, False)
bucket1.access_update(ObjectStorageACL.PRIVATE, False)
print(bucket1.contents())
print(bucket1.ssl_cert().dict)
bucket1.ssl_cert_delete()
bucket1._api_get()

print(bucket1._raw_json)
bucket1.delete()

```