### PR TITLE
new: Support deleting IP address

### DIFF
--- a/linode_api4/objects/networking.py
+++ b/linode_api4/objects/networking.py
@@ -112,6 +112,20 @@ class IPAddress(Base):
 
         return {"address": self.address, "linode_id": linode.id}
 
+    def delete(self):
+        """
+        Override the delete() function from Base to use the correct endpoint.
+        """
+        resp = self._client.delete(
+            "/linode/instances/{}/ips/{}".format(self.linode_id, self.address),
+            model=self,
+        )
+
+        if "error" in resp:
+            return False
+        self.invalidate()
+        return True
+
 
 @dataclass
 class VPCIPAddress(JSONObject):

--- a/test/integration/models/networking/test_networking.py
+++ b/test/integration/models/networking/test_networking.py
@@ -150,3 +150,16 @@ def test_network_transfer_prices(test_linode_client):
             transfer_prices[0].price is None
             or transfer_prices[0].price.hourly >= 0
         )
+
+
+def test_allocate_and_delete_ip(test_linode_client, create_linode):
+    linode = create_linode
+    ip = test_linode_client.networking.ip_allocate(linode.id)
+    linode.invalidate()
+
+    assert ip.linode_id == linode.id
+    assert ip.address in linode.ipv4
+
+    is_deleted = ip.delete()
+
+    assert is_deleted is True

--- a/test/unit/objects/networking_test.py
+++ b/test/unit/objects/networking_test.py
@@ -1,6 +1,6 @@
 from test.unit.base import ClientBaseCase
 
-from linode_api4 import ExplicitNullValue
+from linode_api4 import ExplicitNullValue, Instance
 from linode_api4.objects import Firewall, IPAddress, IPv6Range
 
 
@@ -83,3 +83,14 @@ class NetworkingTest(ClientBaseCase):
         self.assertEqual(ip.vpc_nat_1_1.vpc_id, 242)
         self.assertEqual(ip.vpc_nat_1_1.subnet_id, 194)
         self.assertEqual(ip.vpc_nat_1_1.address, "139.144.244.36")
+
+    def test_delete_ip(self):
+        """
+        Tests that deleting an IP creates the correct api request
+        """
+        with self.mock_delete() as m:
+            ip = IPAddress(self.client, "127.0.0.1")
+            ip.to(Instance(self.client, 123))
+            ip.delete()
+
+            self.assertEqual(m.call_url, "/linode/instances/123/ips/127.0.0.1")


### PR DESCRIPTION
## 📝 Description

Allow user to use `ip.delete()` when they want to delete a public or private IPv4 address associated with a Linode. This will fail if it is the Linode's last remaining public IPv4 address, or if the address has a 1:1 NAT with an active VPC Subnet address.

It overrides the delete() function from base to adapt the correct endpoint for IPAddress.

## ✔️ How to Test

```
make testunit
```

```
make TEST_CASE="test_allocate_and_delete_ip -vvv" testint
```
