### PR TITLE
test: Update warm resizing test case

### DIFF
--- a/test/integration/models/linode/test_linode.py
+++ b/test/integration/models/linode/test_linode.py
@@ -392,7 +392,7 @@ def test_linode_resize_with_migration_type(
         # there is no resizing state in warm migration anymore hence wait for resizing and poll event
         test_linode_client.polling.event_poller_create(
             "linode", "linode_resize", entity_id=linode.id
-        ).wait_for_next_event_finished(interval=5)
+        ).wait_for_next_event_finished(interval=5, timeout=500)
 
         wait_for_condition(
             10,


### PR DESCRIPTION
## 📝 Description

Seems like `test_linode_resize_with_migration_type` is taking considerably longer to complete, hence increasing the event polling timeout value

## ✔️ How to Test

`make TEST_CASE="test_linode_resize_with_migration_type -v" testint`

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**