### PR TITLE
Make use of `_flatten_request_body_recursive(...)` wherever possible

### DIFF
--- a/linode_api4/groups/database.py
+++ b/linode_api4/groups/database.py
@@ -1,13 +1,13 @@
 from linode_api4.errors import UnexpectedResponseError
 from linode_api4.groups import Group
 from linode_api4.objects import (
-    Base,
     Database,
     DatabaseEngine,
     DatabaseType,
     MySQLDatabase,
     PostgreSQLDatabase,
 )
+from linode_api4.objects.base import _flatten_request_body_recursive
 
 
 class DatabaseGroup(Group):
@@ -126,13 +126,16 @@ class DatabaseGroup(Group):
 
         params = {
             "label": label,
-            "region": region.id if issubclass(type(region), Base) else region,
-            "engine": engine.id if issubclass(type(engine), Base) else engine,
-            "type": ltype.id if issubclass(type(ltype), Base) else ltype,
+            "region": region,
+            "engine": engine,
+            "type": ltype,
         }
         params.update(kwargs)
 
-        result = self.client.post("/databases/mysql/instances", data=params)
+        result = self.client.post(
+            _flatten_request_body_recursive("/databases/mysql/instances"),
+            data=params,
+        )
 
         if "id" not in result:
             raise UnexpectedResponseError(
@@ -191,14 +194,15 @@ class DatabaseGroup(Group):
 
         params = {
             "label": label,
-            "region": region.id if issubclass(type(region), Base) else region,
-            "engine": engine.id if issubclass(type(engine), Base) else engine,
-            "type": ltype.id if issubclass(type(ltype), Base) else ltype,
+            "region": region,
+            "engine": engine,
+            "type": ltype,
         }
         params.update(kwargs)
 
         result = self.client.post(
-            "/databases/postgresql/instances", data=params
+            "/databases/postgresql/instances",
+            data=_flatten_request_body_recursive(params),
         )
 
         if "id" not in result:

--- a/linode_api4/groups/database.py
+++ b/linode_api4/groups/database.py
@@ -1,13 +1,13 @@
 from linode_api4.errors import UnexpectedResponseError
 from linode_api4.groups import Group
 from linode_api4.objects import (
+    Base,
     Database,
     DatabaseEngine,
     DatabaseType,
     MySQLDatabase,
     PostgreSQLDatabase,
 )
-from linode_api4.objects.base import _flatten_request_body_recursive
 
 
 class DatabaseGroup(Group):
@@ -126,16 +126,13 @@ class DatabaseGroup(Group):
 
         params = {
             "label": label,
-            "region": region,
-            "engine": engine,
-            "type": ltype,
+            "region": region.id if issubclass(type(region), Base) else region,
+            "engine": engine.id if issubclass(type(engine), Base) else engine,
+            "type": ltype.id if issubclass(type(ltype), Base) else ltype,
         }
         params.update(kwargs)
 
-        result = self.client.post(
-            _flatten_request_body_recursive("/databases/mysql/instances"),
-            data=params,
-        )
+        result = self.client.post("/databases/mysql/instances", data=params)
 
         if "id" not in result:
             raise UnexpectedResponseError(
@@ -194,15 +191,14 @@ class DatabaseGroup(Group):
 
         params = {
             "label": label,
-            "region": region,
-            "engine": engine,
-            "type": ltype,
+            "region": region.id if issubclass(type(region), Base) else region,
+            "engine": engine.id if issubclass(type(engine), Base) else engine,
+            "type": ltype.id if issubclass(type(ltype), Base) else ltype,
         }
         params.update(kwargs)
 
         result = self.client.post(
-            "/databases/postgresql/instances",
-            data=_flatten_request_body_recursive(params),
+            "/databases/postgresql/instances", data=params
         )
 
         if "id" not in result:

--- a/linode_api4/groups/image.py
+++ b/linode_api4/groups/image.py
@@ -4,7 +4,8 @@ import requests
 
 from linode_api4.errors import UnexpectedResponseError
 from linode_api4.groups import Group
-from linode_api4.objects import Base, Disk, Image
+from linode_api4.objects import Disk, Image
+from linode_api4.objects.base import _flatten_request_body_recursive
 from linode_api4.util import drop_null_keys
 
 
@@ -58,7 +59,7 @@ class ImageGroup(Group):
         :rtype: Image
         """
         params = {
-            "disk_id": disk.id if issubclass(type(disk), Base) else disk,
+            "disk_id": disk,
             "label": label,
             "description": description,
             "tags": tags,
@@ -67,7 +68,10 @@ class ImageGroup(Group):
         if cloud_init:
             params["cloud_init"] = cloud_init
 
-        result = self.client.post("/images", data=drop_null_keys(params))
+        result = self.client.post(
+            "/images",
+            data=_flatten_request_body_recursive(drop_null_keys(params)),
+        )
 
         if not "id" in result:
             raise UnexpectedResponseError(

--- a/linode_api4/groups/volume.py
+++ b/linode_api4/groups/volume.py
@@ -1,6 +1,7 @@
 from linode_api4.errors import UnexpectedResponseError
 from linode_api4.groups import Group
-from linode_api4.objects import Base, Volume, VolumeType
+from linode_api4.objects import Volume, VolumeType
+from linode_api4.objects.base import _flatten_request_body_recursive
 
 
 class VolumeGroup(Group):
@@ -57,14 +58,15 @@ class VolumeGroup(Group):
         params = {
             "label": label,
             "size": size,
-            "region": region.id if issubclass(type(region), Base) else region,
-            "linode_id": (
-                linode.id if issubclass(type(linode), Base) else linode
-            ),
+            "region": region,
+            "linode_id": linode,
         }
         params.update(kwargs)
 
-        result = self.client.post("/volumes", data=params)
+        result = self.client.post(
+            "/volumes",
+            data=_flatten_request_body_recursive(params),
+        )
 
         if not "id" in result:
             raise UnexpectedResponseError(

--- a/linode_api4/objects/linode.py
+++ b/linode_api4/objects/linode.py
@@ -8,10 +8,14 @@ from random import randint
 from typing import Any, Dict, List, Optional, Union
 from urllib import parse
 
-from linode_api4 import util
 from linode_api4.common import load_and_validate_keys
 from linode_api4.errors import UnexpectedResponseError
-from linode_api4.objects.base import Base, MappedObject, Property
+from linode_api4.objects.base import (
+    Base,
+    MappedObject,
+    Property,
+    _flatten_request_body_recursive,
+)
 from linode_api4.objects.dbase import DerivedBase
 from linode_api4.objects.filtering import FilterableAttribute
 from linode_api4.objects.image import Image
@@ -26,6 +30,7 @@ from linode_api4.objects.region import Region
 from linode_api4.objects.serializable import JSONObject, StrEnum
 from linode_api4.objects.vpc import VPC, VPCSubnet
 from linode_api4.paginated_list import PaginatedList
+from linode_api4.util import drop_null_keys
 
 PASSWORD_CHARS = string.ascii_letters + string.digits + string.punctuation
 
@@ -96,14 +101,14 @@ class Backup(DerivedBase):
         """
 
         d = {
-            "linode_id": (
-                linode.id if issubclass(type(linode), Base) else linode
-            ),
+            "linode_id": linode,
         }
         d.update(kwargs)
 
         self._client.post(
-            "{}/restore".format(Backup.api_endpoint), model=self, data=d
+            "{}/restore".format(Backup.api_endpoint),
+            model=self,
+            data=_flatten_request_body_recursive(d),
         )
         return True
 
@@ -1063,8 +1068,6 @@ class Instance(Base):
         :rtype: bool
         """
 
-        new_type = new_type.id if issubclass(type(new_type), Base) else new_type
-
         params = {
             "type": new_type,
             "allow_auto_disk_resize": allow_auto_disk_resize,
@@ -1073,7 +1076,9 @@ class Instance(Base):
         params.update(kwargs)
 
         resp = self._client.post(
-            "{}/resize".format(Instance.api_endpoint), model=self, data=params
+            "{}/resize".format(Instance.api_endpoint),
+            model=self,
+            data=_flatten_request_body_recursive(params),
         )
 
         if "error" in resp:
@@ -1189,7 +1194,7 @@ class Instance(Base):
             param_interfaces.append(interface)
 
         params = {
-            "kernel": kernel.id if issubclass(type(kernel), Base) else kernel,
+            "kernel": kernel,
             "label": (
                 label
                 if label
@@ -1201,7 +1206,9 @@ class Instance(Base):
         params.update(kwargs)
 
         result = self._client.post(
-            "{}/configs".format(Instance.api_endpoint), model=self, data=params
+            "{}/configs".format(Instance.api_endpoint),
+            model=self,
+            data=_flatten_request_body_recursive(params),
         )
         self.invalidate()
 
@@ -1280,6 +1287,7 @@ class Instance(Base):
             "filesystem": filesystem,
             "authorized_keys": authorized_keys,
             "authorized_users": authorized_users,
+            "stackscript_id": stackscript,
         }
 
         if disk_encryption is not None:
@@ -1288,20 +1296,18 @@ class Instance(Base):
         if image:
             params.update(
                 {
-                    "image": (
-                        image.id if issubclass(type(image), Base) else image
-                    ),
+                    "image": image,
                     "root_pass": root_pass,
                 }
             )
 
-        if stackscript:
-            params["stackscript_id"] = stackscript.id
-            if stackscript_args:
-                params["stackscript_data"] = stackscript_args
+        if stackscript_args:
+            params["stackscript_data"] = stackscript_args
 
         result = self._client.post(
-            "{}/disks".format(Instance.api_endpoint), model=self, data=params
+            "{}/disks".format(Instance.api_endpoint),
+            model=self,
+            data=_flatten_request_body_recursive(drop_null_keys(params)),
         )
         self.invalidate()
 
@@ -1461,18 +1467,20 @@ class Instance(Base):
         authorized_keys = load_and_validate_keys(authorized_keys)
 
         params = {
-            "image": image.id if issubclass(type(image), Base) else image,
+            "image": image,
             "root_pass": root_pass,
             "authorized_keys": authorized_keys,
+            "disk_encryption": (
+                str(disk_encryption) if disk_encryption else None
+            ),
         }
-
-        if disk_encryption is not None:
-            params["disk_encryption"] = str(disk_encryption)
 
         params.update(kwargs)
 
         result = self._client.post(
-            "{}/rebuild".format(Instance.api_endpoint), model=self, data=params
+            "{}/rebuild".format(Instance.api_endpoint),
+            model=self,
+            data=_flatten_request_body_recursive(drop_null_keys(params)),
         )
 
         if not "id" in result:
@@ -1597,7 +1605,7 @@ class Instance(Base):
         """
 
         params = {
-            "region": region.id if issubclass(type(region), Base) else region,
+            "region": region,
             "upgrade": upgrade,
             "type": migration_type,
             "placement_group": _expand_placement_group_assignment(
@@ -1605,10 +1613,10 @@ class Instance(Base):
             ),
         }
 
-        util.drop_null_keys(params)
-
         self._client.post(
-            "{}/migrate".format(Instance.api_endpoint), model=self, data=params
+            "{}/migrate".format(Instance.api_endpoint),
+            model=self,
+            data=_flatten_request_body_recursive(drop_null_keys(params)),
         )
 
     def firewalls(self):
@@ -1740,21 +1748,12 @@ class Instance(Base):
         if not isinstance(disks, list) and not isinstance(disks, PaginatedList):
             disks = [disks]
 
-        cids = [c.id if issubclass(type(c), Base) else c for c in configs]
-        dids = [d.id if issubclass(type(d), Base) else d for d in disks]
-
         params = {
-            "linode_id": (
-                to_linode.id if issubclass(type(to_linode), Base) else to_linode
-            ),
-            "region": region.id if issubclass(type(region), Base) else region,
-            "type": (
-                instance_type.id
-                if issubclass(type(instance_type), Base)
-                else instance_type
-            ),
-            "configs": cids if cids else None,
-            "disks": dids if dids else None,
+            "linode_id": to_linode,
+            "region": region,
+            "type": instance_type,
+            "configs": configs,
+            "disks": disks,
             "label": label,
             "group": group,
             "with_backups": with_backups,
@@ -1763,10 +1762,10 @@ class Instance(Base):
             ),
         }
 
-        util.drop_null_keys(params)
-
         result = self._client.post(
-            "{}/clone".format(Instance.api_endpoint), model=self, data=params
+            "{}/clone".format(Instance.api_endpoint),
+            model=self,
+            data=_flatten_request_body_recursive(drop_null_keys(params)),
         )
 
         if not "id" in result:


### PR DESCRIPTION
## 📝 Description

This pull request updates the implementation of various endpoint methods to make use of the `_flatten_request_body_recursive(...)` helper, which eliminates the need to use the `x.id if issubclass(x, Base) else x` pattern. 

Additionally, this change adds a few extra keyword argument type hints where necessary.

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally and run `make install`

### Integration Testing

```
make testint
```

### Unit Testing

```
make testunit
```