### PR TITLE
Add support for Nodebalancers UDP

### DIFF
--- a/linode_api4/objects/nodebalancer.py
+++ b/linode_api4/objects/nodebalancer.py
@@ -76,6 +76,13 @@ class NodeBalancerConfig(DerivedBase):
     """
     The configuration information for a single port of this NodeBalancer.
 
+    When attempting to update a NodeBalancerConfig with UDP protocol, consider setting the cipher_suite field to Null
+    using the ExplicitNullValue class::
+
+        config.udp_check_port = 4321
+        config.cipher_suite = ExplicitNullValue
+        config.save()
+
     API documentation: https://techdocs.akamai.com/linode-api/reference/get-node-balancer-config
     """
 
@@ -97,6 +104,8 @@ class NodeBalancerConfig(DerivedBase):
         "check_path": Property(mutable=True),
         "check_body": Property(mutable=True),
         "check_passive": Property(mutable=True),
+        "udp_check_port": Property(mutable=True),
+        "udp_session_timeout": Property(),
         "ssl_cert": Property(mutable=True),
         "ssl_key": Property(mutable=True),
         "ssl_commonname": Property(),
@@ -233,6 +242,7 @@ class NodeBalancer(Base):
         "configs": Property(derived_class=NodeBalancerConfig),
         "transfer": Property(),
         "tags": Property(mutable=True, unordered=True),
+        "client_udp_sess_throttle": Property(mutable=True),
     }
 
     # create derived objects

--- a/linode_api4/objects/nodebalancer.py
+++ b/linode_api4/objects/nodebalancer.py
@@ -3,7 +3,13 @@ from urllib import parse
 
 from linode_api4.common import Price, RegionPrice
 from linode_api4.errors import UnexpectedResponseError
-from linode_api4.objects.base import Base, MappedObject, Property, ExplicitNullValue, _flatten_request_body_recursive
+from linode_api4.objects.base import (
+    Base,
+    ExplicitNullValue,
+    MappedObject,
+    Property,
+    _flatten_request_body_recursive,
+)
 from linode_api4.objects.dbase import DerivedBase
 from linode_api4.objects.networking import Firewall, IPAddress
 from linode_api4.objects.region import Region
@@ -132,8 +138,8 @@ class NodeBalancerConfig(DerivedBase):
 
             # Allow explicit null values
             if (
-                    isinstance(value, ExplicitNullValue)
-                    or value == ExplicitNullValue
+                isinstance(value, ExplicitNullValue)
+                or value == ExplicitNullValue
             ):
                 value = None
 
@@ -160,7 +166,9 @@ class NodeBalancerConfig(DerivedBase):
 
         data = self._serialize()
 
-        result = self._client.put(NodeBalancerConfig.api_endpoint, model=self, data=data)
+        result = self._client.put(
+            NodeBalancerConfig.api_endpoint, model=self, data=data
+        )
 
         if "error" in result:
             return False

--- a/test/fixtures/nodebalancers_123456_configs.json
+++ b/test/fixtures/nodebalancers_123456_configs.json
@@ -24,9 +24,35 @@
       "protocol": "http",
       "ssl_fingerprint": "",
       "proxy_protocol": "none"
+    },
+    {
+      "check": "connection",
+      "check_attempts": 2,
+      "stickiness": "table",
+      "check_interval": 5,
+      "check_body": "",
+      "id": 65431,
+      "check_passive": true,
+      "algorithm": "roundrobin",
+      "check_timeout": 3,
+      "check_path": "/",
+      "ssl_cert": null,
+      "ssl_commonname": "",
+      "port": 80,
+      "nodebalancer_id": 123456,
+      "cipher_suite": "recommended",
+      "ssl_key": null,
+      "nodes_status": {
+        "up": 0,
+        "down": 0
+      },
+      "protocol": "udp",
+      "ssl_fingerprint": "",
+      "proxy_protocol": "none",
+      "udp_check_port": 12345
     }
   ],
-  "results": 1,
+  "results": 2,
   "page": 1,
   "pages": 1
 }

--- a/test/fixtures/nodebalancers_123456_configs.json
+++ b/test/fixtures/nodebalancers_123456_configs.json
@@ -40,7 +40,7 @@
       "ssl_commonname": "",
       "port": 80,
       "nodebalancer_id": 123456,
-      "cipher_suite": "recommended",
+      "cipher_suite": "none",
       "ssl_key": null,
       "nodes_status": {
         "up": 0,

--- a/test/fixtures/nodebalancers_123456_configs_65432_nodes.json
+++ b/test/fixtures/nodebalancers_123456_configs_65432_nodes.json
@@ -9,9 +9,19 @@
       "mode": "accept",
       "config_id": 54321,
       "nodebalancer_id": 123456
+    },
+    {
+      "id": 12345,
+      "address": "192.168.210.120",
+      "label": "node12345",
+      "status": "UP",
+      "weight": 50,
+      "mode": "none",
+      "config_id": 123456,
+      "nodebalancer_id": 123456
     }
   ],
   "pages": 1,
   "page": 1,
-  "results": 1
+  "results": 2
 }

--- a/test/integration/models/nodebalancer/test_nodebalancer.py
+++ b/test/integration/models/nodebalancer/test_nodebalancer.py
@@ -141,7 +141,6 @@ def test_update_nb_config(test_linode_client, create_nb_config_with_udp):
     )
 
     config.udp_check_port = 4321
-    config.cipher_suite = ExplicitNullValue
     config.save()
 
     config_updated = test_linode_client.load(

--- a/test/integration/models/nodebalancer/test_nodebalancer.py
+++ b/test/integration/models/nodebalancer/test_nodebalancer.py
@@ -9,7 +9,7 @@ from test.integration.helpers import get_test_label
 
 import pytest
 
-from linode_api4 import ApiError, ExplicitNullValue, LinodeClient, NodeBalancer
+from linode_api4 import ApiError, LinodeClient, NodeBalancer
 from linode_api4.objects import (
     NodeBalancerConfig,
     NodeBalancerNode,

--- a/test/integration/models/nodebalancer/test_nodebalancer.py
+++ b/test/integration/models/nodebalancer/test_nodebalancer.py
@@ -9,7 +9,7 @@ from test.integration.helpers import get_test_label
 
 import pytest
 
-from linode_api4 import ApiError, LinodeClient, NodeBalancer, ExplicitNullValue
+from linode_api4 import ApiError, ExplicitNullValue, LinodeClient, NodeBalancer
 from linode_api4.objects import (
     NodeBalancerConfig,
     NodeBalancerNode,
@@ -100,7 +100,10 @@ def test_create_nb(test_linode_client, e2e_test_firewall):
     label = get_test_label(8)
 
     nb = client.nodebalancer_create(
-        region=TEST_REGION, label=label, firewall=e2e_test_firewall.id, client_udp_sess_throttle=5
+        region=TEST_REGION,
+        label=label,
+        firewall=e2e_test_firewall.id,
+        client_udp_sess_throttle=5,
     )
 
     assert TEST_REGION, nb.region
@@ -155,6 +158,8 @@ def test_get_nb(test_linode_client, create_nb):
         NodeBalancer,
         create_nb.id,
     )
+
+    assert nb.id == create_nb.id
 
 
 def test_update_nb(test_linode_client, create_nb):

--- a/test/unit/objects/nodebalancers_test.py
+++ b/test/unit/objects/nodebalancers_test.py
@@ -46,6 +46,19 @@ class NodeBalancerConfigTest(ClientBaseCase):
         self.assertEqual(config_udp.protocol, "udp")
         self.assertEqual(config_udp.udp_check_port, 12345)
 
+    def test_update_config_udp(self):
+        """
+        Tests that a config with a protocol of udp can be updated and that cipher suite is properly excluded in save()
+        """
+        with self.mock_put("nodebalancers/123456/configs/65431") as m:
+            config = self.client.load(NodeBalancerConfig, 65431, 123456)
+            config.udp_check_port = 54321
+            config.save()
+
+            self.assertEqual(m.call_url, "/nodebalancers/123456/configs/65431")
+            self.assertEqual(m.call_data["udp_check_port"], 54321)
+            self.assertNotIn("cipher_suite", m.call_data)
+
 
 class NodeBalancerNodeTest(ClientBaseCase):
     """

--- a/test/unit/objects/nodebalancers_test.py
+++ b/test/unit/objects/nodebalancers_test.py
@@ -42,6 +42,10 @@ class NodeBalancerConfigTest(ClientBaseCase):
         self.assertEqual(config.ssl_fingerprint, "")
         self.assertEqual(config.proxy_protocol, "none")
 
+        config_udp = NodeBalancerConfig(self.client, 65431, 123456)
+        self.assertEqual(config_udp.protocol, "udp")
+        self.assertEqual(config_udp.udp_check_port, 12345)
+
 
 class NodeBalancerNodeTest(ClientBaseCase):
     """
@@ -65,6 +69,9 @@ class NodeBalancerNodeTest(ClientBaseCase):
         self.assertEqual(node.mode, "accept")
         self.assertEqual(node.config_id, 65432)
         self.assertEqual(node.nodebalancer_id, 123456)
+
+        node_udp = NodeBalancerNode(self.client, 12345, (65432, 123456))
+        self.assertEqual(node_udp.mode, "none")
 
     def test_create_node(self):
         """


### PR DESCRIPTION
## 📝 Description

Added support for Nodebalancers UDP and corresponding tests.

## ✔️ How to Test

Pull down this PR locally before running tests.

### Unit Tests
`make testunit`

### Integration Tests
`make TEST_CASE="test_create_nb" testint`
`make TEST_CASE="test_get_nb_config_with_udp" testint`
`make TEST_CASE="test_update_nb_config" testint`
`make TEST_CASE="test_get_nb" testint`
`make TEST_CASE="test_update_nb" testint`
