### PR TITLE
TPT-3319: Add support for Apply Linode Firewalls

### DIFF
--- a/linode_api4/objects/linode.py
+++ b/linode_api4/objects/linode.py
@@ -1638,6 +1638,22 @@ class Instance(Base):
             for firewall in result["data"]
         ]
 
+    def apply_firewalls(self):
+        """
+        Reapply assigned firewalls to a Linode in case they were not applied successfully.
+
+        API Documentation: https://techdocs.akamai.com/linode-api/reference/post-apply-firewalls
+
+        :returns: Returns True if the operation was successful
+        :rtype: bool
+        """
+
+        self._client.post(
+            "{}/firewalls/apply".format(Instance.api_endpoint), model=self
+        )
+
+        return True
+
     def nodebalancers(self):
         """
         View a list of NodeBalancers that are assigned to this Linode and readable by the requesting User.

--- a/test/integration/models/linode/test_linode.py
+++ b/test/integration/models/linode/test_linode.py
@@ -38,7 +38,7 @@ def linode_with_volume_firewall(test_linode_client):
     linode_instance, password = client.linode.instance_create(
         "g6-nanode-1",
         region,
-        image="linode/debian10",
+        image="linode/debian12",
         label=label + "_modlinode",
     )
 

--- a/test/integration/models/linode/test_linode.py
+++ b/test/integration/models/linode/test_linode.py
@@ -426,6 +426,14 @@ def test_linode_firewalls(linode_with_volume_firewall):
     assert "firewall" in firewalls[0].label
 
 
+def test_linode_apply_firewalls(linode_with_volume_firewall):
+    linode = linode_with_volume_firewall
+
+    result = linode.apply_firewalls()
+
+    assert result
+
+
 def test_linode_volumes(linode_with_volume_firewall):
     linode = linode_with_volume_firewall
 

--- a/test/unit/objects/linode_test.py
+++ b/test/unit/objects/linode_test.py
@@ -284,6 +284,19 @@ class LinodeTest(ClientBaseCase):
             self.assertEqual(m.call_url, "/linode/instances/123/firewalls")
             self.assertEqual(len(result), 1)
 
+    def test_apply_firewalls(self):
+        """
+        Tests that you can submit a correct apply firewalls api request
+        """
+        linode = Instance(self.client, 123)
+
+        with self.mock_post({}) as m:
+            result = linode.apply_firewalls()
+            self.assertEqual(
+                m.call_url, "/linode/instances/123/firewalls/apply"
+            )
+            self.assertEqual(result, True)
+
     def test_volumes(self):
         """
         Tests that you can submit a correct volumes api request


### PR DESCRIPTION
## 📝 Description

This adds support for the `POST /linode/instances/:id/firewalls/apply` endpoint.

https://techdocs.akamai.com/linode-api/reference/post-apply-firewalls

## ✔️ How to Test
Code example:
```python
    client = LinodeClient(os.getenv("LINODE_TOKEN"))

    # linode_id = YOUR LINODE ID

    linode = Instance(client, linode_id)
    linode.apply_firewalls() # Returns True if successful 
```

**Integration test:**
```
make TEST_CASE=test_linode_apply_firewall testint
```

**Unit tests:**
```
make testunit
```