### PR TITLE
new: Add support for LKE node pool labels & taints

### DIFF
--- a/linode_api4/objects/lke.py
+++ b/linode_api4/objects/lke.py
@@ -152,7 +152,7 @@ class LKENodePool(DerivedBase):
         "autoscaler": Property(mutable=True),
         "tags": Property(mutable=True, unordered=True),
         "labels": Property(mutable=True),
-        "taints": Property(mutable=True, json_object=LKENodePoolTaint),
+        "taints": Property(mutable=True),
     }
 
     def _parse_raw_node(
@@ -183,21 +183,21 @@ class LKENodePool(DerivedBase):
         Parse Nodes into more useful LKENodePoolNode objects
         """
 
-        super()._populate(json)
-
         if json is not None and json != {}:
-            self._set(
-                "nodes",
-                [self._parse_raw_node(node) for node in json.get("nodes", [])],
-            )
+            json["nodes"] = [
+                self._parse_raw_node(node) for node in json.get("nodes", [])
+            ]
 
-            self._set(
-                "taints",
-                [
+            json["taints"] = [
+                (
                     LKENodePoolTaint.from_json(taint)
-                    for taint in json.get("taints", [])
-                ],
-            )
+                    if not isinstance(taint, LKENodePoolTaint)
+                    else taint
+                )
+                for taint in json.get("taints", [])
+            ]
+
+        super()._populate(json)
 
     def recycle(self):
         """

--- a/linode_api4/objects/lke.py
+++ b/linode_api4/objects/lke.py
@@ -30,6 +30,18 @@ class KubeVersion(Base):
 
 
 @dataclass
+class LKENodePoolTaint(JSONObject):
+    """
+    LKENodePoolTaint represents the structure of a single taint that can be
+    applied to a node pool.
+    """
+
+    key: str = ""
+    value: str = ""
+    effect: str = ""
+
+
+@dataclass
 class LKEClusterControlPlaneACLAddressesOptions(JSONObject):
     """
     LKEClusterControlPlaneACLAddressesOptions are options used to configure
@@ -139,39 +151,53 @@ class LKENodePool(DerivedBase):
         ),  # this is formatted in _populate below
         "autoscaler": Property(mutable=True),
         "tags": Property(mutable=True, unordered=True),
+        "labels": Property(mutable=True),
+        "taints": Property(mutable=True, json_object=LKENodePoolTaint),
     }
+
+    def _parse_raw_node(
+        self, raw_node: Union[LKENodePoolNode, dict, str]
+    ) -> LKENodePoolNode:
+        """
+        Builds a list of LKENodePoolNode objects given a node pool response's JSON.
+        """
+        if isinstance(raw_node, LKENodePoolNode):
+            return raw_node
+
+        if isinstance(raw_node, dict):
+            node_id = raw_node.get("id")
+            if node_id is None:
+                raise ValueError("Node dictionary does not contain 'id' key")
+
+            return LKENodePoolNode(self._client, raw_node)
+
+        if isinstance(raw_node, str):
+            return self._client.load(
+                LKENodePoolNode, target_id=raw_node, target_parent_id=self.id
+            )
+
+        raise TypeError("Unsupported node type: {}".format(type(raw_node)))
 
     def _populate(self, json):
         """
         Parse Nodes into more useful LKENodePoolNode objects
         """
-        if json is not None and json != {}:
-            new_nodes = []
-            for c in json["nodes"]:
-                if isinstance(c, LKENodePoolNode):
-                    new_nodes.append(c)
-                elif isinstance(c, dict):
-                    node_id = c.get("id")
-                    if node_id is not None:
-                        new_nodes.append(LKENodePoolNode(self._client, c))
-                    else:
-                        raise ValueError(
-                            "Node dictionary does not contain 'id' key"
-                        )
-                elif isinstance(c, str):
-                    node_details = self._client.get(
-                        LKENodePool.api_endpoint.format(
-                            cluster_id=self.id, id=c
-                        )
-                    )
-                    new_nodes.append(
-                        LKENodePoolNode(self._client, node_details)
-                    )
-                else:
-                    raise TypeError("Unsupported node type: {}".format(type(c)))
-            json["nodes"] = new_nodes
 
         super()._populate(json)
+
+        if json is not None and json != {}:
+            self._set(
+                "nodes",
+                [self._parse_raw_node(node) for node in json.get("nodes", [])],
+            )
+
+            self._set(
+                "taints",
+                [
+                    LKENodePoolTaint.from_json(taint)
+                    for taint in json.get("taints", [])
+                ],
+            )
 
     def recycle(self):
         """
@@ -302,7 +328,14 @@ class LKECluster(Base):
 
         return LKEClusterControlPlaneACL.from_json(self._control_plane_acl)
 
-    def node_pool_create(self, node_type, node_count, **kwargs):
+    def node_pool_create(
+        self,
+        node_type: Union[Type, str],
+        node_count: int,
+        labels: Dict[str, str] = None,
+        taints: List[Union[LKENodePoolTaint, Dict[str, Any]]] = None,
+        **kwargs,
+    ):
         """
         Creates a new :any:`LKENodePool` for this cluster.
 
@@ -312,6 +345,10 @@ class LKECluster(Base):
         :type node_type: :any:`Type` or str
         :param node_count: The number of nodes to create in this pool.
         :type node_count: int
+        :param labels: A dict mapping labels to their values to apply to this pool.
+        :type labels: Dict[str, str]
+        :param taints: A list of taints to apply to this pool.
+        :type taints: List of :any:`LKENodePoolTaint` or dict
         :param kwargs: Any other arguments to pass to the API.  See the API docs
                        for possible values.
 
@@ -322,6 +359,13 @@ class LKECluster(Base):
             "type": node_type,
             "count": node_count,
         }
+
+        if labels is not None:
+            params["labels"] = labels
+
+        if taints is not None:
+            params["taints"] = taints
+
         params.update(kwargs)
 
         result = self._client.post(

--- a/linode_api4/objects/lke.py
+++ b/linode_api4/objects/lke.py
@@ -36,9 +36,9 @@ class LKENodePoolTaint(JSONObject):
     applied to a node pool.
     """
 
-    key: str = ""
-    value: str = ""
-    effect: str = ""
+    key: Optional[str] = None
+    value: Optional[str] = None
+    effect: Optional[str] = None
 
 
 @dataclass

--- a/test/fixtures/lke_clusters_18881_pools_456.json
+++ b/test/fixtures/lke_clusters_18881_pools_456.json
@@ -23,6 +23,17 @@
       "example tag",
       "another example"
     ],
+    "taints": [
+      {
+        "key": "foo",
+        "value": "bar",
+        "effect": "NoSchedule"
+      }
+    ],
+    "labels": {
+      "foo": "bar",
+      "bar": "foo"
+    },
     "type": "g6-standard-4",
     "disk_encryption": "enabled"
   }

--- a/test/unit/objects/lke_test.py
+++ b/test/unit/objects/lke_test.py
@@ -345,9 +345,7 @@ class LKETest(ClientBaseCase):
             assert m.call_data["node_pools"][0] == {
                 "type": "g6-nanode-1",
                 "count": 3,
-                "labels": {
-                    "foo": "bar"
-                },
+                "labels": {"foo": "bar"},
                 "taints": [
                     {"key": "a", "value": "b", "effect": "NoSchedule"},
                     {"key": "b", "value": "a", "effect": "NoSchedule"},


### PR DESCRIPTION
## 📝 Description

This pull request adds support for specifying the `labels` and `taints` field when creating, updating and accessing an LKE node pool.

Additionally, this pull request makes the following improvements to the object serialization logic:

* Adds a new `_flatten_request_body_recursive(...)` helper function to consolidate request body flattening logic and to address some minor inconsistencies
    * This also introduces support for serializing nested JSONObjects, which is a requirement for the `taints` field
* Breaks the `LKENodePool._populate(...)` method into multiple functions to improve modularity and readability

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally and run `make install`.

### Unit Testing

```
make testunit
```

### Integration Testing

```
make TEST_COMMAND=models/lke
```

### Manual Testing

1. In a linode_api4-python sandbox environment (e.g. dx-devenv), run the following:

```python
import json
import os

from linode_api4 import LinodeClient, LKENodePoolTaint

client = LinodeClient(os.getenv("LINODE_TOKEN"))

# Create a cluster with labels and taints
cluster = client.lke.cluster_create(
    region="us-mia",
    label="test-cluster",
    kube_version="1.30",
    node_pools=[
        client.lke.node_pool(
            "g6-standard-1",
            2,
            labels={
                "foo.example.com/test": "bar",
                "foo.example.com/test2": "test",
            },
            taints=[
                LKENodePoolTaint(
                    key="foo.example.com/test", value="bar", effect="NoSchedule"
                )
            ],
        )
    ],
)

target_pool = cluster.pools[0]

print(f"Initial node pool:\n{json.dumps(target_pool._serialize(), indent=4)}\n")

# Update the labels and taints on this cluster
updated_labels = {
    "foo.example.com/test": "bar",
    "foo.example.com/test3": "cool",
}

updated_taints = [
    LKENodePoolTaint(key="foo.example.com/test3", value="cool", effect="NoExecute")
]

target_pool.labels = updated_labels
target_pool.taints = updated_taints

print(f"Updated pool (pre-refresh):\n{json.dumps(target_pool._serialize(), indent=4)}\n")

# Invalid the pool so it is implicitly refreshed
target_pool.invalidate()

print(f"Updated pool (post-refresh):\n{json.dumps(target_pool._serialize(), indent=4)}\n")
```

2. Ensure the output matches the following:

```json
Initial node pool:
{
    "count": 2,
    "autoscaler": {
        "enabled": false,
        "min": 2,
        "max": 2
    },
    "tags": [],
    "labels": {
        "foo.example.com/test": "bar",
        "foo.example.com/test2": "test"
    },
    "taints": [
        {
            "key": "foo.example.com/test",
            "value": "bar",
            "effect": "NoSchedule"
        }
    ]
}

Updated pool (pre-refresh):
{
    "count": 2,
    "autoscaler": {
        "enabled": false,
        "min": 2,
        "max": 2
    },
    "tags": [],
    "labels": {
        "foo.example.com/test": "bar",
        "foo.example.com/test3": "cool"
    },
    "taints": [
        {
            "key": "foo.example.com/test3",
            "value": "cool",
            "effect": "NoExecute"
        }
    ]
}

Updated pool (post-refresh):
{
    "count": 2,
    "autoscaler": {
        "enabled": false,
        "min": 2,
        "max": 2
    },
    "tags": [],
    "labels": {
        "foo.example.com/test": "bar",
        "foo.example.com/test2": "test"
    },
    "taints": [
        {
            "key": "foo.example.com/test",
            "value": "bar",
            "effect": "NoSchedule"
        }
    ]
}
```