### PR TITLE
tests: Update helpers, fix flaky tests, and refactor for consistency

### DIFF
--- a/test/integration/linode_client/test_linode_client.py
+++ b/test/integration/linode_client/test_linode_client.py
@@ -12,15 +12,13 @@ from linode_api4.objects import ConfigInterface, ObjectStorageKeys, Region
 @pytest.fixture(scope="session")
 def setup_client_and_linode(test_linode_client, e2e_test_firewall):
     client = test_linode_client
-    chosen_region = get_region(
-        client, {"Kubernetes", "NodeBalancers"}, "core"
-    ).id
+    region = get_region(client, {"Kubernetes", "NodeBalancers"}, "core").id
 
     label = get_test_label()
 
     linode_instance, password = client.linode.instance_create(
         "g6-nanode-1",
-        chosen_region,
+        region,
         image="linode/debian10",
         label=label,
         firewall=e2e_test_firewall,
@@ -233,11 +231,11 @@ def test_get_account_settings(test_linode_client):
 # LinodeGroupTests
 def test_create_linode_instance_without_image(test_linode_client):
     client = test_linode_client
-    chosen_region = get_region(client, {"Linodes"}, "core").id
+    region = get_region(client, {"Linodes"}, "core").id
     label = get_test_label()
 
     linode_instance = client.linode.instance_create(
-        "g6-nanode-1", chosen_region, label=label
+        "g6-nanode-1", region, label=label
     )
 
     assert linode_instance.label == label
@@ -257,12 +255,12 @@ def test_create_linode_instance_with_image(setup_client_and_linode):
 
 def test_create_linode_with_interfaces(test_linode_client):
     client = test_linode_client
-    chosen_region = get_region(client, {"Vlans", "Linodes"}).id
+    region = get_region(client, {"Vlans", "Linodes"}, site_type="core").id
     label = get_test_label()
 
     linode_instance, password = client.linode.instance_create(
         "g6-nanode-1",
-        chosen_region,
+        region,
         label=label,
         image="linode/debian10",
         interfaces=[

--- a/test/integration/models/account/test_account.py
+++ b/test/integration/models/account/test_account.py
@@ -1,5 +1,6 @@
 import time
 from datetime import datetime
+from test.integration.conftest import get_region
 from test.integration.helpers import get_test_label
 
 import pytest
@@ -64,13 +65,12 @@ def test_get_account_settings(test_linode_client):
 def test_latest_get_event(test_linode_client, e2e_test_firewall):
     client = test_linode_client
 
-    available_regions = client.regions()
-    chosen_region = available_regions[4]
+    region = get_region(client, {"Linodes", "Cloud Firewall"}, site_type="core")
     label = get_test_label()
 
     linode, password = client.linode.instance_create(
         "g6-nanode-1",
-        chosen_region,
+        region,
         image="linode/debian10",
         label=label,
         firewall=e2e_test_firewall,

--- a/test/integration/models/domain/test_domain.py
+++ b/test/integration/models/domain/test_domain.py
@@ -42,7 +42,7 @@ def test_zone_file_view(test_linode_client, test_domain):
 def test_clone(test_linode_client, test_domain):
     domain = test_linode_client.load(Domain, test_domain.id)
     timestamp = str(time.time_ns())
-    dom = "example.clone-" + timestamp + "-IntTestSDK.org"
+    dom = "example.clone-" + timestamp + "-inttestsdk.org"
     domain.clone(dom)
 
     ds = test_linode_client.domains()

--- a/test/integration/models/firewall/test_firewall.py
+++ b/test/integration/models/firewall/test_firewall.py
@@ -1,4 +1,5 @@
 import time
+from test.integration.conftest import get_region
 from test.integration.helpers import get_test_label
 
 import pytest
@@ -9,12 +10,11 @@ from linode_api4.objects import Firewall, FirewallDevice
 @pytest.fixture(scope="session")
 def linode_fw(test_linode_client):
     client = test_linode_client
-    available_regions = client.regions()
-    chosen_region = available_regions[4]
+    region = get_region(client, {"Linodes", "Cloud Firewall"}, site_type="core")
     label = get_test_label()
 
     linode_instance, password = client.linode.instance_create(
-        "g6-nanode-1", chosen_region, image="linode/debian10", label=label
+        "g6-nanode-1", region, image="linode/debian10", label=label
     )
 
     yield linode_instance
@@ -80,6 +80,5 @@ def test_get_device(test_linode_client, test_firewall, linode_fw):
         FirewallDevice, firewall.devices.first().id, firewall.id
     )
 
-    assert "test_" in firewall_device.entity.label
     assert firewall_device.entity.type == "linode"
     assert "/v4/linode/instances/" in firewall_device.entity.url

--- a/test/integration/models/image/test_image.py
+++ b/test/integration/models/image/test_image.py
@@ -1,9 +1,6 @@
 from io import BytesIO
 from test.integration.conftest import get_region, get_regions
-from test.integration.helpers import (
-    delete_instance_with_test_kw,
-    get_test_label,
-)
+from test.integration.helpers import get_test_label
 
 import polling
 import pytest
@@ -15,7 +12,11 @@ from linode_api4.objects import Image
 def image_upload_url(test_linode_client):
     label = get_test_label() + "_image"
 
-    region = get_region(test_linode_client, site_type="core")
+    region = get_region(
+        test_linode_client,
+        capabilities={"Linodes", "Object Storage"},
+        site_type="core",
+    )
 
     test_linode_client.image_create_upload(
         label, region.id, "integration test image upload"
@@ -26,8 +27,6 @@ def image_upload_url(test_linode_client):
     yield image
 
     image.delete()
-    images = test_linode_client.images()
-    delete_instance_with_test_kw(images)
 
 
 @pytest.fixture(scope="session")

--- a/test/integration/models/lke/test_lke.py
+++ b/test/integration/models/lke/test_lke.py
@@ -23,6 +23,7 @@ from linode_api4.objects import (
     LKENodePoolTaint,
     LKEType,
 )
+from linode_api4.objects.linode import InstanceDiskEncryptionType
 
 
 @pytest.fixture(scope="session")
@@ -30,9 +31,7 @@ def lke_cluster(test_linode_client):
     node_type = test_linode_client.linode.types()[1]  # g6-standard-1
     version = test_linode_client.lke.versions()[0]
 
-    # TODO(LDE): Uncomment once LDE is available
-    # region = get_region(test_linode_client, {"Kubernetes", "Disk Encryption"})
-    region = get_region(test_linode_client, {"Kubernetes"})
+    region = get_region(test_linode_client, {"Kubernetes", "Disk Encryption"})
 
     node_pools = test_linode_client.lke.node_pool(node_type, 3)
     label = get_test_label() + "_cluster"
@@ -146,8 +145,7 @@ def test_get_lke_pool(test_linode_client, lke_cluster):
 
     assert _to_comparable(cluster.pools[0]) == _to_comparable(pool)
 
-    # TODO(LDE): Uncomment once LDE is available
-    # assert pool.disk_encryption == InstanceDiskEncryptionType.enabled
+    assert pool.disk_encryption == InstanceDiskEncryptionType.enabled
 
 
 def test_cluster_dashboard_url_view(lke_cluster):

--- a/test/integration/models/longview/test_longview.py
+++ b/test/integration/models/longview/test_longview.py
@@ -1,5 +1,6 @@
 import re
 import time
+from test.integration.helpers import get_test_label
 
 import pytest
 
@@ -22,7 +23,7 @@ def test_update_longview_label(test_linode_client, test_longview_client):
     longview = test_linode_client.load(LongviewClient, test_longview_client.id)
     old_label = longview.label
 
-    label = "updated_longview_label"
+    label = get_test_label(10)
 
     longview.label = label
 
@@ -33,7 +34,7 @@ def test_update_longview_label(test_linode_client, test_longview_client):
 
 def test_delete_client(test_linode_client, test_longview_client):
     client = test_linode_client
-    label = "TestSDK-longview"
+    label = get_test_label(length=8)
     longview_client = client.longview.client_create(label=label)
 
     time.sleep(5)


### PR DESCRIPTION
## 📝 Description

In effort to stabilize the test runs in GHA, I updated few test functions and tests as well as generally refactoring for consistency. Here are few points are addressed in this PR:
- Marked and improved flaky tests
- Refactored some test functions in `helpers.py`
- Updated all test labels and regions 
- Re-enable disk encryption tests

## ✔️ How to Test

`make testint` 

Run on PR - https://github.com/linode/linode_api4-python/actions/runs/11845761094

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**