### PR TITLE
test/workflow: Update make test commands and related workflows

### DIFF
--- a/.github/workflows/e2e-test-pr.yml
+++ b/.github/workflows/e2e-test-pr.yml
@@ -80,7 +80,7 @@ jobs:
         run: |
           timestamp=$(date +'%Y%m%d%H%M')
           report_filename="${timestamp}_sdk_test_report.xml"
-          make testint TEST_ARGS="--junitxml=${report_filename}" TEST_SUITE="${{ github.event.inputs.test_suite }}"
+          make test-int TEST_ARGS="--junitxml=${report_filename}" TEST_SUITE="${{ github.event.inputs.test_suite }}"
         env:
           LINODE_TOKEN: ${{ secrets.LINODE_TOKEN }}
 

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -159,7 +159,7 @@ jobs:
   notify-slack:
     runs-on: ubuntu-latest
     needs: [integration-tests]
-    if: ${{ (success() || failure()) && github.repository == 'linode/linode_api4-python' }} # Run even if integration tests fail and only on main repository
+    if: ${{ (success() || failure()) }} # Run even if integration tests fail and only on main repository
     steps:
       - name: Notify Slack
         uses: slackapi/slack-github-action@v2.0.0

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -4,18 +4,18 @@ on:
   workflow_dispatch:
     inputs:
       use_minimal_test_account:
-        description: 'Use minimal test account'
+        description: 'Indicate whether to use a minimal test account with limited resources for testing. Defaults to "false"'
         required: false
         default: 'false'
       sha:
-        description: 'The hash value of the commit'
-        required: false
+        description: 'Specify commit hash to test. This value is mandatory to ensure the tests run against a specific commit'
+        required: true
         default: ''
       python-version:
-        description: 'Specify Python version to use'
+        description: 'Specify the Python version to use for running tests. Leave empty to use the default Python version configured in the environment'
         required: false
       run-eol-python-version:
-        description: 'Run EOL python version?'
+        description: 'Indicates whether to run tests using an End-of-Life (EOL) Python version. Defaults to "false". Choose "true" to include tests for deprecated Python versions'
         required: false
         default: 'false'
         type: choice
@@ -28,8 +28,8 @@ on:
       - dev
 
 env:
-  DEFAULT_PYTHON_VERSION: "3.9"
-  EOL_PYTHON_VERSION: "3.8"
+  DEFAULT_PYTHON_VERSION: "3.10"
+  EOL_PYTHON_VERSION: "3.9"
   EXIT_STATUS: 0
 
 jobs:
@@ -72,7 +72,7 @@ jobs:
         run: |
           timestamp=$(date +'%Y%m%d%H%M')
           report_filename="${timestamp}_sdk_test_report.xml"
-          make testint TEST_ARGS="--junitxml=${report_filename}"
+          make test-int TEST_ARGS="--junitxml=${report_filename}"
         env:
           LINODE_TOKEN: ${{ env.LINODE_TOKEN }}
 

--- a/.github/workflows/nightly-smoke-tests.yml
+++ b/.github/workflows/nightly-smoke-tests.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Run smoke tests
         id: smoke_tests
         run: |
-          make smoketest
+          make test-smoke
         env:
           LINODE_TOKEN: ${{ secrets.LINODE_TOKEN }}
 

--- a/README.rst
+++ b/README.rst
@@ -148,16 +148,16 @@ Running the tests
 ^^^^^^^^^^^^^^^^^
 Run the tests locally using the make command. Run the entire test suite using command below::
 
-    make testint
+    make test-int
 
 To run a specific package/suite, use the environment variable `TEST_SUITE` using directory names in `integration/...` folder ::
 
-    make TEST_SUITE="account" testint          // Runs tests in `integration/models/account` directory
-    make TEST_SUITE="linode_client" testint    // Runs tests in `integration/linode_client` directory
+    make TEST_SUITE="account" test-int          // Runs tests in `integration/models/account` directory
+    make TEST_SUITE="linode_client" test-int    // Runs tests in `integration/linode_client` directory
 
-Lastly to run a specific test case use environment variable `TEST_CASE` with `testint` command::
+Lastly to run a specific test case use environment variable `TEST_CASE` with `test-int` command::
 
-    make TEST_CASE=test_get_domain_record testint
+    make TEST_CASE=test_get_domain_record test-int
 
 Documentation
 -------------


### PR DESCRIPTION
## 📝 Description

In efforts to unify test commands across all repository, the commands are refactored in Makefile. Refer to "How to Test" Section

Also related GHA workflow yamls have been updated with the latest commands

## ✔️ How to Test

- Integration test: `make test-int`
- Unit test: `make test-unit`
- Smoke test: `make test-smoke`

Integration test arguments and usage:
```
TEST_SUITE: Optional, specify a test suite (e.g. domains), Default to run everything if not set
TEST_CASE: Optional, specify a test case (e.g. 'test_image_replication')
TEST_ARGS: Optional, additional arguments for pytest (e.g. '-v' for verbose mode)
```

e.g.
`make TEST_SUITE=domains test-int`
`make TEST_CASE=test_image_replication test-int`
`make TEST_CASE=test_image_replication TEST_ARGS="-v" test-int`

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**