### PR TITLE
Increase max wait time for `test_linode_resize`

### DIFF
--- a/test/integration/models/linode/test_linode.py
+++ b/test/integration/models/linode/test_linode.py
@@ -315,11 +315,11 @@ def test_linode_boot(create_linode):
 def test_linode_resize(create_linode_for_long_running_tests):
     linode = create_linode_for_long_running_tests
 
-    wait_for_condition(10, 100, get_status, linode, "running")
+    wait_for_condition(10, 240, get_status, linode, "running")
 
     retry_sending_request(3, linode.resize, "g6-standard-6")
 
-    wait_for_condition(10, 100, get_status, linode, "resizing")
+    wait_for_condition(10, 240, get_status, linode, "resizing")
 
     assert linode.status == "resizing"
 


### PR DESCRIPTION
## 📝 Description

This is to hopefully address the intermittent test error on `test_linode_resize` in [this run](https://github.com/linode/linode_api4-python/actions/runs/10321836586/job/28664237527?pr=449).