### PR TITLE
test: Add job in E2E CI to attach firewall to any remaining instances

### DIFF
--- a/.github/workflows/e2e-test-pr.yml
+++ b/.github/workflows/e2e-test-pr.yml
@@ -71,14 +71,6 @@ jobs:
       - name: Install Python deps
         run: pip install -U setuptools wheel boto3 certifi
 
-      - name: Download kubectl and calicoctl for LKE clusters
-        run: |
-          curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
-          curl -LO "https://github.com/projectcalico/calico/releases/download/v3.25.0/calicoctl-linux-amd64"
-          chmod +x calicoctl-linux-amd64 kubectl
-          mv calicoctl-linux-amd64 /usr/local/bin/calicoctl
-          mv kubectl /usr/local/bin/kubectl
-
       - name: Install Python SDK
         run: make dev-install
         env:
@@ -89,13 +81,6 @@ jobs:
           timestamp=$(date +'%Y%m%d%H%M')
           report_filename="${timestamp}_sdk_test_report.xml"
           make testint TEST_ARGS="--junitxml=${report_filename}" TEST_SUITE="${{ github.event.inputs.test_suite }}"
-        env:
-          LINODE_TOKEN: ${{ secrets.LINODE_TOKEN }}
-
-      - name: Apply Calico Rules to LKE
-        if: always()
-        run: |
-          cd scripts && ./lke_calico_rules_e2e.sh
         env:
           LINODE_TOKEN: ${{ secrets.LINODE_TOKEN }}
 
@@ -141,3 +126,60 @@ jobs:
               conclusion: process.env.conclusion
             });
             return result;
+
+  apply-calico-rules:
+    runs-on: ubuntu-latest
+    needs: [integration-tests]
+    if: ${{ success() || failure() }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: 'recursive'
+
+      - name: Download kubectl and calicoctl for LKE clusters
+        run: |
+          curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
+          curl -LO "https://github.com/projectcalico/calico/releases/download/v3.25.0/calicoctl-linux-amd64"
+          chmod +x calicoctl-linux-amd64 kubectl
+          mv calicoctl-linux-amd64 /usr/local/bin/calicoctl
+          mv kubectl /usr/local/bin/kubectl
+
+      - name: Apply Calico Rules to LKE
+        run: |
+          cd e2e_scripts/cloud_security_scripts/lke_calico_rules/ && ./lke_calico_rules_e2e.sh
+        env:
+          LINODE_TOKEN: ${{ secrets.LINODE_TOKEN }}
+
+  add-fw-to-remaining-instances:
+    runs-on: ubuntu-latest
+    needs: [integration-tests]
+    if: ${{ success() || failure() }}
+
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install Linode CLI
+        run: |
+          pip install linode-cli
+
+      - name: Create Firewall and Attach to Instances
+        run: |
+          FIREWALL_ID=$(linode-cli firewalls create --label "e2e-fw-$(date +%s)" --rules.inbound_policy "DROP" --rules.outbound_policy "ACCEPT" --text --format=id --no-headers)
+          echo "Created Firewall with ID: $FIREWALL_ID"
+          
+          for instance_id in $(linode-cli linodes list --format "id" --text --no-header); do
+            echo "Attaching firewall to instance: $instance_id"
+            if linode-cli firewalls device-create "$FIREWALL_ID" --id "$instance_id" --type linode; then
+              echo "Firewall attached to instance $instance_id successfully."
+            else
+              echo "An error occurred while attaching firewall to instance $instance_id. Skipping..."
+            fi
+          done
+        env:
+          LINODE_CLI_TOKEN: ${{ secrets.LINODE_TOKEN }}

--- a/.github/workflows/e2e-test-pr.yml
+++ b/.github/workflows/e2e-test-pr.yml
@@ -129,7 +129,7 @@ jobs:
 
   apply-calico-rules:
     runs-on: ubuntu-latest
-    needs: [integration-tests]
+    needs: [integration-fork-ubuntu]
     if: ${{ success() || failure() }}
 
     steps:
@@ -155,7 +155,7 @@ jobs:
 
   add-fw-to-remaining-instances:
     runs-on: ubuntu-latest
-    needs: [integration-tests]
+    needs: [integration-fork-ubuntu]
     if: ${{ success() || failure() }}
 
     steps:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -50,14 +50,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Download kubectl and calicoctl for LKE clusters
-        run: |
-          curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
-          curl -LO "https://github.com/projectcalico/calico/releases/download/v3.25.0/calicoctl-linux-amd64"
-          chmod +x calicoctl-linux-amd64 kubectl
-          mv calicoctl-linux-amd64 /usr/local/bin/calicoctl
-          mv kubectl /usr/local/bin/kubectl
-
       - name: Set LINODE_TOKEN
         run: |
           echo "LINODE_TOKEN=${{ secrets[inputs.use_minimal_test_account == 'true' && 'MINIMAL_LINODE_TOKEN' || 'LINODE_TOKEN'] }}" >> $GITHUB_ENV
@@ -67,13 +59,6 @@ jobs:
           timestamp=$(date +'%Y%m%d%H%M')
           report_filename="${timestamp}_sdk_test_report.xml"
           make testint TEST_ARGS="--junitxml=${report_filename}"
-        env:
-          LINODE_TOKEN: ${{ env.LINODE_TOKEN }}
-
-      - name: Apply Calico Rules to LKE
-        if: always()
-        run: |
-          cd scripts && ./lke_calico_rules_e2e.sh
         env:
           LINODE_TOKEN: ${{ env.LINODE_TOKEN }}
 
@@ -92,10 +77,67 @@ jobs:
           LINODE_CLI_OBJ_ACCESS_KEY: ${{ secrets.LINODE_CLI_OBJ_ACCESS_KEY }}
           LINODE_CLI_OBJ_SECRET_KEY: ${{ secrets.LINODE_CLI_OBJ_SECRET_KEY }}
 
+  apply-calico-rules:
+    runs-on: ubuntu-latest
+    needs: [integration-tests]
+    if: ${{ success() || failure() }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: 'recursive'
+
+      - name: Download kubectl and calicoctl for LKE clusters
+        run: |
+          curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
+          curl -LO "https://github.com/projectcalico/calico/releases/download/v3.25.0/calicoctl-linux-amd64"
+          chmod +x calicoctl-linux-amd64 kubectl
+          mv calicoctl-linux-amd64 /usr/local/bin/calicoctl
+          mv kubectl /usr/local/bin/kubectl
+
+      - name: Apply Calico Rules to LKE
+        run: |
+          cd e2e_scripts/cloud_security_scripts/lke_calico_rules/ && ./lke_calico_rules_e2e.sh
+        env:
+          LINODE_TOKEN: ${{ env.LINODE_TOKEN }}
+
+  add-fw-to-remaining-instances:
+    runs-on: ubuntu-latest
+    needs: [integration-tests]
+    if: ${{ success() || failure() }}
+
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install Linode CLI
+        run: |
+          pip install linode-cli
+
+      - name: Create Firewall and Attach to Instances
+        run: |
+          FIREWALL_ID=$(linode-cli firewalls create --label "e2e-fw-$(date +%s)" --rules.inbound_policy "DROP" --rules.outbound_policy "ACCEPT" --text --format=id --no-headers)
+          echo "Created Firewall with ID: $FIREWALL_ID"
+          
+          for instance_id in $(linode-cli linodes list --format "id" --text --no-header); do
+            echo "Attaching firewall to instance: $instance_id"
+            if linode-cli firewalls device-create "$FIREWALL_ID" --id "$instance_id" --type linode; then
+              echo "Firewall attached to instance $instance_id successfully."
+            else
+              echo "An error occurred while attaching firewall to instance $instance_id. Skipping..."
+            fi
+          done
+        env:
+          LINODE_CLI_TOKEN: ${{ env.LINODE_TOKEN }}
+
   notify-slack:
     runs-on: ubuntu-latest
     needs: [integration-tests]
-    if: always() && github.repository == 'linode/linode_api4-python' # Run even if integration tests fail and only on main repository
+    if: ${{ (success() || failure()) && github.repository == 'linode/linode_api4-python' }} # Run even if integration tests fail and only on main repository
 
     steps:
       - name: Notify Slack


### PR DESCRIPTION
## 📝 Description

Adding `add-fw-to-remaining-instances` job to E2E CIs to ensure all remaining instances or nodes have CFW attached

## ✔️ How to Test

Passing on CLI integration workflow, the job is essentially the same - https://github.com/linode/linode-cli/actions/runs/11634047963

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**