### PR TITLE
test: Add missing integration tests to improve coverage for identified gaps

### DIFF
--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -26,6 +26,13 @@ def get_api_url():
     return os.environ.get(ENV_API_URL_NAME, "https://api.linode.com/v4beta")
 
 
+def get_random_label():
+    timestamp = str(time.time_ns())[:-5]
+    label = "label_" + timestamp
+
+    return label
+
+
 def get_region(client: LinodeClient, capabilities: Set[str] = None):
     region_override = os.environ.get(ENV_REGION_OVERRIDE)
 
@@ -313,7 +320,7 @@ def test_sshkey(test_linode_client, ssh_key_gen):
 
 
 @pytest.fixture
-def ssh_keys_object_storage(test_linode_client):
+def access_keys_object_storage(test_linode_client):
     client = test_linode_client
     label = "TestSDK-obj-storage-key"
     key = client.object_storage.keys_create(label)
@@ -348,8 +355,10 @@ def test_firewall(test_linode_client):
 @pytest.fixture
 def test_oauth_client(test_linode_client):
     client = test_linode_client
+    label = get_random_label() + "_oauth"
+
     oauth_client = client.account.oauth_client_create(
-        "test-oauth-client", "https://localhost/oauth/callback"
+        label, "https://localhost/oauth/callback"
     )
 
     yield oauth_client

--- a/test/integration/linode_client/test_linode_client.py
+++ b/test/integration/linode_client/test_linode_client.py
@@ -353,26 +353,6 @@ def test_fails_to_create_cluster_with_invalid_version(test_linode_client):
         assert e.status == 400
 
 
-# ProfileGroupTest
-
-
-def test_get_sshkeys(test_linode_client, test_sshkey):
-    client = test_linode_client
-
-    ssh_keys = client.profile.ssh_keys()
-
-    ssh_labels = [i.label for i in ssh_keys]
-
-    assert test_sshkey.label in ssh_labels
-
-
-def test_ssh_key_create(test_sshkey, ssh_key_gen):
-    pub_key = ssh_key_gen[0]
-    key = test_sshkey
-
-    assert pub_key == key._raw_json["ssh_key"]
-
-
 # ObjectStorageGroupTests
 
 
@@ -385,9 +365,9 @@ def test_get_object_storage_clusters(test_linode_client):
     assert "us-east" in clusters[0].region.id
 
 
-def test_get_keys(test_linode_client, ssh_keys_object_storage):
+def test_get_keys(test_linode_client, access_keys_object_storage):
     client = test_linode_client
-    key = ssh_keys_object_storage
+    key = access_keys_object_storage
 
     keys = client.object_storage.keys()
     key_labels = [i.label for i in keys]
@@ -395,8 +375,8 @@ def test_get_keys(test_linode_client, ssh_keys_object_storage):
     assert key.label in key_labels
 
 
-def test_keys_create(test_linode_client, ssh_keys_object_storage):
-    key = ssh_keys_object_storage
+def test_keys_create(test_linode_client, access_keys_object_storage):
+    key = access_keys_object_storage
 
     assert type(key) == type(
         ObjectStorageKeys(client=test_linode_client, id="123")

--- a/test/integration/login_client/test_login_client.py
+++ b/test/integration/login_client/test_login_client.py
@@ -32,7 +32,7 @@ def test_get_oathclient(test_linode_client, test_oauth_client):
 
     oauth_client = client.load(OAuthClient, test_oauth_client.id)
 
-    assert "test-oauth-client" == oauth_client.label
+    assert "_oauth" in test_oauth_client.label
     assert "https://localhost/oauth/callback" == oauth_client.redirect_uri
 
 

--- a/test/integration/models/account/test_account.py
+++ b/test/integration/models/account/test_account.py
@@ -1,4 +1,5 @@
 import time
+from datetime import datetime
 from test.integration.helpers import get_test_label
 
 import pytest
@@ -91,7 +92,6 @@ def test_get_user(test_linode_client):
 
     assert username == user.username
     assert "email" in user._raw_json
-    assert "email" in user._raw_json
 
 
 def test_list_child_accounts(test_linode_client):
@@ -102,3 +102,25 @@ def test_list_child_accounts(test_linode_client):
         child_account = ChildAccount(client, child_accounts[0].euuid)
         child_account._api_get()
         child_account.create_token()
+
+
+def test_get_invoice(test_linode_client):
+    client = test_linode_client
+
+    invoices = client.account.invoices()
+
+    if len(invoices) > 0:
+        assert isinstance(invoices[0].subtotal, float)
+        assert isinstance(invoices[0].tax, float)
+        assert isinstance(invoices[0].total, float)
+        assert r"'billing_source': 'linode'" in str(invoices[0]._raw_json)
+
+
+def test_get_payments(test_linode_client):
+    client = test_linode_client
+
+    payments = client.account.payments()
+
+    if len(payments) > 0:
+        assert isinstance(payments[0].date, datetime)
+        assert isinstance(payments[0].usd, float)

--- a/test/integration/models/lke/test_lke.py
+++ b/test/integration/models/lke/test_lke.py
@@ -1,3 +1,4 @@
+import base64
 import re
 from test.integration.helpers import (
     get_test_label,
@@ -95,8 +96,16 @@ def test_cluster_dashboard_url_view(lke_cluster):
     assert re.search("https://+", url)
 
 
-def test_kubeconfig_delete(lke_cluster):
+def test_get_and_delete_kubeconfig(lke_cluster):
     cluster = lke_cluster
+
+    kubeconfig_encoded = cluster.kubeconfig
+
+    kubeconfig_decoded = base64.b64decode(kubeconfig_encoded).decode("utf-8")
+
+    assert "kind: Config" in kubeconfig_decoded
+
+    assert "apiVersion:" in kubeconfig_decoded
 
     res = send_request_when_resource_available(300, cluster.kubeconfig_delete)
 

--- a/test/integration/models/longview/test_longview.py
+++ b/test/integration/models/longview/test_longview.py
@@ -4,10 +4,10 @@ import time
 import pytest
 
 from linode_api4.objects import (
+    ApiError,
     LongviewClient,
     LongviewPlan,
     LongviewSubscription,
-    ApiError,
 )
 
 
@@ -52,10 +52,10 @@ def test_get_longview_subscription(test_linode_client, test_longview_client):
     assert re.search("[0-9]+", str(sub.price.hourly))
     assert re.search("[0-9]+", str(sub.price.monthly))
 
-    assert 'longview-3' in str(subs.lists)
-    assert 'longview-10' in str(subs.lists)
-    assert 'longview-40' in str(subs.lists)
-    assert 'longview-100' in str(subs.lists)
+    assert "longview-3" in str(subs.lists)
+    assert "longview-10" in str(subs.lists)
+    assert "longview-40" in str(subs.lists)
+    assert "longview-100" in str(subs.lists)
 
 
 def test_longview_plan_update_method_not_allowed(test_linode_client):

--- a/test/integration/models/longview/test_longview.py
+++ b/test/integration/models/longview/test_longview.py
@@ -3,7 +3,11 @@ import time
 
 import pytest
 
-from linode_api4.objects import LongviewClient, LongviewSubscription
+from linode_api4.objects import (
+    LongviewClient,
+    LongviewPlan,
+    LongviewSubscription,
+)
 
 
 @pytest.mark.smoke
@@ -46,3 +50,11 @@ def test_get_longview_subscription(test_linode_client, test_longview_client):
 
     assert re.search("[0-9]+", str(sub.price.hourly))
     assert re.search("[0-9]+", str(sub.price.monthly))
+
+
+def test_get_current_longview_plan(test_linode_client):
+    lv_plan = test_linode_client.load(LongviewPlan, "")
+
+    assert "Longview" in lv_plan.label
+    assert "hourly" in lv_plan.price.dict
+    assert "monthly" in lv_plan.price.dict

--- a/test/integration/models/longview/test_longview.py
+++ b/test/integration/models/longview/test_longview.py
@@ -7,6 +7,7 @@ from linode_api4.objects import (
     LongviewClient,
     LongviewPlan,
     LongviewSubscription,
+    ApiError,
 )
 
 
@@ -51,10 +52,24 @@ def test_get_longview_subscription(test_linode_client, test_longview_client):
     assert re.search("[0-9]+", str(sub.price.hourly))
     assert re.search("[0-9]+", str(sub.price.monthly))
 
+    assert 'longview-3' in str(subs.lists)
+    assert 'longview-10' in str(subs.lists)
+    assert 'longview-40' in str(subs.lists)
+    assert 'longview-100' in str(subs.lists)
+
+
+def test_longview_plan_update_method_not_allowed(test_linode_client):
+    try:
+        test_linode_client.longview.longview_plan_update("longview-100")
+    except ApiError as e:
+        assert e.status == 405
+        assert "Method Not Allowed" in str(e)
+
 
 def test_get_current_longview_plan(test_linode_client):
     lv_plan = test_linode_client.load(LongviewPlan, "")
 
-    assert "Longview" in lv_plan.label
-    assert "hourly" in lv_plan.price.dict
-    assert "monthly" in lv_plan.price.dict
+    if lv_plan.label is not None:
+        assert "Longview" in lv_plan.label
+        assert "hourly" in lv_plan.price.dict
+        assert "monthly" in lv_plan.price.dict

--- a/test/integration/models/objectstorage/test_obj_storage.py
+++ b/test/integration/models/objectstorage/test_obj_storage.py
@@ -1,0 +1,105 @@
+import time
+from test.integration.conftest import get_region
+
+import pytest
+
+from linode_api4.objects import (
+    ObjectStorageACL,
+    ObjectStorageBucket,
+    ObjectStorageCluster,
+    ObjectStorageKeys,
+)
+
+
+@pytest.fixture(scope="session")
+def test_object_storage_bucket(test_linode_client):
+    client = test_linode_client
+
+    region = get_region(client, {"Object Storage"})
+    cluster_region_name = region.id + "-1"
+    label = str(time.time_ns())[:-5] + "-bucket"
+
+    bucket = client.object_storage.bucket_create(
+        cluster=cluster_region_name, label=label
+    )
+
+    yield bucket
+
+    bucket.delete()
+
+
+def test_list_obj_storage_bucket(
+    test_linode_client, test_object_storage_bucket
+):
+    client = test_linode_client
+
+    buckets = client.object_storage.buckets()
+    target_bucket = test_object_storage_bucket
+
+    bucket_ids = [bucket.id for bucket in buckets]
+
+    assert target_bucket.id in bucket_ids
+    assert isinstance(target_bucket, ObjectStorageBucket)
+
+
+def test_bucket_access_modify(test_object_storage_bucket):
+    bucket = test_object_storage_bucket
+
+    res = bucket.access_modify(ObjectStorageACL.PRIVATE, cors_enabled=True)
+
+    assert res
+
+
+def test_bucket_access_update(test_object_storage_bucket):
+    bucket = test_object_storage_bucket
+    res = bucket.access_update(ObjectStorageACL.PRIVATE, cors_enabled=True)
+
+    assert res
+
+
+def test_get_ssl_cert(test_object_storage_bucket):
+    bucket = test_object_storage_bucket
+
+    res = bucket.ssl_cert().ssl
+
+    assert res is False
+
+
+def test_create_key_for_specific_bucket(
+    test_linode_client, test_object_storage_bucket
+):
+    client = test_linode_client
+    bucket = test_object_storage_bucket
+    keys = client.object_storage.keys_create(
+        "restricted-keys",
+        bucket_access=client.object_storage.bucket_access(
+            bucket.cluster, bucket.id, "read_write"
+        ),
+    )
+
+    assert isinstance(keys, ObjectStorageKeys)
+    assert keys.bucket_access[0].bucket_name == bucket.id
+    assert keys.bucket_access[0].permissions == "read_write"
+    assert keys.bucket_access[0].cluster == bucket.cluster
+
+
+def test_get_cluster(test_linode_client, test_object_storage_bucket):
+    client = test_linode_client
+    bucket = test_object_storage_bucket
+
+    cluster = client.load(ObjectStorageCluster, bucket.cluster)
+
+    assert "linodeobjects.com" in cluster.domain
+    assert cluster.id == bucket.cluster
+    assert "available" == cluster.status
+
+
+def test_get_buckets_in_cluster(test_linode_client, test_object_storage_bucket):
+    client = test_linode_client
+    bucket = test_object_storage_bucket
+
+    cluster = client.load(ObjectStorageCluster, bucket.cluster)
+    buckets = cluster.buckets_in_cluster()
+    bucket_ids = [bucket.id for bucket in buckets]
+
+    assert bucket.id in bucket_ids

--- a/test/integration/models/profile/test_profile.py
+++ b/test/integration/models/profile/test_profile.py
@@ -1,0 +1,36 @@
+from linode_api4.objects import PersonalAccessToken, Profile, SSHKey
+
+
+def test_user_profile(test_linode_client):
+    client = test_linode_client
+
+    profile = client.profile()
+
+    assert isinstance(profile, Profile)
+
+
+def test_get_personal_access_token_objects(test_linode_client):
+    client = test_linode_client
+
+    personal_access_tokens = client.profile.tokens()
+
+    if len(personal_access_tokens) > 0:
+        assert isinstance(personal_access_tokens[0], PersonalAccessToken)
+
+
+def test_get_sshkeys(test_linode_client, test_sshkey):
+    client = test_linode_client
+
+    ssh_keys = client.profile.ssh_keys()
+
+    ssh_labels = [i.label for i in ssh_keys]
+
+    assert isinstance(test_sshkey, SSHKey)
+    assert test_sshkey.label in ssh_labels
+
+
+def test_ssh_key_create(test_sshkey, ssh_key_gen):
+    pub_key = ssh_key_gen[0]
+    key = test_sshkey
+
+    assert pub_key == key._raw_json["ssh_key"]


### PR DESCRIPTION
## 📝 Description

Filling in identified test gaps found in spike - TPT-2699. Integration Tests have been added to following test suites:
- Account 
- LKE
- Longview
- Object Storage
- Profile

For more details refer to spreadsheet attached in TPT-3010

## ✔️ How to Test

```
make TEST_SUITE="login_client" testint 
make TEST_SUITE="account" testint  
make TEST_SUITE="lke" testint  
make TEST_SUITE="longview" testint  
make TEST_SUITE="objectstorage" testint
make TEST_SUITE="profile" testint
```


## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**