### PR TITLE
Fix skip condition for database tests when RUN_DB_TESTS is unset

### DIFF
--- a/test/integration/models/database/test_database.py
+++ b/test/integration/models/database/test_database.py
@@ -130,7 +130,7 @@ def test_fork_postgres_db(test_linode_client, test_create_postgres_db):
 
 
 @pytest.mark.skipif(
-    os.getenv("RUN_DB_TESTS").strip().lower() not in {"yes", "true"},
+    os.getenv("RUN_DB_TESTS", "").strip().lower() not in {"yes", "true"},
     reason="RUN_DB_TESTS environment variable must be set to 'yes' or 'true' (case insensitive)",
 )
 def test_get_types(test_linode_client):
@@ -142,7 +142,7 @@ def test_get_types(test_linode_client):
 
 
 @pytest.mark.skipif(
-    os.getenv("RUN_DB_TESTS").strip().lower() not in {"yes", "true"},
+    os.getenv("RUN_DB_TESTS", "").strip().lower() not in {"yes", "true"},
     reason="RUN_DB_TESTS environment variable must be set to 'yes' or 'true' (case insensitive)",
 )
 def test_get_engines(test_linode_client):
@@ -156,7 +156,7 @@ def test_get_engines(test_linode_client):
 
 
 @pytest.mark.skipif(
-    os.getenv("RUN_DB_TESTS").strip().lower() not in {"yes", "true"},
+    os.getenv("RUN_DB_TESTS", "").strip().lower() not in {"yes", "true"},
     reason="RUN_DB_TESTS environment variable must be set to 'yes' or 'true' (case insensitive)",
 )
 def test_database_instance(test_linode_client, test_create_sql_db):
@@ -167,7 +167,7 @@ def test_database_instance(test_linode_client, test_create_sql_db):
 
 # ------- POSTGRESQL DB Test cases -------
 @pytest.mark.skipif(
-    os.getenv("RUN_DB_TESTS").strip().lower() not in {"yes", "true"},
+    os.getenv("RUN_DB_TESTS", "").strip().lower() not in {"yes", "true"},
     reason="RUN_DB_TESTS environment variable must be set to 'yes' or 'true' (case insensitive)",
 )
 def test_get_sql_db_instance(test_linode_client, test_create_sql_db):
@@ -185,7 +185,7 @@ def test_get_sql_db_instance(test_linode_client, test_create_sql_db):
 
 
 @pytest.mark.skipif(
-    os.getenv("RUN_DB_TESTS").strip().lower() not in {"yes", "true"},
+    os.getenv("RUN_DB_TESTS", "").strip().lower() not in {"yes", "true"},
     reason="RUN_DB_TESTS environment variable must be set to 'yes' or 'true' (case insensitive)",
 )
 def test_update_sql_db(test_linode_client, test_create_sql_db):
@@ -218,7 +218,7 @@ def test_update_sql_db(test_linode_client, test_create_sql_db):
 
 
 @pytest.mark.skipif(
-    os.getenv("RUN_DB_TESTS").strip().lower() not in {"yes", "true"},
+    os.getenv("RUN_DB_TESTS", "").strip().lower() not in {"yes", "true"},
     reason="RUN_DB_TESTS environment variable must be set to 'yes' or 'true' (case insensitive)",
 )
 def test_get_sql_ssl(test_linode_client, test_create_sql_db):
@@ -228,7 +228,7 @@ def test_get_sql_ssl(test_linode_client, test_create_sql_db):
 
 
 @pytest.mark.skipif(
-    os.getenv("RUN_DB_TESTS").strip().lower() not in {"yes", "true"},
+    os.getenv("RUN_DB_TESTS", "").strip().lower() not in {"yes", "true"},
     reason="RUN_DB_TESTS environment variable must be set to 'yes' or 'true' (case insensitive)",
 )
 def test_sql_patch(test_linode_client, test_create_sql_db):
@@ -260,7 +260,7 @@ def test_sql_patch(test_linode_client, test_create_sql_db):
 
 
 @pytest.mark.skipif(
-    os.getenv("RUN_DB_TESTS").strip().lower() not in {"yes", "true"},
+    os.getenv("RUN_DB_TESTS", "").strip().lower() not in {"yes", "true"},
     reason="RUN_DB_TESTS environment variable must be set to 'yes' or 'true' (case insensitive)",
 )
 def test_get_sql_credentials(test_linode_client, test_create_sql_db):
@@ -271,7 +271,7 @@ def test_get_sql_credentials(test_linode_client, test_create_sql_db):
 
 
 @pytest.mark.skipif(
-    os.getenv("RUN_DB_TESTS").strip().lower() not in {"yes", "true"},
+    os.getenv("RUN_DB_TESTS", "").strip().lower() not in {"yes", "true"},
     reason="RUN_DB_TESTS environment variable must be set to 'yes' or 'true' (case insensitive)",
 )
 def test_reset_sql_credentials(test_linode_client, test_create_sql_db):
@@ -290,7 +290,7 @@ def test_reset_sql_credentials(test_linode_client, test_create_sql_db):
 
 # ------- POSTGRESQL DB Test cases -------
 @pytest.mark.skipif(
-    os.getenv("RUN_DB_TESTS").strip().lower() not in {"yes", "true"},
+    os.getenv("RUN_DB_TESTS", "").strip().lower() not in {"yes", "true"},
     reason="RUN_DB_TESTS environment variable must be set to 'yes' or 'true' (case insensitive)",
 )
 def test_get_postgres_db_instance(test_linode_client, test_create_postgres_db):
@@ -310,7 +310,7 @@ def test_get_postgres_db_instance(test_linode_client, test_create_postgres_db):
 
 
 @pytest.mark.skipif(
-    os.getenv("RUN_DB_TESTS").strip().lower() not in {"yes", "true"},
+    os.getenv("RUN_DB_TESTS", "").strip().lower() not in {"yes", "true"},
     reason="RUN_DB_TESTS environment variable must be set to 'yes' or 'true' (case insensitive)",
 )
 def test_update_postgres_db(test_linode_client, test_create_postgres_db):
@@ -345,7 +345,7 @@ def test_update_postgres_db(test_linode_client, test_create_postgres_db):
 
 
 @pytest.mark.skipif(
-    os.getenv("RUN_DB_TESTS").strip().lower() not in {"yes", "true"},
+    os.getenv("RUN_DB_TESTS", "").strip().lower() not in {"yes", "true"},
     reason="RUN_DB_TESTS environment variable must be set to 'yes' or 'true' (case insensitive)",
 )
 def test_get_postgres_ssl(test_linode_client, test_create_postgres_db):
@@ -355,7 +355,7 @@ def test_get_postgres_ssl(test_linode_client, test_create_postgres_db):
 
 
 @pytest.mark.skipif(
-    os.getenv("RUN_DB_TESTS").strip().lower() not in {"yes", "true"},
+    os.getenv("RUN_DB_TESTS", "").strip().lower() not in {"yes", "true"},
     reason="RUN_DB_TESTS environment variable must be set to 'yes' or 'true' (case insensitive)",
 )
 def test_postgres_patch(test_linode_client, test_create_postgres_db):
@@ -387,7 +387,7 @@ def test_postgres_patch(test_linode_client, test_create_postgres_db):
 
 
 @pytest.mark.skipif(
-    os.getenv("RUN_DB_TESTS").strip().lower() not in {"yes", "true"},
+    os.getenv("RUN_DB_TESTS", "").strip().lower() not in {"yes", "true"},
     reason="RUN_DB_TESTS environment variable must be set to 'yes' or 'true' (case insensitive)",
 )
 def test_get_postgres_credentials(test_linode_client, test_create_postgres_db):
@@ -398,7 +398,7 @@ def test_get_postgres_credentials(test_linode_client, test_create_postgres_db):
 
 
 @pytest.mark.skipif(
-    os.getenv("RUN_DB_TESTS").strip().lower() not in {"yes", "true"},
+    os.getenv("RUN_DB_TESTS", "").strip().lower() not in {"yes", "true"},
     reason="RUN_DB_TESTS environment variable must be set to 'yes' or 'true' (case insensitive)",
 )
 def test_reset_postgres_credentials(


### PR DESCRIPTION
## 📝 Description

Addressing issue below where RUN_DB_TESTS is required when running integration tests.
```
ERROR test/integration/models/database/test_database.py - AttributeError: 'NoneType' object has no attribute 'strip'
```

## ✔️ How to Test

Run smoke test without specifying RUN_DB_TESTS

`make test-smoke`

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**