### PR TITLE
test: Fix slack payload in integration workflow

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -120,7 +120,7 @@ jobs:
                   "fields": [
                     {
                       "type": "mrkdwn",
-                      "text": "*Build Result:*\n${{ steps.integration-tests.outcome == 'success' && ':large_green_circle: Build Passed' || ':red_circle: Build Failed' }}"
+                      "text": "*Build Result:*\n${{ needs.integration-tests.result == 'success' && ':large_green_circle: Build Passed' || ':red_circle: Build Failed' }}"
                     },
                     {
                       "type": "mrkdwn",


### PR DESCRIPTION
## 📝 Description

Needed to use job status instead of step outcome
e.g.
```
"text": "*Build Result:*\n${{ steps.integration_tests.outcome == 'success' && ':large_green_circle: Build Passed' || ':red_circle: Build Failed' }}"
```
Instead need to use,
```
"text": "*Build Result:*\n${{ needs.integration_tests.result == 'success' && ':large_green_circle: Build Passed' || ':red_circle: Build Failed' }}"
```
## ✔️ How to Test

Tested on forked repo - https://github.com/ykim-1/linodego/actions/runs/11075403223

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**