### PR TITLE
new: Support Image Gen2 functionalities

### DIFF
--- a/linode_api4/groups/image.py
+++ b/linode_api4/groups/image.py
@@ -1,4 +1,4 @@
-from typing import BinaryIO, Tuple, List
+from typing import BinaryIO, List, Tuple
 
 import requests
 
@@ -29,7 +29,9 @@ class ImageGroup(Group):
         """
         return self.client._get_and_filter(Image, *filters)
 
-    def create(self, disk, label=None, description=None, cloud_init=False, tags=None):
+    def create(
+        self, disk, label=None, description=None, cloud_init=False, tags=None
+    ):
         """
         Creates a new Image from a disk you own.
 
@@ -54,7 +56,7 @@ class ImageGroup(Group):
             "disk_id": disk.id if issubclass(type(disk), Base) else disk,
             "label": label,
             "description": description,
-            "tags": tags
+            "tags": tags,
         }
 
         if cloud_init:
@@ -98,7 +100,12 @@ class ImageGroup(Group):
         :returns: A tuple containing the new image and the image upload URL.
         :rtype: (Image, str)
         """
-        params = {"label": label, "region": region, "description": description, "tags": tags}
+        params = {
+            "label": label,
+            "region": region,
+            "description": description,
+            "tags": tags,
+        }
 
         if cloud_init:
             params["cloud_init"] = cloud_init
@@ -116,7 +123,12 @@ class ImageGroup(Group):
         return Image(self.client, result_image["id"], result_image), result_url
 
     def upload(
-        self, label: str, region: str, file: BinaryIO, description: str = None, tags: List[str] = None,
+        self,
+        label: str,
+        region: str,
+        file: BinaryIO,
+        description: str = None,
+        tags: List[str] = None,
     ) -> Image:
         """
         Creates and uploads a new image.
@@ -137,7 +149,9 @@ class ImageGroup(Group):
         :rtype: Image
         """
 
-        image, url = self.create_upload(label, region, description=description, tags=tags)
+        image, url = self.create_upload(
+            label, region, description=description, tags=tags
+        )
 
         requests.put(
             url,

--- a/linode_api4/groups/image.py
+++ b/linode_api4/groups/image.py
@@ -1,10 +1,10 @@
-from typing import BinaryIO, List, Tuple
+from typing import BinaryIO, List, Optional, Tuple, Union
 
 import requests
 
 from linode_api4.errors import UnexpectedResponseError
 from linode_api4.groups import Group
-from linode_api4.objects import Base, Image
+from linode_api4.objects import Base, Disk, Image
 from linode_api4.util import drop_null_keys
 
 
@@ -30,7 +30,12 @@ class ImageGroup(Group):
         return self.client._get_and_filter(Image, *filters)
 
     def create(
-        self, disk, label=None, description=None, cloud_init=False, tags=None
+        self,
+        disk: Union[Disk, int],
+        label: str = None,
+        description: str = None,
+        cloud_init: bool = False,
+        tags: Optional[List[str]] = None,
     ):
         """
         Creates a new Image from a disk you own.
@@ -38,7 +43,7 @@ class ImageGroup(Group):
         API Documentation: https://www.linode.com/docs/api/images/#image-create
 
         :param disk: The Disk to imagize.
-        :type disk: Disk or int
+        :type disk: Union[Disk, int]
         :param label: The label for the resulting Image (defaults to the disk's
                       label.
         :type label: str
@@ -47,7 +52,7 @@ class ImageGroup(Group):
         :param cloud_init: Whether this Image supports cloud-init.
         :type cloud_init: bool
         :param tags: A list of customized tags of this new Image.
-        :type tags: List[str]
+        :type tags: Optional[List[str]]
 
         :returns: The new Image.
         :rtype: Image
@@ -79,7 +84,7 @@ class ImageGroup(Group):
         region: str,
         description: str = None,
         cloud_init: bool = False,
-        tags: List[str] = None,
+        tags: Optional[List[str]] = None,
     ) -> Tuple[Image, str]:
         """
         Creates a new Image and returns the corresponding upload URL.
@@ -95,7 +100,7 @@ class ImageGroup(Group):
         :param cloud_init: Whether this Image supports cloud-init.
         :type cloud_init: bool
         :param tags: A list of customized tags of this Image.
-        :type tags: List[str]
+        :type tags: Optional[List[str]]
 
         :returns: A tuple containing the new image and the image upload URL.
         :rtype: (Image, str)
@@ -128,7 +133,7 @@ class ImageGroup(Group):
         region: str,
         file: BinaryIO,
         description: str = None,
-        tags: List[str] = None,
+        tags: Optional[List[str]] = None,
     ) -> Image:
         """
         Creates and uploads a new image.
@@ -143,7 +148,7 @@ class ImageGroup(Group):
         :param description: The description for the new Image.
         :type description: str
         :param tags: A list of customized tags of this Image.
-        :type tags: List[str]
+        :type tags: Optional[List[str]]
 
         :returns: The resulting image.
         :rtype: Image

--- a/linode_api4/linode_client.py
+++ b/linode_api4/linode_client.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import logging
 from importlib.metadata import version
-from typing import BinaryIO, Tuple
+from typing import BinaryIO, Tuple, List
 from urllib import parse
 
 import requests
@@ -378,15 +378,15 @@ class LinodeClient:
 
         super().__setattr__(key, value)
 
-    def image_create(self, disk, label=None, description=None):
+    def image_create(self, disk, label=None, description=None, tags=None):
         """
         .. note:: This method is an alias to maintain backwards compatibility.
                   Please use :meth:`LinodeClient.images.create(...) <.ImageGroup.create>` for all new projects.
         """
-        return self.images.create(disk, label=label, description=description)
+        return self.images.create(disk, label=label, description=description, tags=tags)
 
     def image_create_upload(
-        self, label: str, region: str, description: str = None
+        self, label: str, region: str, description: str = None, tags: List[str] = None
     ) -> Tuple[Image, str]:
         """
         .. note:: This method is an alias to maintain backwards compatibility.
@@ -394,16 +394,16 @@ class LinodeClient:
                   for all new projects.
         """
 
-        return self.images.create_upload(label, region, description=description)
+        return self.images.create_upload(label, region, description=description, tags=tags)
 
     def image_upload(
-        self, label: str, region: str, file: BinaryIO, description: str = None
+        self, label: str, region: str, file: BinaryIO, description: str = None, tags: List[str] = None
     ) -> Image:
         """
         .. note:: This method is an alias to maintain backwards compatibility.
                   Please use :meth:`LinodeClient.images.upload(...) <.ImageGroup.upload>` for all new projects.
         """
-        return self.images.upload(label, region, file, description=description)
+        return self.images.upload(label, region, file, description=description, tags=tags)
 
     def nodebalancer_create(self, region, **kwargs):
         """

--- a/linode_api4/linode_client.py
+++ b/linode_api4/linode_client.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import logging
 from importlib.metadata import version
-from typing import BinaryIO, Tuple, List
+from typing import BinaryIO, List, Tuple
 from urllib import parse
 
 import requests
@@ -383,10 +383,16 @@ class LinodeClient:
         .. note:: This method is an alias to maintain backwards compatibility.
                   Please use :meth:`LinodeClient.images.create(...) <.ImageGroup.create>` for all new projects.
         """
-        return self.images.create(disk, label=label, description=description, tags=tags)
+        return self.images.create(
+            disk, label=label, description=description, tags=tags
+        )
 
     def image_create_upload(
-        self, label: str, region: str, description: str = None, tags: List[str] = None
+        self,
+        label: str,
+        region: str,
+        description: str = None,
+        tags: List[str] = None,
     ) -> Tuple[Image, str]:
         """
         .. note:: This method is an alias to maintain backwards compatibility.
@@ -394,16 +400,25 @@ class LinodeClient:
                   for all new projects.
         """
 
-        return self.images.create_upload(label, region, description=description, tags=tags)
+        return self.images.create_upload(
+            label, region, description=description, tags=tags
+        )
 
     def image_upload(
-        self, label: str, region: str, file: BinaryIO, description: str = None, tags: List[str] = None
+        self,
+        label: str,
+        region: str,
+        file: BinaryIO,
+        description: str = None,
+        tags: List[str] = None,
     ) -> Image:
         """
         .. note:: This method is an alias to maintain backwards compatibility.
                   Please use :meth:`LinodeClient.images.upload(...) <.ImageGroup.upload>` for all new projects.
         """
-        return self.images.upload(label, region, file, description=description, tags=tags)
+        return self.images.upload(
+            label, region, file, description=description, tags=tags
+        )
 
     def nodebalancer_create(self, region, **kwargs):
         """

--- a/linode_api4/objects/image.py
+++ b/linode_api4/objects/image.py
@@ -1,9 +1,8 @@
 from dataclasses import dataclass
-from linode_api4.objects.serializable  import StrEnum
 from typing import List, Union
 
 from linode_api4.objects import Base, Property, Region
-from linode_api4.objects.serializable import JSONObject
+from linode_api4.objects.serializable import JSONObject, StrEnum
 
 
 class ReplicationStatus(StrEnum):

--- a/linode_api4/objects/image.py
+++ b/linode_api4/objects/image.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from enum import StrEnum
+from linode_api4.objects.serializable  import StrEnum
 from typing import List, Union
 
 from linode_api4.objects import Base, Property, Region

--- a/linode_api4/objects/image.py
+++ b/linode_api4/objects/image.py
@@ -19,7 +19,7 @@ class ReplicationStatus(StrEnum):
 
 
 @dataclass
-class ImageReplica(JSONObject):
+class ImageRegion(JSONObject):
     """
     The region and status of an image replica.
     """
@@ -57,7 +57,7 @@ class Image(Base):
         ),
         "tags": Property(mutable=True, unordered=True),
         "total_size": Property(),
-        "regions": Property(json_object=ImageReplica, unordered=True),
+        "regions": Property(json_object=ImageRegion, unordered=True),
     }
 
     def replicate(self, regions: Union[List[str], List[Region]]):

--- a/linode_api4/objects/image.py
+++ b/linode_api4/objects/image.py
@@ -1,5 +1,28 @@
-from linode_api4.objects import Base, Property
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import List, Union
 
+from linode_api4.objects.serializable import JSONObject
+from linode_api4.objects import Base, Property, Region
+
+class ReplicationStatus(StrEnum):
+    """
+    The Enum class represents replications status.
+    """
+    pending_replication = "pending replication"
+    pending_deletion = "pending deletion"
+    available = "available"
+    creating = "creating"
+    pending = "pending"
+    replicating = "replicating"
+
+@dataclass
+class ImageReplica(JSONObject):
+    """
+    The region and status of a image replica.
+    """
+    region: str = ""
+    status: ReplicationStatus = None
 
 class Image(Base):
     """
@@ -28,4 +51,28 @@ class Image(Base):
         "capabilities": Property(
             unordered=True,
         ),
+        "tags": Property(mutable=True, unordered=True),
+        "total_size": Property(),
+        "regions": Property(json_object=ImageReplica, unordered=True),
     }
+
+    def replicate(self, regions: Union[List[str], List[Region]]):
+        """
+        Replicate the image to other regions.
+
+        API Documentation: TODO
+
+        :param regions: A list of regions that the customer wants to replicate this image in.
+                        At least one valid region is required and only core regions allowed.
+                        Existing images in the regions not passed will be removed.
+        :type regions: List[str]
+        """
+        params = {"regions": [region.id if isinstance(region, Region) else region for region in regions]}
+
+        result = self._client.post(
+            "{}/regions".format(self.api_endpoint), model=self, data=params
+        )
+
+        # The replicate endpoint returns the updated Image, so we can use this
+        # as an opportunity to refresh the object
+        self._populate(result)

--- a/linode_api4/objects/image.py
+++ b/linode_api4/objects/image.py
@@ -2,13 +2,15 @@ from dataclasses import dataclass
 from enum import StrEnum
 from typing import List, Union
 
-from linode_api4.objects.serializable import JSONObject
 from linode_api4.objects import Base, Property, Region
+from linode_api4.objects.serializable import JSONObject
+
 
 class ReplicationStatus(StrEnum):
     """
     The Enum class represents image replication status.
     """
+
     pending_replication = "pending replication"
     pending_deletion = "pending deletion"
     available = "available"
@@ -16,13 +18,16 @@ class ReplicationStatus(StrEnum):
     pending = "pending"
     replicating = "replicating"
 
+
 @dataclass
 class ImageReplica(JSONObject):
     """
     The region and status of an image replica.
     """
+
     region: str = ""
     status: ReplicationStatus = None
+
 
 class Image(Base):
     """
@@ -67,7 +72,12 @@ class Image(Base):
                         Existing images in the regions not passed will be removed.
         :type regions: List[str]
         """
-        params = {"regions": [region.id if isinstance(region, Region) else region for region in regions]}
+        params = {
+            "regions": [
+                region.id if isinstance(region, Region) else region
+                for region in regions
+            ]
+        }
 
         result = self._client.post(
             "{}/regions".format(self.api_endpoint), model=self, data=params

--- a/linode_api4/objects/image.py
+++ b/linode_api4/objects/image.py
@@ -7,7 +7,7 @@ from linode_api4.objects import Base, Property, Region
 
 class ReplicationStatus(StrEnum):
     """
-    The Enum class represents replications status.
+    The Enum class represents image replication status.
     """
     pending_replication = "pending replication"
     pending_deletion = "pending deletion"
@@ -19,7 +19,7 @@ class ReplicationStatus(StrEnum):
 @dataclass
 class ImageReplica(JSONObject):
     """
-    The region and status of a image replica.
+    The region and status of an image replica.
     """
     region: str = ""
     status: ReplicationStatus = None

--- a/test/fixtures/images.json
+++ b/test/fixtures/images.json
@@ -18,7 +18,15 @@
           "eol": "2026-07-01T04:00:00",
           "expiry": "2026-08-01T04:00:00",
           "updated": "2020-07-01T04:00:00",
-          "capabilities": []
+          "capabilities": [],
+          "tags": ["tests"],
+          "total_size": 1100,
+          "regions": [
+            {
+              "region": "us-east",
+              "status": "available"
+            }
+          ]
         },
         {
           "created": "2017-01-01T00:01:01",
@@ -35,7 +43,19 @@
           "eol": "2026-07-01T04:00:00",
           "expiry": "2026-08-01T04:00:00",
           "updated": "2020-07-01T04:00:00",
-          "capabilities": []
+          "capabilities": [],
+          "tags": ["tests"],
+          "total_size": 3000,
+          "regions": [
+            {
+              "region": "us-east",
+              "status": "available"
+            },
+            {
+              "region": "us-mia",
+              "status": "pending"
+            }
+          ]
         },
         {
           "created": "2017-01-01T00:01:01",

--- a/test/fixtures/images_private_123_regions.json
+++ b/test/fixtures/images_private_123_regions.json
@@ -1,0 +1,29 @@
+{
+  "created": "2017-08-20T14:01:01",
+  "description": null,
+  "deprecated": false,
+  "status": "available",
+  "created_by": "testguy",
+  "id": "private/123",
+  "label": "Gold Master",
+  "size": 650,
+  "is_public": false,
+  "type": "manual",
+  "vendor": null,
+  "eol": "2026-07-01T04:00:00",
+  "expiry": "2026-08-01T04:00:00",
+  "updated": "2020-07-01T04:00:00",
+  "capabilities": ["cloud-init"],
+  "tags": ["tests"],
+  "total_size": 1300,
+  "regions": [
+    {
+      "region": "us-east",
+      "status": "available"
+    },
+    {
+      "region": "us-west",
+      "status": "pending replication"
+    }
+  ]
+}

--- a/test/fixtures/images_upload.json
+++ b/test/fixtures/images_upload.json
@@ -14,7 +14,8 @@
         "type": "manual",
         "updated": "2021-08-14T22:44:02",
         "vendor": "Debian",
-        "capabilities": ["cloud-init"]
+        "capabilities": ["cloud-init"],
+        "tags": ["test_tag", "test2"]
     },
     "upload_to": "https://linode.com/"
 }

--- a/test/integration/linode_client/test_linode_client.py
+++ b/test/integration/linode_client/test_linode_client.py
@@ -11,8 +11,12 @@ from linode_api4.objects import ConfigInterface, ObjectStorageKeys, Region
 @pytest.fixture(scope="session")
 def setup_client_and_linode(test_linode_client, e2e_test_firewall):
     client = test_linode_client
-    available_regions = client.regions()
-    chosen_region = available_regions[4]  # us-ord (Chicago)
+    # The available region in alpha testing is very limited. `us_east` can be used.
+    # We can uncomment this logic once we can talk to prod.
+    #
+    # available_regions = client.regions()
+    # chosen_region = available_regions[4]  # us-ord (Chicago)
+    chosen_region = "us-east"
     label = get_test_label()
 
     linode_instance, password = client.linode.instance_create(
@@ -100,6 +104,9 @@ def test_image_create(setup_client_and_linode):
     assert image.label == label
     assert image.description == description
     assert image.tags == tags
+    # size and total_size are the same because this image is not replicated
+    assert image.size == image.total_size
+    assert len(image.regions) == 0
 
 
 def test_fails_to_create_image_with_non_existing_disk_id(

--- a/test/integration/linode_client/test_linode_client.py
+++ b/test/integration/linode_client/test_linode_client.py
@@ -90,14 +90,16 @@ def test_image_create(setup_client_and_linode):
 
     label = get_test_label()
     description = "Test description"
+    tags = ["test"]
     usable_disk = [v for v in linode.disks if v.filesystem != "swap"]
 
     image = client.image_create(
-        disk=usable_disk[0].id, label=label, description=description
+        disk=usable_disk[0].id, label=label, description=description, tags=tags
     )
 
     assert image.label == label
     assert image.description == description
+    assert image.tags == tags
 
 
 def test_fails_to_create_image_with_non_existing_disk_id(

--- a/test/integration/linode_client/test_linode_client.py
+++ b/test/integration/linode_client/test_linode_client.py
@@ -12,7 +12,7 @@ from linode_api4.objects import ConfigInterface, ObjectStorageKeys, Region
 def setup_client_and_linode(test_linode_client, e2e_test_firewall):
     client = test_linode_client
     # The available region in alpha testing is very limited. `us_east` can be used.
-    # We can uncomment this logic once we can talk to prod.
+    # TODO: We can uncomment this logic once we can talk to prod.
     #
     # available_regions = client.regions()
     # chosen_region = available_regions[4]  # us-ord (Chicago)
@@ -106,7 +106,6 @@ def test_image_create(setup_client_and_linode):
     assert image.tags == tags
     # size and total_size are the same because this image is not replicated
     assert image.size == image.total_size
-    assert len(image.regions) == 0
 
 
 def test_fails_to_create_image_with_non_existing_disk_id(

--- a/test/integration/models/image/test_image.py
+++ b/test/integration/models/image/test_image.py
@@ -13,6 +13,9 @@ from linode_api4.objects import Image
 def image_upload(test_linode_client):
     label = get_test_label() + "_image"
 
+    # TODO: use get_region to get regions randomly with specific functionality
+    # region = get_region(test_linode_client, {"Functionality"})
+
     test_linode_client.image_create_upload(
         label, "us-east", "integration test image upload"
     )
@@ -53,13 +56,13 @@ def test_image_create_upload(test_linode_client):
     assert image.tags[0] == "tests"
 
 
-# Image is not ready for replication yet. We'll add this test when the API is ready.
-# @pytest.mark.smoke
-# def test_image_replication(test_linode_client, image_upload):
-#     image = test_linode_client.load(Image, image_upload.id)
-#
-#     image.replicate("us-mia")
-#
-#     assert image.label == image_upload.label
-#     assert image.total_size == image_upload.size * 2
-#     assert len(image.regions) == 2
+# TODO: Image is not ready for replication yet. We'll verify this test when the API is ready.
+@pytest.mark.smoke
+def test_image_replication(test_linode_client, image_upload):
+    image = test_linode_client.load(Image, image_upload.id)
+
+    image.replicate("us-central")
+
+    assert image.label == image_upload.label
+    assert image.total_size == image_upload.size * 2
+    assert len(image.regions) == 2

--- a/test/integration/models/image/test_image.py
+++ b/test/integration/models/image/test_image.py
@@ -42,7 +42,7 @@ def test_image_create_upload(test_linode_client):
     label = get_test_label() + "_image"
     image = test_linode_client.image_upload(
         label,
-        "us-ord",
+        "us-east",
         BytesIO(test_image_content),
         description="integration test image upload",
         tags=["tests"],
@@ -53,12 +53,13 @@ def test_image_create_upload(test_linode_client):
     assert image.tags[0] == "tests"
 
 
-@pytest.mark.smoke
-def test_image_replication(test_linode_client, image_upload):
-    image = test_linode_client.load(Image, image_upload.id)
-
-    image.replicate("us-mia")
-
-    assert image.label == image_upload.label
-    assert image.total_size == image_upload.size * 2
-    assert len(image.regions) == 2
+# Image is not ready for replication yet. We'll add this test when the API is ready.
+# @pytest.mark.smoke
+# def test_image_replication(test_linode_client, image_upload):
+#     image = test_linode_client.load(Image, image_upload.id)
+#
+#     image.replicate("us-mia")
+#
+#     assert image.label == image_upload.label
+#     assert image.total_size == image_upload.size * 2
+#     assert len(image.regions) == 2

--- a/test/integration/models/image/test_image.py
+++ b/test/integration/models/image/test_image.py
@@ -45,7 +45,19 @@ def test_image_create_upload(test_linode_client):
         "us-ord",
         BytesIO(test_image_content),
         description="integration test image upload",
+        tags=["tests"]
     )
 
     assert image.label == label
     assert image.description == "integration test image upload"
+    assert image.tags[0] == "tests"
+
+@pytest.mark.smoke
+def test_image_replication(test_linode_client, image_upload):
+    image = test_linode_client.load(Image, image_upload.id)
+
+    image.replicate("us-mia")
+
+    assert image.label == image_upload.label
+    assert image.total_size == image_upload.size * 2
+    assert len(image.regions) == 2

--- a/test/integration/models/image/test_image.py
+++ b/test/integration/models/image/test_image.py
@@ -45,12 +45,13 @@ def test_image_create_upload(test_linode_client):
         "us-ord",
         BytesIO(test_image_content),
         description="integration test image upload",
-        tags=["tests"]
+        tags=["tests"],
     )
 
     assert image.label == label
     assert image.description == "integration test image upload"
     assert image.tags[0] == "tests"
+
 
 @pytest.mark.smoke
 def test_image_replication(test_linode_client, image_upload):

--- a/test/unit/linode_client_test.py
+++ b/test/unit/linode_client_test.py
@@ -127,7 +127,7 @@ class LinodeClientGeneralTest(ClientBaseCase):
         Tests that an Image can be created successfully
         """
         with self.mock_post("images/private/123") as m:
-            i = self.client.image_create(654, "Test-Image", "This is a test")
+            i = self.client.image_create(654, "Test-Image", "This is a test", ["test"])
 
             self.assertIsNotNone(i)
             self.assertEqual(i.id, "private/123")
@@ -141,6 +141,7 @@ class LinodeClientGeneralTest(ClientBaseCase):
                     "disk_id": 654,
                     "label": "Test-Image",
                     "description": "This is a test",
+                    "tags": ["test"]
                 },
             )
 

--- a/test/unit/linode_client_test.py
+++ b/test/unit/linode_client_test.py
@@ -127,7 +127,9 @@ class LinodeClientGeneralTest(ClientBaseCase):
         Tests that an Image can be created successfully
         """
         with self.mock_post("images/private/123") as m:
-            i = self.client.image_create(654, "Test-Image", "This is a test", ["test"])
+            i = self.client.image_create(
+                654, "Test-Image", "This is a test", ["test"]
+            )
 
             self.assertIsNotNone(i)
             self.assertEqual(i.id, "private/123")
@@ -141,7 +143,7 @@ class LinodeClientGeneralTest(ClientBaseCase):
                     "disk_id": 654,
                     "label": "Test-Image",
                     "description": "This is a test",
-                    "tags": ["test"]
+                    "tags": ["test"],
                 },
             )
 

--- a/test/unit/objects/image_test.py
+++ b/test/unit/objects/image_test.py
@@ -51,6 +51,11 @@ class ImageTest(ClientBaseCase):
             datetime(year=2020, month=7, day=1, hour=4, minute=0, second=0),
         )
 
+        self.assertEqual(image.tags[0], "tests")
+        self.assertEqual(image.total_size, 1100)
+        self.assertEqual(image.regions[0].region, "us-east")
+        self.assertEqual(image.regions[0].status, "available")
+
     def test_image_create_upload(self):
         """
         Test that an image upload URL can be created successfully.
@@ -61,6 +66,7 @@ class ImageTest(ClientBaseCase):
                 "Realest Image Upload",
                 "us-southeast",
                 description="very real image upload.",
+                tags=["test_tag", "test2"]
             )
 
             self.assertEqual(m.call_url, "/images/upload")
@@ -71,6 +77,7 @@ class ImageTest(ClientBaseCase):
                     "label": "Realest Image Upload",
                     "region": "us-southeast",
                     "description": "very real image upload.",
+                    "tags": ["test_tag", "test2"]
                 },
             )
 
@@ -78,6 +85,8 @@ class ImageTest(ClientBaseCase):
         self.assertEqual(image.label, "Realest Image Upload")
         self.assertEqual(image.description, "very real image upload.")
         self.assertEqual(image.capabilities[0], "cloud-init")
+        self.assertEqual(image.tags[0], "test_tag")
+        self.assertEqual(image.tags[1], "test2")
 
         self.assertEqual(url, "https://linode.com/")
 
@@ -96,11 +105,14 @@ class ImageTest(ClientBaseCase):
                 "us-southeast",
                 BytesIO(TEST_IMAGE_CONTENT),
                 description="very real image upload.",
+                tags=["test_tag", "test2"]
             )
 
         self.assertEqual(image.id, "private/1337")
         self.assertEqual(image.label, "Realest Image Upload")
         self.assertEqual(image.description, "very real image upload.")
+        self.assertEqual(image.tags[0], "test_tag")
+        self.assertEqual(image.tags[1], "test2")
 
     def test_image_create_cloud_init(self):
         """
@@ -131,3 +143,22 @@ class ImageTest(ClientBaseCase):
             )
 
             self.assertTrue(m.call_data["cloud_init"])
+
+    def test_image_replication(self):
+        """
+        Test that image can be replicated.
+        """
+
+        replication_url = "/images/private/123/regions"
+        regions = ["us-east", "us-west"]
+        with self.mock_post(replication_url) as m:
+            image = Image(self.client, "private/123")
+            image.replicate(regions)
+
+            self.assertEqual(replication_url, m.call_url)
+            self.assertEqual(
+                m.call_data,
+                {
+                   "regions": regions
+                },
+            )

--- a/test/unit/objects/image_test.py
+++ b/test/unit/objects/image_test.py
@@ -66,7 +66,7 @@ class ImageTest(ClientBaseCase):
                 "Realest Image Upload",
                 "us-southeast",
                 description="very real image upload.",
-                tags=["test_tag", "test2"]
+                tags=["test_tag", "test2"],
             )
 
             self.assertEqual(m.call_url, "/images/upload")
@@ -77,7 +77,7 @@ class ImageTest(ClientBaseCase):
                     "label": "Realest Image Upload",
                     "region": "us-southeast",
                     "description": "very real image upload.",
-                    "tags": ["test_tag", "test2"]
+                    "tags": ["test_tag", "test2"],
                 },
             )
 
@@ -105,7 +105,7 @@ class ImageTest(ClientBaseCase):
                 "us-southeast",
                 BytesIO(TEST_IMAGE_CONTENT),
                 description="very real image upload.",
-                tags=["test_tag", "test2"]
+                tags=["test_tag", "test2"],
             )
 
         self.assertEqual(image.id, "private/1337")
@@ -158,7 +158,5 @@ class ImageTest(ClientBaseCase):
             self.assertEqual(replication_url, m.call_url)
             self.assertEqual(
                 m.call_data,
-                {
-                   "regions": ["us-east", "us-west"]
-                },
+                {"regions": ["us-east", "us-west"]},
             )

--- a/test/unit/objects/image_test.py
+++ b/test/unit/objects/image_test.py
@@ -4,7 +4,7 @@ from test.unit.base import ClientBaseCase
 from typing import BinaryIO
 from unittest.mock import patch
 
-from linode_api4.objects import Image
+from linode_api4.objects import Image, Region
 
 # A minimal gzipped image that will be accepted by the API
 TEST_IMAGE_CONTENT = (
@@ -150,7 +150,7 @@ class ImageTest(ClientBaseCase):
         """
 
         replication_url = "/images/private/123/regions"
-        regions = ["us-east", "us-west"]
+        regions = ["us-east", Region(self.client, "us-west")]
         with self.mock_post(replication_url) as m:
             image = Image(self.client, "private/123")
             image.replicate(regions)
@@ -159,6 +159,6 @@ class ImageTest(ClientBaseCase):
             self.assertEqual(
                 m.call_data,
                 {
-                   "regions": regions
+                   "regions": ["us-east", "us-west"]
                 },
             )


### PR DESCRIPTION
## 📝 Description

Support the new image fields, including `tags`, `total_size`, `regions`. Support image replication.

## ✔️ How to Test

### Unite test:
```
make testunit
```

Before running the integration test, you'll need to set up these environment variables:
```
export LINODE_API_URL=https://.../v4
export LINODE_API_CA=$PWD/cacert.pem
export LINODE_TOKEN=...
```

### Integration test:
```
make testint TEST_SUITE=linode_client
make testint TEST_SUITE=image TEST_CASE=test_image_create_upload
make testint TEST_SUITE=image TEST_CASE=test_get_image

# replication is not functional yet
# make testint TEST_SUITE=image TEST_CASE=test_image_replication
```

### Manual Test
1. In a sandbox environment, run the following to create an image with tags:
```python
import os
from linode_api4 import LinodeClient

client = LinodeClient(
        os.getenv("LINODE_TOKEN"),
        base_url="https://.../v4",
        ca_path=".../CA.pem",
)
    
linode, _ = client.linode.instance_create(
    "g6-nanode-1",
    "us-east",
    label="test-image-gen2",
    image="linode/alpine3.19",
)

image = client.image_create(
    disk=linode.disks[0].id, label="image-gen-2", description="Test", tags=["test", "image-gen2"]
)

print(image.tags)
print(image.total_size)
# regions is expected to be empty here since it's not properly functional yet
print(image.regions)

linode.delete()
image.delete()
```
2. Observe that new fields tags, total_size, and regions are populated.