### PR TITLE
test: Temporarily disable LDE integration tests

### DIFF
--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -496,5 +496,6 @@ def create_placement_group_with_linode(
 @pytest.mark.smoke
 def pytest_configure(config):
     config.addinivalue_line(
-        "markers", "smoke: mark test as part of smoke test suite"
+        "markers",
+        "smoke: mark test as part of smoke test suite",
     )

--- a/test/integration/models/linode/test_linode.py
+++ b/test/integration/models/linode/test_linode.py
@@ -208,14 +208,17 @@ def test_linode_rebuild(test_linode_client):
         3,
         linode.rebuild,
         "linode/debian10",
-        disk_encryption=InstanceDiskEncryptionType.disabled,
+        # TODO(LDE): Uncomment once LDE is available
+        # disk_encryption=InstanceDiskEncryptionType.disabled,
     )
 
     wait_for_condition(10, 100, get_status, linode, "rebuilding")
 
     assert linode.status == "rebuilding"
     assert linode.image.id == "linode/debian10"
-    assert linode.disk_encryption == InstanceDiskEncryptionType.disabled
+
+    # TODO(LDE): Uncomment once LDE is available
+    # assert linode.disk_encryption == InstanceDiskEncryptionType.disabled
 
     wait_for_condition(10, 300, get_status, linode, "running")
 
@@ -418,6 +421,8 @@ def test_linode_volumes(linode_with_volume_firewall):
     assert "test" in volumes[0].label
 
 
+# TODO(LDE): Remove skip once LDE is available
+@pytest.skip("LDE is not currently enabled")
 @pytest.mark.parametrize(
     "linode_with_disk_encryption", ["disabled"], indirect=True
 )

--- a/test/integration/models/linode/test_linode.py
+++ b/test/integration/models/linode/test_linode.py
@@ -195,7 +195,11 @@ def test_linode_transfer(test_linode_client, linode_with_volume_firewall):
 
 def test_linode_rebuild(test_linode_client):
     client = test_linode_client
-    chosen_region = get_region(client, {"Disk Encryption"})
+
+    # TODO(LDE): Uncomment once LDE is available
+    # chosen_region = get_region(client, {"Disk Encryption"})
+    chosen_region = get_region(client)
+
     label = get_test_label() + "_rebuild"
 
     linode, password = client.linode.instance_create(
@@ -422,7 +426,7 @@ def test_linode_volumes(linode_with_volume_firewall):
 
 
 # TODO(LDE): Remove skip once LDE is available
-@pytest.skip("LDE is not currently enabled")
+@pytest.mark.skip("LDE is not currently enabled")
 @pytest.mark.parametrize(
     "linode_with_disk_encryption", ["disabled"], indirect=True
 )

--- a/test/integration/models/lke/test_lke.py
+++ b/test/integration/models/lke/test_lke.py
@@ -11,7 +11,6 @@ from typing import Any, Dict
 import pytest
 
 from linode_api4 import (
-    InstanceDiskEncryptionType,
     LKEClusterControlPlaneACLAddressesOptions,
     LKEClusterControlPlaneACLOptions,
     LKEClusterControlPlaneOptions,
@@ -22,9 +21,14 @@ from linode_api4.objects import LKECluster, LKENodePool
 
 @pytest.fixture(scope="session")
 def lke_cluster(test_linode_client):
+
     node_type = test_linode_client.linode.types()[1]  # g6-standard-1
     version = test_linode_client.lke.versions()[0]
-    region = get_region(test_linode_client, {"Disk Encryption", "Kubernetes"})
+
+    # TODO(LDE): Uncomment once LDE is available
+    # region = get_region(test_linode_client, {"Kubernetes", "Disk Encryption"})
+    region = get_region(test_linode_client, {"Kubernetes"})
+
     node_pools = test_linode_client.lke.node_pool(node_type, 3)
     label = get_test_label() + "_cluster"
 
@@ -98,7 +102,9 @@ def test_get_lke_pool(test_linode_client, lke_cluster):
         return {k: v for k, v in p._raw_json.items() if k not in {"nodes"}}
 
     assert _to_comparable(cluster.pools[0]) == _to_comparable(pool)
-    assert pool.disk_encryption == InstanceDiskEncryptionType.enabled
+
+    # TODO(LDE): Uncomment once LDE is available
+    # assert pool.disk_encryption == InstanceDiskEncryptionType.enabled
 
 
 def test_cluster_dashboard_url_view(lke_cluster):

--- a/test/integration/models/lke/test_lke.py
+++ b/test/integration/models/lke/test_lke.py
@@ -21,7 +21,6 @@ from linode_api4.objects import LKECluster, LKENodePool
 
 @pytest.fixture(scope="session")
 def lke_cluster(test_linode_client):
-
     node_type = test_linode_client.linode.types()[1]  # g6-standard-1
     version = test_linode_client.lke.versions()[0]
 


### PR DESCRIPTION
## 📝 Description

This PR temporarily disables LDE-related test logic while it is still not fully available. This change will be reverted in a follow-up ticket once LDE is confirmed to be available.

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally and run `make install`.

### Integration Tests

```
make TEST_COMMAND="models/linode/test_linode.py -k 'test_linode_with_disk_encryption_disabled or test_linode_rebuild'" testint

make TEST_COMMAND="models/lke/test_lke.py" testint
