### PR TITLE
test: Address pytest warnings; remove duplicate test helper

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,3 +89,9 @@ in-place = true
 recursive = true
 remove-all-unused-imports = true
 remove-duplicate-keys = false
+
+[tool.pytest.ini_options]
+markers = [
+    "smoke: mark a test as a smoke test",
+    "flaky: mark a test as a flaky test for rerun"
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dev = [
     "sphinxcontrib-fulltoc>=1.2.0",
     "build>=0.10.0",
     "twine>=4.0.2",
+    "pytest-rerunfailures",
 ]
 
 doc = [

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 markers =
     smoke: mark a test as a smoke test
-    flaky: mark a test as a flay test for rerun
+    flaky: mark a test as a flaky test for rerun

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,0 @@
-[pytest]
-markers =
-    smoke: mark a test as a smoke test
-    flaky: mark a test as a flaky test for rerun

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    smoke: mark a test as a smoke test
+    flaky: mark a test as an integration test

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 markers =
     smoke: mark a test as a smoke test
-    flaky: mark a test as an integration test
+    flaky: mark a test as a flay test for rerun

--- a/test/integration/helpers.py
+++ b/test/integration/helpers.py
@@ -12,12 +12,6 @@ def get_test_label():
     return label
 
 
-def get_rand_nanosec_test_label():
-    unique_timestamp = str(time.time_ns())[:-3]
-    label = "test_" + unique_timestamp
-    return label
-
-
 def delete_instance_with_test_kw(paginated_list: PaginatedList):
     for i in paginated_list:
         try:

--- a/test/integration/models/account/test_account.py
+++ b/test/integration/models/account/test_account.py
@@ -80,9 +80,10 @@ def test_latest_get_event(test_linode_client, e2e_test_firewall):
 
     latest_events = events._raw_json.get("data")
 
+    linode.delete()
+
     for event in latest_events[:15]:
         if label == event["entity"]["label"]:
-            linode.delete()
             break
     else:
         assert False, f"Linode '{label}' not found in the last 15 events"

--- a/test/integration/models/account/test_account.py
+++ b/test/integration/models/account/test_account.py
@@ -61,7 +61,7 @@ def test_get_account_settings(test_linode_client):
 
 
 @pytest.mark.smoke
-def test_latest_get_event(test_linode_client):
+def test_latest_get_event(test_linode_client, e2e_test_firewall):
     client = test_linode_client
 
     available_regions = client.regions()
@@ -69,7 +69,11 @@ def test_latest_get_event(test_linode_client):
     label = get_test_label()
 
     linode, password = client.linode.instance_create(
-        "g6-nanode-1", chosen_region, image="linode/debian10", label=label
+        "g6-nanode-1",
+        chosen_region,
+        image="linode/debian10",
+        label=label,
+        firewall=e2e_test_firewall,
     )
 
     events = client.load(Event, "")

--- a/test/integration/models/account/test_account.py
+++ b/test/integration/models/account/test_account.py
@@ -74,11 +74,14 @@ def test_latest_get_event(test_linode_client):
 
     events = client.load(Event, "")
 
-    latest_event = events._raw_json.get("data")[0]
+    latest_events = events._raw_json.get("data")
 
-    linode.delete()
-
-    assert label in latest_event["entity"]["label"]
+    for event in latest_events[:15]:
+        if label == event["entity"]["label"]:
+            linode.delete()
+            break
+    else:
+        assert False, f"Linode '{label}' not found in the last 15 events"
 
 
 def test_get_user(test_linode_client):

--- a/test/integration/models/firewall/test_firewall.py
+++ b/test/integration/models/firewall/test_firewall.py
@@ -1,4 +1,5 @@
 import time
+from test.integration.helpers import get_test_label
 
 import pytest
 
@@ -10,7 +11,7 @@ def linode_fw(test_linode_client):
     client = test_linode_client
     available_regions = client.regions()
     chosen_region = available_regions[4]
-    label = "linode_instance_fw_device"
+    label = get_test_label()
 
     linode_instance, password = client.linode.instance_create(
         "g6-nanode-1", chosen_region, image="linode/debian10", label=label
@@ -79,6 +80,6 @@ def test_get_device(test_linode_client, test_firewall, linode_fw):
         FirewallDevice, firewall.devices.first().id, firewall.id
     )
 
-    assert firewall_device.entity.label == "linode_instance_fw_device"
+    assert "test_" in firewall_device.entity.label
     assert firewall_device.entity.type == "linode"
     assert "/v4/linode/instances/" in firewall_device.entity.url

--- a/test/integration/models/networking/test_networking.py
+++ b/test/integration/models/networking/test_networking.py
@@ -1,4 +1,4 @@
-from test.integration.helpers import get_rand_nanosec_test_label
+from test.integration.helpers import get_test_label
 
 import pytest
 
@@ -22,7 +22,7 @@ def create_linode(test_linode_client):
     client = test_linode_client
     available_regions = client.regions()
     chosen_region = available_regions[4]
-    label = get_rand_nanosec_test_label()
+    label = get_test_label()
 
     linode_instance, _ = client.linode.instance_create(
         "g6-nanode-1",


### PR DESCRIPTION
## 📝 Description

- Remove pytest warnings on tests that are marked with `pytest.ini` file.
e.g.
```
test/integration/models/profile/test_profile.py:37
  /home/runner/work/linode_api4-python/linode_api4-python/test/integration/models/profile/test_profile.py:37: PytestUnknownMarkWarning: Unknown pytest.mark.flaky - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.flaky(reruns=3, reruns_delay=2)
```

- Remove duplicate test helper

- Add `pytest-rerunfailures` in pyproject.toml to allow `dev-install` to pick up the library during test runs

## ✔️ How to Test

`make testint`

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**