### PR TITLE
new: Support deleting VLAN in networking group

### DIFF
--- a/linode_api4/groups/networking.py
+++ b/linode_api4/groups/networking.py
@@ -377,9 +377,7 @@ class NetworkingGroup(Group):
 
         :param vlan: The label of the VLAN to be deleted.
         :type vlan: str or VLAN
-        :param region: The Region in which the assignments should take place.
-               All Instances and IPAddresses involved in the assignment
-               must be within this region.
+        :param region: The VLAN's region.
         :type region: str or Region
         """
         if isinstance(region, Region):

--- a/linode_api4/groups/networking.py
+++ b/linode_api4/groups/networking.py
@@ -367,3 +367,32 @@ class NetworkingGroup(Group):
         return self.client._get_and_filter(
             NetworkTransferPrice, *filters, endpoint="/network-transfer/prices"
         )
+
+    def delete_vlan(self, vlan, region):
+        """
+        This operation deletes a VLAN.
+        You can't delete a VLAN if it's still attached to a Linode.
+
+        API Documentation: https://techdocs.akamai.com/linode-api/reference/delete-vlan
+
+        :param vlan: The label of the VLAN to be deleted.
+        :type vlan: str or VLAN
+        :param region: The Region in which the assignments should take place.
+               All Instances and IPAddresses involved in the assignment
+               must be within this region.
+        :type region: str or Region
+        """
+        if isinstance(region, Region):
+            region = region.id
+
+        if isinstance(vlan, VLAN):
+            vlan = vlan.label
+        resp = self.client.delete(
+            "/networking/vlans/{}/{}".format(region, vlan),
+            model=self,
+        )
+
+        if "error" in resp:
+            return False
+
+        return True

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -502,3 +502,22 @@ def pytest_configure(config):
         "markers",
         "smoke: mark test as part of smoke test suite",
     )
+
+
+@pytest.fixture(scope="session")
+def linode_for_vlan_tests(test_linode_client, e2e_test_firewall):
+    client = test_linode_client
+    region = get_region(client, {"Linodes", "Vlans"}, site_type="core")
+    label = get_test_label(length=8)
+
+    linode_instance, password = client.linode.instance_create(
+        "g6-nanode-1",
+        region,
+        image="linode/debian12",
+        label=label,
+        firewall=e2e_test_firewall,
+    )
+
+    yield linode_instance
+
+    linode_instance.delete()

--- a/test/unit/objects/networking_test.py
+++ b/test/unit/objects/networking_test.py
@@ -1,6 +1,6 @@
 from test.unit.base import ClientBaseCase
 
-from linode_api4 import ExplicitNullValue, Instance
+from linode_api4 import VLAN, ExplicitNullValue, Instance, Region
 from linode_api4.objects import Firewall, IPAddress, IPv6Range
 
 
@@ -94,3 +94,17 @@ class NetworkingTest(ClientBaseCase):
             ip.delete()
 
             self.assertEqual(m.call_url, "/linode/instances/123/ips/127.0.0.1")
+
+    def test_delete_vlan(self):
+        """
+        Tests that deleting a VLAN creates the correct api request
+        """
+        with self.mock_delete() as m:
+            self.client.networking.delete_vlan(
+                VLAN(self.client, "vlan-test"),
+                Region(self.client, "us-southeast"),
+            )
+
+            self.assertEqual(
+                m.call_url, "/networking/vlans/us-southeast/vlan-test"
+            )


### PR DESCRIPTION
## 📝 Description

Allow user to delete a VLAN using `networking.delete_vlan()`. Note that a VLAN can't be deleted if it's still attached to a Linode.

## ✔️ How to Test

```
make testunit
```

```
make TEST_CASE="test_create_and_delete_vlan -v" testint
```

