### PR TITLE
test: update deprecated images and slack payload in workflows

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -160,64 +160,34 @@ jobs:
     runs-on: ubuntu-latest
     needs: [integration-tests]
     if: ${{ (success() || failure()) && github.repository == 'linode/linode_api4-python' }} # Run even if integration tests fail and only on main repository
-
     steps:
       - name: Notify Slack
         uses: slackapi/slack-github-action@v2.0.0
         with:
-          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ":rocket: *${{ github.workflow }} Completed in: ${{ github.repository }}* :white_check_mark:"
-                  }
-                },
-                {
-                  "type": "divider"
-                },
-                {
-                  "type": "section",
-                  "fields": [
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Build Result:*\n${{ needs.integration-tests.result == 'success' && ':large_green_circle: Build Passed' || ':red_circle: Build Failed' }}"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Branch:*\n`${{ github.ref_name }}`"
-                    }
-                  ]
-                },
-                {
-                  "type": "section",
-                  "fields": [
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Commit Hash:*\n<${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}>"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Run URL:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run Details>"
-                    }
-                  ]
-                },
-                {
-                  "type": "divider"
-                },
-                {
-                  "type": "context",
-                  "elements": [
-                    {
-                      "type": "mrkdwn",
-                      "text": "Triggered by: :bust_in_silhouette: `${{ github.actor }}`"
-                    }
-                  ]
-                }
-              ]
-            }
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: ":rocket: *${{ github.workflow }} Completed in: ${{ github.repository }}* :white_check_mark:"
+              - type: divider
+              - type: section
+                fields:
+                  - type: mrkdwn
+                    text: "*Build Result:*\n${{ needs.integration-tests.result == 'success' && ':large_green_circle: Build Passed' || ':red_circle: Build Failed' }}"
+                  - type: mrkdwn
+                    text: "*Branch:*\n`${{ github.ref_name }}`"
+              - type: section
+                fields:
+                  - type: mrkdwn
+                    text: "*Commit Hash:*\n<${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}>"
+                  - type: mrkdwn
+                    text: "*Run URL:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run Details>"
+              - type: divider
+              - type: context
+                elements:
+                  - type: mrkdwn
+                    text: "Triggered by: :bust_in_silhouette: `${{ github.actor }}`"

--- a/.github/workflows/nightly-smoke-tests.yml
+++ b/.github/workflows/nightly-smoke-tests.yml
@@ -47,60 +47,31 @@ jobs:
         if: always() && github.repository == 'linode/linode_api4-python'
         uses: slackapi/slack-github-action@v2.0.0
         with:
-          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ":rocket: *${{ github.workflow }} Completed in: ${{ github.repository }}* :white_check_mark:"
-                  }
-                },
-                {
-                  "type": "divider"
-                },
-                {
-                  "type": "section",
-                  "fields": [
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Build Result:*\n${{ steps.smoke_tests.outcome == 'success' && ':large_green_circle: Build Passed' || ':red_circle: Build Failed' }}"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Branch:*\n`${{ github.ref_name }}`"
-                    }
-                  ]
-                },
-                {
-                  "type": "section",
-                  "fields": [
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Commit Hash:*\n<${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}>"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Run URL:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run Details>"
-                    }
-                  ]
-                },
-                {
-                  "type": "divider"
-                },
-                {
-                  "type": "context",
-                  "elements": [
-                    {
-                      "type": "mrkdwn",
-                      "text": "Triggered by: :bust_in_silhouette: `${{ github.actor }}`"
-                    }
-                  ]
-                }
-              ]
-            }
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: ":rocket: *${{ github.workflow }} Completed in: ${{ github.repository }}* :white_check_mark:"
+              - type: divider
+              - type: section
+                fields:
+                  - type: mrkdwn
+                    text: "*Build Result:*\n${{ steps.smoke_tests.outcome == 'success' && ':large_green_circle: Build Passed' || ':red_circle: Build Failed' }}"
+                  - type: mrkdwn
+                    text: "*Branch:*\n`${{ github.ref_name }}`"
+              - type: section
+                fields:
+                  - type: mrkdwn
+                    text: "*Commit Hash:*\n<${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}>"
+                  - type: mrkdwn
+                    text: "*Run URL:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run Details>"
+              - type: divider
+              - type: context
+                elements:
+                  - type: mrkdwn
+                    text: "Triggered by: :bust_in_silhouette: `${{ github.actor }}`"
 

--- a/.github/workflows/release-notify-slack.yml
+++ b/.github/workflows/release-notify-slack.yml
@@ -13,18 +13,12 @@ jobs:
         id: main_message
         uses: slackapi/slack-github-action@v2.0.0
         with:
-          channel-id: ${{ secrets.DEV_DX_SLACK_CHANNEL_ID }}
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "*New Release Published: _linode_api4-python_ <${{ github.event.release.html_url }}|${{ github.event.release.tag_name }}> is now live!* :tada:"
-                  }
-                }
-              ]
-            }
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+            channel: ${{ secrets.DEV_DX_SLACK_CHANNEL_ID }}
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "*New Release Published: _linode_api4-python_ <${{ github.event.release.html_url }}|${{ github.event.release.tag_name }}> is now live!* :tada:"

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -184,7 +184,7 @@ def create_linode_for_pass_reset(test_linode_client, e2e_test_firewall):
     linode_instance, password = client.linode.instance_create(
         "g6-nanode-1",
         region,
-        image="linode/debian10",
+        image="linode/debian12",
         label=label,
         firewall=e2e_test_firewall,
     )

--- a/test/integration/linode_client/test_linode_client.py
+++ b/test/integration/linode_client/test_linode_client.py
@@ -19,7 +19,7 @@ def setup_client_and_linode(test_linode_client, e2e_test_firewall):
     linode_instance, password = client.linode.instance_create(
         "g6-nanode-1",
         region,
-        image="linode/debian10",
+        image="linode/debian12",
         label=label,
         firewall=e2e_test_firewall,
     )
@@ -250,7 +250,7 @@ def test_create_linode_instance_without_image(test_linode_client):
 def test_create_linode_instance_with_image(setup_client_and_linode):
     linode = setup_client_and_linode[1]
 
-    assert re.search("linode/debian10", str(linode.image))
+    assert re.search("linode/debian12", str(linode.image))
 
 
 def test_create_linode_with_interfaces(test_linode_client):
@@ -262,7 +262,7 @@ def test_create_linode_with_interfaces(test_linode_client):
         "g6-nanode-1",
         region,
         label=label,
-        image="linode/debian10",
+        image="linode/debian12",
         interfaces=[
             {"purpose": "public"},
             ConfigInterface(

--- a/test/integration/models/account/test_account.py
+++ b/test/integration/models/account/test_account.py
@@ -71,7 +71,7 @@ def test_latest_get_event(test_linode_client, e2e_test_firewall):
     linode, password = client.linode.instance_create(
         "g6-nanode-1",
         region,
-        image="linode/debian10",
+        image="linode/debian12",
         label=label,
         firewall=e2e_test_firewall,
     )

--- a/test/integration/models/firewall/test_firewall.py
+++ b/test/integration/models/firewall/test_firewall.py
@@ -14,7 +14,7 @@ def linode_fw(test_linode_client):
     label = get_test_label()
 
     linode_instance, password = client.linode.instance_create(
-        "g6-nanode-1", region, image="linode/debian10", label=label
+        "g6-nanode-1", region, image="linode/debian12", label=label
     )
 
     yield linode_instance

--- a/test/integration/models/linode/test_linode.py
+++ b/test/integration/models/linode/test_linode.py
@@ -169,7 +169,7 @@ def linode_with_disk_encryption(test_linode_client, request):
     linode_instance, password = client.linode.instance_create(
         "g6-nanode-1",
         target_region,
-        image="linode/ubuntu23.10",
+        image="linode/ubuntu24.10",
         label=label,
         booted=False,
         disk_encryption=disk_encryption,

--- a/test/integration/models/linode/test_linode.py
+++ b/test/integration/models/linode/test_linode.py
@@ -38,7 +38,7 @@ def linode_with_volume_firewall(test_linode_client):
     linode_instance, password = client.linode.instance_create(
         "g6-nanode-1",
         region,
-        image="linode/debian10",
+        image="linode/debian12",
         label=label + "_modlinode",
     )
 
@@ -76,7 +76,7 @@ def linode_for_network_interface_tests(test_linode_client, e2e_test_firewall):
     linode_instance, password = client.linode.instance_create(
         "g6-nanode-1",
         region,
-        image="linode/debian10",
+        image="linode/debian12",
         label=label,
         firewall=e2e_test_firewall,
     )
@@ -147,7 +147,7 @@ def create_linode_for_long_running_tests(test_linode_client, e2e_test_firewall):
     linode_instance, password = client.linode.instance_create(
         "g6-nanode-1",
         region,
-        image="linode/debian10",
+        image="linode/debian12",
         label=label + "_long_tests",
         firewall=e2e_test_firewall,
     )
@@ -214,7 +214,7 @@ def test_linode_rebuild(test_linode_client):
     label = get_test_label() + "_rebuild"
 
     linode, password = client.linode.instance_create(
-        "g6-nanode-1", region, image="linode/debian10", label=label
+        "g6-nanode-1", region, image="linode/debian12", label=label
     )
 
     wait_for_condition(10, 100, get_status, linode, "running")
@@ -222,14 +222,14 @@ def test_linode_rebuild(test_linode_client):
     retry_sending_request(
         3,
         linode.rebuild,
-        "linode/debian10",
+        "linode/debian12",
         disk_encryption=InstanceDiskEncryptionType.disabled,
     )
 
     wait_for_condition(10, 100, get_status, linode, "rebuilding")
 
     assert linode.status == "rebuilding"
-    assert linode.image.id == "linode/debian10"
+    assert linode.image.id == "linode/debian12"
 
     assert linode.disk_encryption == InstanceDiskEncryptionType.disabled
 
@@ -272,7 +272,7 @@ def test_delete_linode(test_linode_client):
     linode_instance, password = client.linode.instance_create(
         "g6-nanode-1",
         region,
-        image="linode/debian10",
+        image="linode/debian12",
         label=label + "_linode",
     )
 

--- a/test/integration/models/nodebalancer/test_nodebalancer.py
+++ b/test/integration/models/nodebalancer/test_nodebalancer.py
@@ -36,7 +36,7 @@ def linode_with_private_ip(test_linode_client, e2e_test_firewall):
     linode_instance, password = client.linode.instance_create(
         "g6-nanode-1",
         TEST_REGION,
-        image="linode/debian10",
+        image="linode/debian12",
         label=label,
         private_ip=True,
         firewall=e2e_test_firewall,

--- a/test/integration/models/volume/test_volume.py
+++ b/test/integration/models/volume/test_volume.py
@@ -49,7 +49,7 @@ def linode_for_volume(test_linode_client, e2e_test_firewall):
     linode_instance, password = client.linode.instance_create(
         "g6-nanode-1",
         TEST_REGION,
-        image="linode/debian10",
+        image="linode/debian12",
         label=label,
         firewall=e2e_test_firewall,
     )

--- a/test/unit/objects/linode_test.py
+++ b/test/unit/objects/linode_test.py
@@ -413,7 +413,7 @@ class LinodeTest(ClientBaseCase):
                 1234,
                 label="test",
                 authorized_users=["test"],
-                image="linode/debian10",
+                image="linode/debian12",
             )
             self.assertEqual(m.call_url, "/linode/instances/123/disks")
             self.assertEqual(
@@ -422,7 +422,7 @@ class LinodeTest(ClientBaseCase):
                     "size": 1234,
                     "label": "test",
                     "root_pass": gen_pass,
-                    "image": "linode/debian10",
+                    "image": "linode/debian12",
                     "authorized_users": ["test"],
                     "read_only": False,
                 },


### PR DESCRIPTION
## 📝 Description

Update slack payload to comply with v2.0.0 introduced from https://github.com/linode/linode_api4-python/pull/488

Update deprecated test image `debain10` to `debian12`

## ✔️ How to Test

PR run - in progress https://github.com/linode/linode_api4-python/actions/runs/12716364173


## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**