### PR TITLE
fix: Resolve error when creating EventError(...) with message=None

### DIFF
--- a/linode_api4/polling.py
+++ b/linode_api4/polling.py
@@ -13,7 +13,7 @@ class EventError(Exception):
 
     def __init__(self, event_id: int, message: Optional[str]):
         # Edge case, sometimes the message is populated with an empty string
-        if len(message) < 1:
+        if message is not None and len(message) < 1:
             message = None
 
         self.event_id = event_id

--- a/test/unit/objects/polling_test.py
+++ b/test/unit/objects/polling_test.py
@@ -328,3 +328,17 @@ class TestPolling:
             assert err.message == "oh no!"
         else:
             raise Exception("Expected event error, got none")
+
+    def test_event_error(
+        self,
+    ):
+        """
+        Tests that EventError objects can be constructed and
+        will be formatted to the correct output.
+
+        Tests for regression of TPT-3060
+        """
+
+        assert str(EventError(123, None)) == "Event 123 failed"
+        assert str(EventError(123, "")) == "Event 123 failed"
+        assert str(EventError(123, "foobar")) == "Event 123 failed: foobar"


### PR DESCRIPTION
## 📝 Description

This pull request resolves a bug that would cause the following error when attempting to create an EventError with a `None` message value:

```
TypeError: object of type 'NoneType' has no len()
```

This situations is very uncommon but it did cause issues when testing against a non-production environment.

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally and run `make install`.

### Unit Testing

```
make testunit
```

### Manual Testing

1. In a Python SDK sandbox environment (e.g. dx-devenv), run the following:

```python
from linode_api4.polling import EventError

print(EventError(123, None))
```

2. Ensure no TypeError is raised and the following is printed:

```
Event 123 failed
```