### PR TITLE
test: Add error handling in e2e_cloud_firewall fixture

### DIFF
--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -134,7 +134,7 @@ def e2e_test_firewall(test_linode_client):
 
     yield firewall
 
-    # firewall.delete()
+    firewall.delete()
 
 
 @pytest.fixture(scope="session")

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -69,7 +69,7 @@ def e2e_test_firewall(test_linode_client):
         except ipaddress.AddressValueError:
             return False
 
-    def get_public_ip(ip_version="ipv4", retries=3):
+    def get_public_ip(ip_version: str = "ipv4", retries: int = 3):
         url = (
             f"https://api64.ipify.org?format=json"
             if ip_version == "ipv6"


### PR DESCRIPTION
## 📝 Description

Tests will fail due to ConnectionError at rare occasion as seen in [here](https://github.com/linode/linode_api4-python/actions/runs/9601474258/job/26480113068).

This PR adds a retry mechanism with error handling in the e2e_cloud_firewall fixture for more reliable test runs

## ✔️ How to Test

`test testint`, or any test case

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**