### PR TITLE
Add VPC Grant and Refactor `UserGrants` class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ docs/_build/*
 venv
 baked_version
 .vscode
+.DS_Store

--- a/test/integration/linode_client/test_linode_client.py
+++ b/test/integration/linode_client/test_linode_client.py
@@ -222,7 +222,7 @@ def test_get_account_settings(test_linode_client):
 
     assert account_settings._populated == True
     assert re.search(
-        "'network_helper':\s*(True|False)", str(account_settings._raw_json)
+        r"'network_helper':\s*(True|False)", str(account_settings._raw_json)
     )
 
 


### PR DESCRIPTION
## 📝 Description

- Make `UserGrants` class serializable.
- Add `VPC` grant.
- Refactor code, including wrapping up some logic into properties and sort out imports.

## ✔️ How to Test
```bash
make testunit
```

```python
import os
from linode_api4 import LinodeClient

client = LinodeClient(token=os.getenv('LINODE_TOKEN'))

user = client.account.user_create(
    "your.email@example.com",
    "yourtestusername",
)

print(vars(user.grants))
user.delete()
```