### PR TITLE
CI: Notify slack channel on releases

### DIFF
--- a/.github/workflows/release-notify-slack.yml
+++ b/.github/workflows/release-notify-slack.yml
@@ -12,7 +12,7 @@ jobs:
         id: main_message
         uses: slackapi/slack-github-action@v1.27.0
         with:
-          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          channel-id: ${{ secrets.DEV_DX_SLACK_CHANNEL_ID }}
           payload: |
             {
               "blocks": [
@@ -31,7 +31,7 @@ jobs:
       - name: Notify Slack - Threaded Release Notes
         uses: slackapi/slack-github-action@v1.27.0
         with:
-          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          channel-id: ${{ secrets.DEV_DX_SLACK_CHANNEL_ID }}
           payload: |
             {
               "thread_ts": "${{ steps.main_message.outputs.ts }}",

--- a/.github/workflows/release-notify-slack.yml
+++ b/.github/workflows/release-notify-slack.yml
@@ -1,9 +1,12 @@
 name: Notify Dev DX Channel on Release
-
 on:
   release:
+    workflow_dispatch: null
     types: [published]
-#    if: github-token.repository == 'linode/linode_api4-python'
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
     steps:
       - name: Notify Slack - Main Message
         id: main_message
@@ -12,18 +15,17 @@ on:
           channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
           payload: |
             {
-              "text": "*New Release Published in ${{ github.repository }}!*",
               "blocks": [
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*<${{ github.event.release.html_url }}|${{ github.repository }}: ${{ github.event.release.tag_name }}>* is now live! :tada:"
+                    "text": "*New Release Published: _linode_api4-python_ - ${{ github.event.release.tag_name }} is now live!* :tada:"
                   }
                 }
               ]
             }
-          env:
+        env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
       - name: Notify Slack - Threaded Release Notes
@@ -33,7 +35,7 @@ on:
           payload: |
             {
               "thread_ts": "${{ steps.main_message.outputs.ts }}",
-              "text": "Release Notes:\n${{ github.event.release.body }}"
+              "text": "*<${{ github.event.release.html_url }}| ${{ github.event.release.tag_name }} Release notes>*"
             }
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/release-notify-slack.yml
+++ b/.github/workflows/release-notify-slack.yml
@@ -1,11 +1,12 @@
 name: Notify Dev DX Channel on Release
 on:
   release:
-    workflow_dispatch: null
     types: [published]
+  workflow_dispatch: null
 
 jobs:
   notify:
+#    if: github.repository == 'linode/linode_api4-python'
     runs-on: ubuntu-latest
     steps:
       - name: Notify Slack - Main Message
@@ -20,7 +21,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*New Release Published: _linode_api4-python_ - ${{ github.event.release.tag_name }} is now live!* :tada:"
+                    "text": "*New Release Published: _linode_api4-python_ <${{ github.event.release.html_url }}|${{ github.event.release.tag_name }}> is now live!* :tada:"
                   }
                 }
               ]
@@ -28,14 +29,3 @@ jobs:
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
-      - name: Notify Slack - Threaded Release Notes
-        uses: slackapi/slack-github-action@v1.27.0
-        with:
-          channel-id: ${{ secrets.DEV_DX_SLACK_CHANNEL_ID }}
-          payload: |
-            {
-              "thread_ts": "${{ steps.main_message.outputs.ts }}",
-              "text": "*<${{ github.event.release.html_url }}| ${{ github.event.release.tag_name }} Release notes>*"
-            }
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/release-notify-slack.yml
+++ b/.github/workflows/release-notify-slack.yml
@@ -1,0 +1,39 @@
+name: Notify Dev DX Channel on Release
+
+on:
+  release:
+    types: [published]
+#    if: github-token.repository == 'linode/linode_api4-python'
+    steps:
+      - name: Notify Slack - Main Message
+        id: main_message
+        uses: slackapi/slack-github-action@v1.27.0
+        with:
+          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          payload: |
+            {
+              "text": "*New Release Published in ${{ github.repository }}!*",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*<${{ github.event.release.html_url }}|${{ github.repository }}: ${{ github.event.release.tag_name }}>* is now live! :tada:"
+                  }
+                }
+              ]
+            }
+          env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
+      - name: Notify Slack - Threaded Release Notes
+        uses: slackapi/slack-github-action@v1.27.0
+        with:
+          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          payload: |
+            {
+              "thread_ts": "${{ steps.main_message.outputs.ts }}",
+              "text": "Release Notes:\n${{ github.event.release.body }}"
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/release-notify-slack.yml
+++ b/.github/workflows/release-notify-slack.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   notify:
-#    if: github.repository == 'linode/linode_api4-python'
+    if: github.repository == 'linode/linode_api4-python'
     runs-on: ubuntu-latest
     steps:
       - name: Notify Slack - Main Message


### PR DESCRIPTION
## 📝 Description

Notify `dev-dx` slack channel upon release publication.

Main message announces release notice followed by threaded message for release notes link. Refer to images below

## ✔️ How to Test

Tested on my forked and private channel
E.g.
![image](https://github.com/user-attachments/assets/b0094fb4-0b58-436a-a41f-8d4cecd46c58)


## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**