### PR TITLE
Update OBJ Group and Objects for MultiCluster Object Storage API Changes

### DIFF
--- a/linode_api4/groups/object_storage.py
+++ b/linode_api4/groups/object_storage.py
@@ -175,7 +175,6 @@ class ObjectStorageGroup(Group):
         cluster_or_region: str,
         bucket_name: str,
         permissions: Union[str, ObjectStorageKeyPermission],
-        use_region: bool,
     ):
         """
         Returns a dict formatted to be included in the `bucket_access` argument
@@ -197,27 +196,20 @@ class ObjectStorageGroup(Group):
         :rtype: dict
         """
 
-        if not use_region:
-            warnings.warn(
-                "Cluster ID for Object Storage APIs has been deprecated. "
-                "Please consider switch to a region ID (e.g., from `us-mia-1` to `us-mia`)",
-                DeprecationWarning,
-            )
-
-        if use_region and cls.is_cluster(cluster_or_region):
-            raise ValueError(
-                "'use_region' is set to True but a cluster ID is provided."
-            )
-
         result = {
             "bucket_name": bucket_name,
             "permissions": permissions,
         }
 
-        if use_region:
-            result["region"] = cluster_or_region
-        else:
+        if cls.is_cluster(cluster_or_region):
+            warnings.warn(
+                "Cluster ID for Object Storage APIs has been deprecated. "
+                "Please consider switch to a region ID (e.g., from `us-mia-1` to `us-mia`)",
+                DeprecationWarning,
+            )
             result["cluster"] = cluster_or_region
+        else:
+            result["region"] = cluster_or_region
 
         return result
 

--- a/linode_api4/groups/object_storage.py
+++ b/linode_api4/groups/object_storage.py
@@ -13,6 +13,7 @@ from linode_api4.objects import (
     ObjectStorageACL,
     ObjectStorageBucket,
     ObjectStorageCluster,
+    ObjectStorageKeyPermission,
     ObjectStorageKeys,
 )
 from linode_api4.util import drop_null_keys
@@ -141,7 +142,7 @@ class ObjectStorageGroup(Group):
                     warnings.warn(
                         "'cluster' is a deprecated attribute, "
                         "please consider using 'region' instead.",
-                        FutureWarning,
+                        DeprecationWarning,
                     )
                     access_rule_json["cluster"] = (
                         access_rule.id
@@ -173,7 +174,7 @@ class ObjectStorageGroup(Group):
         cls,
         cluster_or_region: str,
         bucket_name: str,
-        permissions: str,
+        permissions: Union[str, ObjectStorageKeyPermission],
         use_region: bool,
     ):
         """
@@ -187,7 +188,7 @@ class ObjectStorageGroup(Group):
         :type bucket_name: str
         :param permissions: The permissions to grant.  Should be one of "read_only"
                             or "read_write".
-        :type permissions: str
+        :type permissions: Union[str, ObjectStorageKeyPermission]
         :param use_region: Whether to use region mode.
         :type use_region: bool
 
@@ -200,7 +201,7 @@ class ObjectStorageGroup(Group):
             warnings.warn(
                 "Cluster ID for Object Storage APIs has been deprecated. "
                 "Please consider switch to a region ID (e.g., from `us-mia-1` to `us-mia`)",
-                FutureWarning,
+                DeprecationWarning,
             )
 
         if use_region and cls.is_cluster(cluster_or_region):
@@ -356,7 +357,13 @@ class ObjectStorageGroup(Group):
         }
 
         if self.is_cluster(cluster_or_region_id):
-            warnings.warn("TODO", FutureWarning)
+            warnings.warn(
+                "The cluster parameter has been deprecated for creating a object "
+                "storage bucket. Please consider switching to a region value. For "
+                "example, a cluster value of `us-mia-1` can be translated to a "
+                "region value of `us-mia`.",
+                DeprecationWarning,
+            )
             params["cluster"] = cluster_or_region_id
         else:
             params["region"] = cluster_or_region_id

--- a/linode_api4/objects/object_storage.py
+++ b/linode_api4/objects/object_storage.py
@@ -30,12 +30,13 @@ class ObjectStorageBucket(DerivedBase):
     API documentation: https://www.linode.com/docs/api/object-storage/#object-storage-bucket-view
     """
 
-    api_endpoint = "/object-storage/buckets/{cluster}/{label}"
-    parent_id_name = "cluster"
+    api_endpoint = "/object-storage/buckets/{region}/{label}"
+    parent_id_name = "region"
     id_attribute = "label"
 
     properties = {
-        "cluster": Property(identifier=True),
+        "region": Property(identifier=True),
+        "cluster": Property(),
         "created": Property(is_datetime=True),
         "hostname": Property(),
         "label": Property(identifier=True),
@@ -59,8 +60,11 @@ class ObjectStorageBucket(DerivedBase):
         """
         if json is None:
             return None
-        if parent_id is None and json["cluster"]:
-            parent_id = json["cluster"]
+
+        cluster_or_region = json.get("region") or json.get("cluster")
+
+        if parent_id is None and cluster_or_region:
+            parent_id = cluster_or_region
 
         if parent_id:
             return super().make(id, client, cls, parent_id=parent_id, json=json)
@@ -388,6 +392,13 @@ class ObjectStorageBucket(DerivedBase):
 
         return MappedObject(**result)
 
+    @deprecated(
+        reason=(
+            "'access' method has been deprecated in favor of the class method "
+            "'bucket_access' in ObjectStorageGroup, which can be accessed by "
+            "'client.object_storage.access'"
+        )
+    )
     def access(self, cluster, bucket_name, permissions):
         """
         Returns a dict formatted to be included in the `bucket_access` argument
@@ -436,6 +447,13 @@ class ObjectStorageCluster(Base):
         "static_site_domain": Property(),
     }
 
+    @deprecated(
+        reason=(
+            "'buckets_in_cluster' method has been deprecated, please consider "
+            "switching to 'buckets_in_region' in the object storage group (can "
+            "be accessed via 'client.object_storage.buckets_in_cluster')."
+        )
+    )
     def buckets_in_cluster(self, *filters):
         """
         Returns a list of Buckets in this cluster belonging to this Account.
@@ -478,4 +496,5 @@ class ObjectStorageKeys(Base):
         "secret_key": Property(),
         "bucket_access": Property(),
         "limited": Property(),
+        "regions": Property(),
     }

--- a/linode_api4/objects/object_storage.py
+++ b/linode_api4/objects/object_storage.py
@@ -501,5 +501,5 @@ class ObjectStorageKeys(Base):
         "secret_key": Property(),
         "bucket_access": Property(),
         "limited": Property(),
-        "regions": Property(),
+        "regions": Property(unordered=True),
     }

--- a/linode_api4/objects/object_storage.py
+++ b/linode_api4/objects/object_storage.py
@@ -23,6 +23,11 @@ class ObjectStorageACL(StrEnum):
     CUSTOM = "custom"
 
 
+class ObjectStorageKeyPermission(StrEnum):
+    READ_ONLY = "read_only"
+    READ_WRITE = "read_write"
+
+
 class ObjectStorageBucket(DerivedBase):
     """
     A bucket where objects are stored in.

--- a/test/fixtures/object-storage_buckets_us-east-1_example-bucket.json
+++ b/test/fixtures/object-storage_buckets_us-east-1_example-bucket.json
@@ -1,5 +1,6 @@
 {
   "cluster": "us-east-1",
+  "region": "us-east",
   "created": "2019-01-01T01:23:45",
   "hostname": "example-bucket.us-east-1.linodeobjects.com",
   "label": "example-bucket",

--- a/test/fixtures/object-storage_keys.json
+++ b/test/fixtures/object-storage_keys.json
@@ -6,13 +6,39 @@
       "id": 1,
       "label": "object-storage-key-1",
       "secret_key": "[REDACTED]",
-      "access_key": "testAccessKeyHere123"
+      "access_key": "testAccessKeyHere123",
+      "limited": false,
+      "regions": [
+        {
+          "id": "us-east",
+          "s3_endpoint": "us-east-1.linodeobjects.com"
+        },
+        {
+          "id": "us-west",
+          "s3_endpoint": "us-west-123.linodeobjects.com"
+        }
+      ]
     },
     {
       "id": 2,
       "label": "object-storage-key-2",
       "secret_key": "[REDACTED]",
-      "access_key": "testAccessKeyHere456"
+      "access_key": "testAccessKeyHere456",
+      "limited": true,
+      "bucket_access": [
+        {
+          "cluster": "us-mia-1",
+          "bucket_name": "example-bucket",
+          "permissions": "read_only",
+          "region": "us-mia"
+        }
+      ],
+      "regions": [
+        {
+          "id": "us-mia",
+          "s3_endpoint": "us-mia-1.linodeobjects.com"
+        }
+      ]
     }
   ],
   "page": 1

--- a/test/integration/models/object_storage/test_obj.py
+++ b/test/integration/models/object_storage/test_obj.py
@@ -1,0 +1,92 @@
+import time
+from test.integration.conftest import get_region
+
+import pytest
+
+from linode_api4.linode_client import LinodeClient
+from linode_api4.objects.object_storage import (
+    ObjectStorageACL,
+    ObjectStorageBucket,
+    ObjectStorageKeyPermission,
+    ObjectStorageKeys,
+)
+
+
+@pytest.fixture(scope="session")
+def region(test_linode_client: LinodeClient):
+    return get_region(test_linode_client, {"Object Storage"}).id
+
+
+@pytest.fixture(scope="session")
+def bucket(test_linode_client: LinodeClient, region: str):
+    bucket = test_linode_client.object_storage.bucket_create(
+        cluster_or_region=region,
+        label="bucket-" + str(time.time_ns()),
+        acl=ObjectStorageACL.PRIVATE,
+        cors_enabled=False,
+    )
+
+    yield bucket
+    bucket.delete()
+
+
+@pytest.fixture(scope="session")
+def obj_key(test_linode_client: LinodeClient):
+    key = test_linode_client.object_storage.keys_create(
+        label="obj-key-" + str(time.time_ns()),
+    )
+
+    yield key
+    key.delete()
+
+
+@pytest.fixture(scope="session")
+def obj_limited_key(
+    test_linode_client: LinodeClient, region: str, bucket: ObjectStorageBucket
+):
+    key = test_linode_client.object_storage.keys_create(
+        label="obj-limited-key-" + str(time.time_ns()),
+        bucket_access=test_linode_client.object_storage.bucket_access(
+            cluster_or_region=region,
+            bucket_name=bucket.label,
+            permissions=ObjectStorageKeyPermission.READ_ONLY,
+        ),
+        regions=[region],
+    )
+
+    yield key
+    key.delete()
+
+
+def test_keys(
+    test_linode_client: LinodeClient,
+    obj_key: ObjectStorageKeys,
+    obj_limited_key: ObjectStorageKeys,
+):
+    loaded_key = test_linode_client.load(ObjectStorageKeys, obj_key.id)
+    loaded_limited_key = test_linode_client.load(
+        ObjectStorageKeys, obj_limited_key.id
+    )
+
+    assert loaded_key.label == obj_key.label
+    assert loaded_limited_key.label == obj_limited_key.label
+
+
+def test_bucket(
+    test_linode_client: LinodeClient,
+    bucket: ObjectStorageBucket,
+):
+    loaded_bucket = test_linode_client.load(ObjectStorageBucket, bucket.label)
+
+    assert loaded_bucket.label == bucket.label
+    assert loaded_bucket.region == bucket.region
+
+
+def test_bucket(
+    test_linode_client: LinodeClient,
+    bucket: ObjectStorageBucket,
+    region: str,
+):
+    buckets = test_linode_client.object_storage.buckets_in_region(region=region)
+    assert len(buckets) >= 1
+    assert any(b.label == bucket.label for b in buckets)

--- a/test/unit/groups/object_storage_test.py
+++ b/test/unit/groups/object_storage_test.py
@@ -1,0 +1,20 @@
+import pytest
+
+from linode_api4.groups.object_storage import ObjectStorageGroup
+
+
+@pytest.mark.parametrize(
+    "cluster_or_region,is_cluster",
+    [
+        ("us-east-1", True),
+        ("us-central-1", True),
+        ("us-mia-1", True),
+        ("us-iad-123", True),
+        ("us-east", False),
+        ("us-central", False),
+        ("us-mia", False),
+        ("us-iad", False),
+    ],
+)
+def test_is_cluster(cluster_or_region: str, is_cluster: bool):
+    assert ObjectStorageGroup.is_cluster(cluster_or_region) == is_cluster

--- a/test/unit/linode_client_test.py
+++ b/test/unit/linode_client_test.py
@@ -980,6 +980,39 @@ class ObjectStorageGroupTest(ClientBaseCase):
             self.assertEqual(m.call_url, "/object-storage/keys")
             self.assertEqual(m.call_data, {"label": "object-storage-key-1"})
 
+    def test_limited_keys_create(self):
+        """
+        Tests that you can create Object Storage Keys
+        """
+        with self.mock_post("object-storage/keys/2") as m:
+            keys = self.client.object_storage.keys_create(
+                "object-storage-key-1",
+                self.client.object_storage.bucket_access(
+                    "us-east", "example-bucket", "read_only", True
+                ),
+                ["us-east"],
+            )
+
+            self.assertIsNotNone(keys)
+            self.assertEqual(keys.id, 2)
+            self.assertEqual(keys.label, "object-storage-key-2")
+
+            self.assertEqual(m.call_url, "/object-storage/keys")
+            self.assertEqual(
+                m.call_data,
+                {
+                    "label": "object-storage-key-1",
+                    "bucket_access": [
+                        {
+                            "permissions": "read_only",
+                            "bucket_name": "example-bucket",
+                            "region": "us-east",
+                        }
+                    ],
+                    "regions": ["us-east"],
+                },
+            )
+
     def test_transfer(self):
         """
         Test that you can get the amount of outbound data transfer

--- a/test/unit/linode_client_test.py
+++ b/test/unit/linode_client_test.py
@@ -988,7 +988,9 @@ class ObjectStorageGroupTest(ClientBaseCase):
             keys = self.client.object_storage.keys_create(
                 "object-storage-key-1",
                 self.client.object_storage.bucket_access(
-                    "us-east", "example-bucket", "read_only", True
+                    "us-east",
+                    "example-bucket",
+                    "read_only",
                 ),
                 ["us-east"],
             )

--- a/test/unit/objects/object_storage_test.py
+++ b/test/unit/objects/object_storage_test.py
@@ -53,11 +53,11 @@ class ObjectStorageTest(ClientBaseCase):
         Test that you can modify bucket access settings.
         """
         bucket_access_modify_url = (
-            "/object-storage/buckets/us-east-1/example-bucket/access"
+            "/object-storage/buckets/us-east/example-bucket/access"
         )
         with self.mock_post({}) as m:
             object_storage_bucket = ObjectStorageBucket(
-                self.client, "example-bucket", "us-east-1"
+                self.client, "example-bucket", "us-east"
             )
             object_storage_bucket.access_modify(ObjectStorageACL.PRIVATE, True)
             self.assertEqual(


### PR DESCRIPTION
## 📝 Description

This is to modify `ObjectStorageGroup` and object storage related SDK objects to adapt to the MultiCluster Object Storage API changes.

## ✔️ How to Test

### Automated Testing
```bash
make testunit
```

```bash
make TEST_SUITE=object_storage testint
```

### Manual Testing

```python
import os

from linode_api4 import LinodeClient
from linode_api4.objects import ObjectStorageACL
from linode_api4.objects.object_storage import ObjectStorageKeyPermission

client = LinodeClient(os.getenv("LINODE_TOKEN"))

TEST_REGION="us-mia"
TEST_CLUSTER="us-mia-1"

bucket1 = client.object_storage.bucket_create(
    cluster_or_region=TEST_REGION,
    label="test-python-sdk-bucket",
    acl=ObjectStorageACL.PRIVATE,
    cors_enabled=False,
)

key1 = client.object_storage.keys_create(
    label="test-python-sdk-limited-key",
    bucket_access=client.object_storage.bucket_access(
        cluster_or_region=TEST_REGION,
        bucket_name=bucket1.label,
        permissions=ObjectStorageKeyPermission.READ_ONLY,
        use_region=True,
    ),
    regions=["us-mia"],
)

bucket1._api_get()
key1._api_get()

print("Created with a region:")
print(bucket1._raw_json)
print(key1._raw_json)

key1.delete()
bucket1.delete()

bucket2 = client.object_storage.bucket_create(
    cluster_or_region=TEST_CLUSTER,
    label="test-python-sdk-bucket",
    acl=ObjectStorageACL.PRIVATE,
    cors_enabled=False,
)

key2 = client.object_storage.keys_create(
    label="test-python-sdk-limited-key",
    bucket_access=client.object_storage.bucket_access(
        cluster_or_region=TEST_CLUSTER,
        bucket_name=bucket2.label,
        permissions=ObjectStorageKeyPermission.READ_ONLY,
        use_region=False,
    ),
)

print("Created with a cluster:")
print(bucket2._raw_json)
print(key2._raw_json)

key2.delete()
bucket2.delete()
```
