### PR TITLE
test: Allow integration and unit tests to run against EOL or desired python version

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -12,7 +12,7 @@ on:
         required: false
         default: ''
       run-eol-python-version:
-        description: 'Run EOL version python version?'
+        description: 'Run EOL python version?'
         required: false
         default: 'false'
         type: choice

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -11,6 +11,10 @@ on:
         description: 'The hash value of the commit'
         required: false
         default: ''
+      python-version:
+        description: 'Specify Python version to use'
+        required: false
+        default: '3.10'
       run-eol-python-version:
         description: 'Run EOL python version?'
         required: false
@@ -23,7 +27,6 @@ on:
     branches:
       - main
       - dev
-
 
 jobs:
   integration-tests:
@@ -49,7 +52,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ inputs.run-eol-python-version == 'true' && '3.9' || '3.10' }}
+          python-version: ${{ inputs.run-eol-python-version == 'true' && '3.9' || inputs.python-version }}
 
       - name: Install Python deps
         run: pip install -U setuptools wheel boto3 certifi

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -11,10 +11,19 @@ on:
         description: 'The hash value of the commit'
         required: false
         default: ''
+      run-eol-python-version:
+        description: 'Run EOL version python version?'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
   push:
     branches:
       - main
       - dev
+
 
 jobs:
   integration-tests:
@@ -40,7 +49,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: ${{ inputs.run-eol-python-version == 'true' && '3.9' || '3.10' }}
 
       - name: Install Python deps
         run: pip install -U setuptools wheel boto3 certifi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8','3.9','3.10','3.11', '3.12']
+        python-version: ['3.9','3.10','3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
## 📝 Description

This PR adds workflow_dispatch input to allow e2e tests run against EOL python version as an option. Also remove 3.8 from unit test matrix as it is no longer supported.

e.g. 
![image](https://github.com/user-attachments/assets/51729b95-7336-497d-ae0f-0fc012a008e3)

## ✔️ How to Test

Forked e2e run with EOL:
- 3.9: https://github.com/ykim-akamai/linode_api4-python/actions/runs/11635801524/job/32405918836


## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**