### PR TITLE
test: Add option to run integration tests against minimal test account without any special customer tags

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,7 +1,16 @@
 name: Integration Tests
 
 on:
-  workflow_dispatch: null
+  workflow_dispatch:
+    inputs:
+      use_minimal_test_account:
+        description: 'Use minimal test account'
+        required: false
+        default: 'false'
+      sha:
+        description: 'The hash value of the commit'
+        required: false
+        default: ''
   push:
     branches:
       - main
@@ -13,7 +22,16 @@ jobs:
     env:
       EXIT_STATUS: 0
     steps:
-      - name: Clone Repository
+      - name: Clone Repository with SHA
+        if: ${{ inputs.sha != '' }}
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: 'recursive'
+          ref: ${{ inputs.sha }}
+
+      - name: Clone Repository without SHA
+        if: ${{ inputs.sha == '' }}
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -40,20 +58,24 @@ jobs:
           mv calicoctl-linux-amd64 /usr/local/bin/calicoctl
           mv kubectl /usr/local/bin/kubectl
 
+      - name: Set LINODE_TOKEN
+        run: |
+          echo "LINODE_TOKEN=${{ secrets[inputs.use_minimal_test_account == 'true' && 'MINIMAL_LINODE_TOKEN' || 'LINODE_TOKEN'] }}" >> $GITHUB_ENV
+
       - name: Run Integration tests
         run: |
           timestamp=$(date +'%Y%m%d%H%M')
           report_filename="${timestamp}_sdk_test_report.xml"
           make testint TEST_ARGS="--junitxml=${report_filename}"
         env:
-          LINODE_TOKEN: ${{ secrets.LINODE_TOKEN }}
+          LINODE_TOKEN: ${{ env.LINODE_TOKEN }}
 
       - name: Apply Calico Rules to LKE
         if: always()
         run: |
           cd scripts && ./lke_calico_rules_e2e.sh
         env:
-          LINODE_TOKEN: ${{ secrets.LINODE_TOKEN }}
+          LINODE_TOKEN: ${{ env.LINODE_TOKEN }}
 
       - name: Upload test results
         if: always()


### PR DESCRIPTION
## 📝 Description

This PR adds option to run integration tests against minimal test account in e2e-test.yml workflow


## ✔️ How to Test

TBD

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**