### PR TITLE
Drop the LKE ACL `addresses` field when its value is null

### DIFF
--- a/linode_api4/groups/lke.py
+++ b/linode_api4/groups/lke.py
@@ -131,7 +131,7 @@ class LKEGroup(Group):
 
         result = self.client.post(
             "/lke/clusters",
-            data=_flatten_request_body_recursive(drop_null_keys(params)),
+            data=drop_null_keys(_flatten_request_body_recursive(params)),
         )
 
         if "id" not in result:

--- a/linode_api4/objects/lke.py
+++ b/linode_api4/objects/lke.py
@@ -14,6 +14,7 @@ from linode_api4.objects import (
     Region,
     Type,
 )
+from linode_api4.util import drop_null_keys
 
 
 class LKEType(Base):
@@ -574,7 +575,7 @@ class LKECluster(Base):
         result = self._client.put(
             f"{LKECluster.api_endpoint}/control_plane_acl",
             model=self,
-            data={"acl": acl},
+            data={"acl": drop_null_keys(acl)},
         )
 
         acl = result.get("acl")

--- a/test/integration/models/lke/test_lke.py
+++ b/test/integration/models/lke/test_lke.py
@@ -291,7 +291,7 @@ def test_lke_cluster_acl(lke_cluster_with_acl):
             enabled=True,
             addresses=LKEClusterControlPlaneACLAddressesOptions(
                 ipv4=["10.0.0.2/32"]
-            )
+            ),
         )
     )
 

--- a/test/integration/models/lke/test_lke.py
+++ b/test/integration/models/lke/test_lke.py
@@ -298,6 +298,20 @@ def test_lke_cluster_acl(lke_cluster_with_acl):
     assert acl.addresses.ipv4 == ["10.0.0.2/32"]
 
 
+def test_lke_cluster_update_acl_null_addresses(lke_cluster_with_acl):
+    cluster = lke_cluster_with_acl
+
+    # Addresses should not be included in the request if it's null,
+    # else an error will be returned by the API.
+    # See: TPT-3489
+    acl = cluster.control_plane_acl_update(
+        {"enabled": False, "addresses": None}
+    )
+
+    assert acl == cluster.control_plane_acl
+    assert acl.addresses.ipv4 == ["10.0.0.1/32"]
+
+
 def test_lke_cluster_disable_acl(lke_cluster_with_acl):
     cluster = lke_cluster_with_acl
 

--- a/test/integration/models/lke/test_lke.py
+++ b/test/integration/models/lke/test_lke.py
@@ -45,7 +45,7 @@ def lke_cluster(test_linode_client):
     cluster.delete()
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def lke_cluster_with_acl(test_linode_client):
     node_type = test_linode_client.linode.types()[1]  # g6-standard-1
     version = test_linode_client.lke.versions()[0]
@@ -288,6 +288,7 @@ def test_lke_cluster_acl(lke_cluster_with_acl):
 
     acl = cluster.control_plane_acl_update(
         LKEClusterControlPlaneACLOptions(
+            enabled=True,
             addresses=LKEClusterControlPlaneACLAddressesOptions(
                 ipv4=["10.0.0.2/32"]
             )
@@ -309,7 +310,7 @@ def test_lke_cluster_update_acl_null_addresses(lke_cluster_with_acl):
     )
 
     assert acl == cluster.control_plane_acl
-    assert acl.addresses.ipv4 == ["10.0.0.1/32"]
+    assert acl.addresses.ipv4 == []
 
 
 def test_lke_cluster_disable_acl(lke_cluster_with_acl):
@@ -325,7 +326,7 @@ def test_lke_cluster_disable_acl(lke_cluster_with_acl):
 
     assert acl.enabled is False
     assert acl == cluster.control_plane_acl
-    assert acl.addresses.ipv4 == ["10.0.0.2/32"]
+    assert acl.addresses.ipv4 == []
 
     cluster.control_plane_acl_delete()
 

--- a/test/unit/objects/lke_test.py
+++ b/test/unit/objects/lke_test.py
@@ -499,7 +499,30 @@ class LKETest(ClientBaseCase):
         assert self.pool.nodes[1].id == "node8"
         assert self.pool.nodes[2].id == "node9"
 
-    def test_cluster_update_null_addresses(self):
+    def test_cluster_create_acl_null_addresses(self):
+        with self.mock_post("lke/clusters") as m:
+            self.client.lke.cluster_create(
+                region="us-mia",
+                label="foobar",
+                kube_version="1.32",
+                node_pools=[self.client.lke.node_pool("g6-standard-1", 3)],
+                control_plane={
+                    "acl": {
+                        "enabled": False,
+                        "addresses": None,
+                    }
+                },
+            )
+
+            # Addresses should not be included in the API request if it's null
+            # See: TPT-3489
+            assert m.call_data["control_plane"] == {
+                "acl": {
+                    "enabled": False,
+                }
+            }
+
+    def test_cluster_update_acl_null_addresses(self):
         cluster = LKECluster(self.client, 18881)
 
         with self.mock_put("lke/clusters/18881/control_plane_acl") as m:

--- a/test/unit/objects/lke_test.py
+++ b/test/unit/objects/lke_test.py
@@ -498,3 +498,18 @@ class LKETest(ClientBaseCase):
         assert self.pool.nodes[0].id == "node7"
         assert self.pool.nodes[1].id == "node8"
         assert self.pool.nodes[2].id == "node9"
+
+    def test_cluster_update_null_addresses(self):
+        cluster = LKECluster(self.client, 18881)
+
+        with self.mock_put("lke/clusters/18881/control_plane_acl") as m:
+            cluster.control_plane_acl_update(
+                LKEClusterControlPlaneACLOptions(
+                    enabled=True,
+                    addresses=None,
+                )
+            )
+
+            # Addresses should not be included in the API request if it's null
+            # See: TPT-3489
+            assert m.call_data == {"acl": {"enabled": True}}

--- a/test/unit/objects/lke_test.py
+++ b/test/unit/objects/lke_test.py
@@ -504,10 +504,10 @@ class LKETest(ClientBaseCase):
 
         with self.mock_put("lke/clusters/18881/control_plane_acl") as m:
             cluster.control_plane_acl_update(
-                LKEClusterControlPlaneACLOptions(
-                    enabled=True,
-                    addresses=None,
-                )
+                {
+                    "enabled": True,
+                    "addresses": None,
+                }
             )
 
             # Addresses should not be included in the API request if it's null


### PR DESCRIPTION
## 📝 Description

This pull request updates the LKE cluster create and control plane ACL update methods to drop the `addresses` field if its value is null. This is necessary because an explicit null value is rejected by the API.

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally.

### Unit Testing

```
make test-unit
```

### Integration Testing

```
make test-int
```

### Manual Testing

1. In a linode_api4-python sandbox environment (e.g. dx-devenv), run the following:

```python
import os

from linode_api4 import LinodeClient


def main():
    client = LinodeClient(os.getenv("LINODE_TOKEN"))

    cluster = client.lke.cluster_create(
        region="us-mia",
        label="apl-test",
        kube_version="1.32",
        node_pools=[client.lke.node_pool("g6-standard-1", 3)],
        control_plane={
            "acl": {
                "enabled": True,
                "addresses": None,
            }
        },
    )

    print("Cluster:", cluster)


if __name__ == "__main__":
    main()
```

2. Ensure the cluster is created successfully.
