### PR TITLE
CI: Set token for security jobs in e2e test workflow

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -103,6 +103,10 @@ jobs:
           fetch-depth: 0
           submodules: 'recursive'
 
+      - name: Set LINODE_TOKEN
+        run: |
+          echo "LINODE_TOKEN=${{ secrets[inputs.use_minimal_test_account == 'true' && 'MINIMAL_LINODE_TOKEN' || 'LINODE_TOKEN'] }}" >> $GITHUB_ENV
+
       - name: Download kubectl and calicoctl for LKE clusters
         run: |
           curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
@@ -131,6 +135,10 @@ jobs:
       - name: Install Linode CLI
         run: |
           pip install linode-cli
+
+      - name: Set LINODE_TOKEN
+        run: |
+          echo "LINODE_TOKEN=${{ secrets[inputs.use_minimal_test_account == 'true' && 'MINIMAL_LINODE_TOKEN' || 'LINODE_TOKEN'] }}" >> $GITHUB_ENV
 
       - name: Create Firewall and Attach to Instances
         run: |


### PR DESCRIPTION
## 📝 Description

Forgot to set token for the security jobs e.g. apply-calico-rules, add-fw-to-remaining-instances

## ✔️ How to Test

Passed on CLI repo which is using basically the same code: https://github.com/linode/linode-cli/actions/runs/11708470979
Forked run - https://github.com/ykim-akamai/linode_api4-python/actions/runs/11808463187 (Test failures are not related)

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**