### PR TITLE
Implement Support for LKE Enterprise

### DIFF
--- a/linode_api4/groups/__init__.py
+++ b/linode_api4/groups/__init__.py
@@ -8,6 +8,7 @@ from .domain import *
 from .image import *
 from .linode import *
 from .lke import *
+from .lke_tier import *
 from .longview import *
 from .networking import *
 from .nodebalancer import *

--- a/linode_api4/groups/lke.py
+++ b/linode_api4/groups/lke.py
@@ -1,7 +1,8 @@
-from typing import Any, Dict, Union
+from typing import Any, Dict, Optional, Union
 
 from linode_api4.errors import UnexpectedResponseError
 from linode_api4.groups import Group
+from linode_api4.groups.lke_tier import LKETierGroup
 from linode_api4.objects import (
     KubeVersion,
     LKECluster,
@@ -67,6 +68,7 @@ class LKEGroup(Group):
             LKEClusterControlPlaneOptions, Dict[str, Any]
         ] = None,
         apl_enabled: bool = False,
+        tier: Optional[str] = None,
         **kwargs,
     ):
         """
@@ -104,9 +106,13 @@ class LKEGroup(Group):
         :param control_plane: The control plane configuration of this LKE cluster.
         :type control_plane: Dict[str, Any] or LKEClusterControlPlaneRequest
         :param apl_enabled: Whether this cluster should use APL.
-                            NOTE: This endpoint is in beta and may only
+                            NOTE: This field is in beta and may only
                             function if base_url is set to `https://api.linode.com/v4beta`.
         :type apl_enabled: bool
+        :param tier: The tier of LKE cluster to create.
+                     NOTE: This field is in beta and may only
+                     function if base_url is set to `https://api.linode.com/v4beta`.
+        :type tier: str
         :param kwargs: Any other arguments to pass along to the API.  See the API
                        docs for possible values.
 
@@ -122,6 +128,7 @@ class LKEGroup(Group):
                 node_pools if isinstance(node_pools, list) else [node_pools]
             ),
             "control_plane": control_plane,
+            "tier": tier,
         }
         params.update(kwargs)
 
@@ -183,3 +190,18 @@ class LKEGroup(Group):
         return self.client._get_and_filter(
             LKEType, *filters, endpoint="/lke/types"
         )
+
+    def tier(self, id: str) -> LKETierGroup:
+        """
+        Returns an object representing the LKE tier API path.
+
+        NOTE: LKE tiers may not currently be available to all users.
+
+        :param id: The ID of the tier.
+        :type id: str
+
+        :returns: An object representing the LKE tier API path.
+        :rtype: LKETier
+        """
+
+        return LKETierGroup(self.client, id)

--- a/linode_api4/groups/lke_tier.py
+++ b/linode_api4/groups/lke_tier.py
@@ -1,0 +1,40 @@
+from linode_api4.groups import Group
+from linode_api4.objects import TieredKubeVersion
+
+
+class LKETierGroup(Group):
+    """
+    Encapsulates methods related to a specific LKE tier. This
+    should not be instantiated on its own, but should instead be used through
+    an instance of :any:`LinodeClient`::
+
+       client = LinodeClient(token)
+       instances = client.lke.tier("standard") # use the LKETierGroup
+
+    This group contains all features beneath the `/lke/tiers/{tier}` group in the API v4.
+    """
+
+    def __init__(self, client: "LinodeClient", tier: str):
+        super().__init__(client)
+        self.tier = tier
+
+    def versions(self, *filters):
+        """
+        Returns a paginated list of versions for this tier matching the given filters.
+
+        API Documentation: Not Yet Available
+
+        :param filters: Any number of filters to apply to this query.
+                        See :doc:`Filtering Collections</linode_api4/objects/filtering>`
+                        for more details on filtering.
+
+        :returns: A paginated list of kube versions that match the query.
+        :rtype: PaginatedList of TieredKubeVersion
+        """
+
+        return self.client._get_and_filter(
+            TieredKubeVersion,
+            endpoint=f"/lke/tiers/{self.tier}/versions",
+            parent_id=self.tier,
+            *filters,
+        )

--- a/linode_api4/linode_client.py
+++ b/linode_api4/linode_client.py
@@ -455,7 +455,13 @@ class LinodeClient:
         )
 
     # helper functions
-    def _get_and_filter(self, obj_type, *filters, endpoint=None):
+    def _get_and_filter(
+        self,
+        obj_type,
+        *filters,
+        endpoint=None,
+        parent_id=None,
+    ):
         parsed_filters = None
         if filters:
             if len(filters) > 1:
@@ -467,8 +473,13 @@ class LinodeClient:
 
         # Use sepcified endpoint
         if endpoint:
-            return self._get_objects(endpoint, obj_type, filters=parsed_filters)
+            return self._get_objects(
+                endpoint, obj_type, parent_id=parent_id, filters=parsed_filters
+            )
         else:
             return self._get_objects(
-                obj_type.api_list(), obj_type, filters=parsed_filters
+                obj_type.api_list(),
+                obj_type,
+                parent_id=parent_id,
+                filters=parsed_filters,
             )

--- a/test/fixtures/lke_clusters_18882.json
+++ b/test/fixtures/lke_clusters_18882.json
@@ -3,13 +3,12 @@
     "status": "ready", 
     "created": "2021-02-10T23:54:21", 
     "updated": "2021-02-10T23:54:21",
-    "label": "example-cluster",
+    "label": "example-cluster-2",
     "region": "ap-west",
-    "k8s_version": "1.19",
-    "tier": "standard",
+    "k8s_version": "1.31.1+lke1",
+    "tier": "enterprise",
     "tags": [],
     "control_plane": {
         "high_availability": true
-    },
-    "apl_enabled": true
+    }
 }

--- a/test/fixtures/lke_clusters_18882_pools_789.json
+++ b/test/fixtures/lke_clusters_18882_pools_789.json
@@ -1,0 +1,18 @@
+{
+    "id": 789,
+    "type": "g6-standard-2",
+    "count": 3,
+    "nodes": [],
+    "disks": [],
+    "autoscaler": {
+        "enabled": false,
+        "min": 3,
+        "max": 3
+    },
+    "labels": {},
+    "taints": [],
+    "tags": [],
+    "disk_encryption": "enabled",
+    "k8s_version": "1.31.1+lke1",
+    "update_strategy": "rolling_update"
+}

--- a/test/fixtures/lke_tiers_standard_versions.json
+++ b/test/fixtures/lke_tiers_standard_versions.json
@@ -1,0 +1,19 @@
+{
+  "data": [
+    {
+      "id": "1.32",
+      "tier": "standard"
+    },
+    {
+      "id": "1.31",
+      "tier": "standard"
+    },
+    {
+      "id": "1.30",
+      "tier": "standard"
+    }
+  ],
+  "page": 1,
+  "pages": 1,
+  "results": 3
+}

--- a/test/integration/models/lke/test_lke.py
+++ b/test/integration/models/lke/test_lke.py
@@ -151,7 +151,7 @@ def lke_cluster_enterprise(test_linode_client):
     node_pools = test_linode_client.lke.node_pool(
         "g6-dedicated-2",
         3,
-        k8s_version=version.id,
+        k8s_version=version,
         update_strategy="rolling_update",
     )
     label = get_test_label() + "_cluster"
@@ -160,7 +160,7 @@ def lke_cluster_enterprise(test_linode_client):
         region,
         label,
         node_pools,
-        version.id,
+        version,
         tier="enterprise",
     )
 

--- a/test/unit/groups/lke_tier_test.py
+++ b/test/unit/groups/lke_tier_test.py
@@ -1,0 +1,18 @@
+from test.unit.base import ClientBaseCase
+
+
+class LKETierGroupTest(ClientBaseCase):
+    """
+    Tests methods under the LKETierGroup class.
+    """
+
+    def test_list_versions(self):
+        """
+        Tests that LKE versions can be listed for a given tier.
+        """
+
+        tiers = self.client.lke.tier("standard").versions()
+
+        assert tiers[0].id == "1.32"
+        assert tiers[1].id == "1.31"
+        assert tiers[2].id == "1.30"


### PR DESCRIPTION
## 📝 Description

This pull request implements support for managing LKE Enterprise enterprise clusters, including the following changes:
* New `lke/tiers/{tier}/versions` and `lke/tiers/{tier}/versions/{version}` endpoints
* New `tier` field when creating and reading LKE clusters
* New `k8s_version` and `update_strategy` fields when creating, updating, and reading LKE node pools

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally and run `make install`.

### Unit Testing

```
make test-unit
```

### Integration Testing

```
make TEST_COMMAND=models/lke test-int
```

### Manual Testing

1. In a linode_api4-python sandbox environment (e.g. dx-devenv), run the following:

```python
import os

from linode_api4 import LinodeClient, TieredKubeVersion


def main():
    client = LinodeClient(os.getenv("LINODE_TOKEN"), base_url="https://api.linode.com/v4beta")

    versions = client.lke.tier("enterprise").versions()
    target_version = versions[0].id

    cluster = client.lke.cluster_create(
        region="us-mia",
        label="test-lke-cluster",
        kube_version=target_version,
        tier="enterprise",
        node_pools=[
            client.lke.node_pool(
                "g6-standard-2",
                3,
                kube_version=target_version,
                update_strategy="on_recycle"
            )
        ]
    )

    print(cluster)

if __name__ == "__main__":
    main()
```

2. Ensure a new matching LKE enterprise cluster is created successfully.