### PR TITLE
Enhanced Interfaces: Add account-related fields

### DIFF
--- a/linode_api4/objects/account.py
+++ b/linode_api4/objects/account.py
@@ -184,6 +184,8 @@ class AccountSettingsInterfacesForNewLinodes(StrEnum):
     """
     A string enum corresponding to valid values
     for the AccountSettings(...).interfaces_for_new_linodes field.
+
+    NOTE: This feature may not currently be available to all users.
     """
 
     legacy_config_only = "legacy_config_only"

--- a/linode_api4/objects/account.py
+++ b/linode_api4/objects/account.py
@@ -197,6 +197,7 @@ class AccountSettings(Base):
         ),
         "object_storage": Property(),
         "backups_enabled": Property(mutable=True),
+        "interfaces_for_new_linodes": Property(mutable=True),
     }
 
 

--- a/linode_api4/objects/account.py
+++ b/linode_api4/objects/account.py
@@ -16,6 +16,7 @@ from linode_api4.objects.longview import LongviewClient, LongviewSubscription
 from linode_api4.objects.networking import Firewall
 from linode_api4.objects.nodebalancer import NodeBalancer
 from linode_api4.objects.profile import PersonalAccessToken
+from linode_api4.objects.serializable import StrEnum
 from linode_api4.objects.support import SupportTicket
 from linode_api4.objects.volume import Volume
 from linode_api4.objects.vpc import VPC
@@ -177,6 +178,22 @@ class Login(Base):
         "status": Property(),
         "username": Property(),
     }
+
+
+class AccountSettingsInterfacesForNewLinodes(StrEnum):
+    """
+    A string enum corresponding to valid values
+    for the AccountSettings(...).interfaces_for_new_linodes field.
+    """
+
+    legacy_config_only = "legacy_config_only"
+    legacy_config_default_but_linode_allowed = (
+        "legacy_config_default_but_linode_allowed"
+    )
+    linode_default_but_legacy_config_allowed = (
+        "linode_default_but_legacy_config_allowed"
+    )
+    linode_only = "linode_only"
 
 
 class AccountSettings(Base):

--- a/test/fixtures/account.json
+++ b/test/fixtures/account.json
@@ -16,7 +16,8 @@
     "Linodes",
     "NodeBalancers",
     "Block Storage",
-    "Object Storage"
+    "Object Storage",
+    "Linode Interfaces"
   ],
   "active_promotions": [
     {

--- a/test/fixtures/account_settings.json
+++ b/test/fixtures/account_settings.json
@@ -3,5 +3,6 @@
   "managed": false,
   "network_helper": false,
   "object_storage": "active",
-  "backups_enabled": true
+  "backups_enabled": true,
+  "interfaces_for_new_linodes": "linode_default_but_legacy_config_allowed"
 }

--- a/test/integration/models/account/test_account.py
+++ b/test/integration/models/account/test_account.py
@@ -59,6 +59,7 @@ def test_get_account_settings(test_linode_client):
     assert "longview_subscription" in str(account_settings._raw_json)
     assert "backups_enabled" in str(account_settings._raw_json)
     assert "object_storage" in str(account_settings._raw_json)
+    assert isinstance(account_settings.interfaces_for_new_linodes, str)
 
 
 @pytest.mark.smoke

--- a/test/unit/linode_client_test.py
+++ b/test/unit/linode_client_test.py
@@ -44,7 +44,13 @@ class LinodeClientGeneralTest(ClientBaseCase):
         self.assertEqual(a.balance, 0)
         self.assertEqual(
             a.capabilities,
-            ["Linodes", "NodeBalancers", "Block Storage", "Object Storage"],
+            [
+                "Linodes",
+                "NodeBalancers",
+                "Block Storage",
+                "Object Storage",
+                "Linode Interfaces",
+            ],
         )
 
     def test_get_regions(self):

--- a/test/unit/objects/account_test.py
+++ b/test/unit/objects/account_test.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 from datetime import datetime
 from test.unit.base import ClientBaseCase
 
+from linode_api4 import AccountSettingsInterfacesForNewLinodes
 from linode_api4.objects import (
     Account,
     AccountAvailability,
@@ -124,7 +125,7 @@ class InvoiceTest(ClientBaseCase):
         self.assertEqual(settings.backups_enabled, True)
         self.assertEqual(
             settings.interfaces_for_new_linodes,
-            "linode_default_but_legacy_config_allowed",
+            AccountSettingsInterfacesForNewLinodes.linode_default_but_legacy_config_allowed,
         )
 
     def test_post_account_settings(self):
@@ -136,7 +137,9 @@ class InvoiceTest(ClientBaseCase):
 
         settings.network_helper = True
         settings.backups_enabled = False
-        settings.interfaces_for_new_linodes = "linode_only"
+        settings.interfaces_for_new_linodes = (
+            AccountSettingsInterfacesForNewLinodes.linode_only
+        )
 
         with self.mock_put("/account/settings") as m:
             settings.save()
@@ -144,7 +147,7 @@ class InvoiceTest(ClientBaseCase):
             assert m.call_data == {
                 "network_helper": True,
                 "backups_enabled": False,
-                "interfaces_for_new_linodes": "linode_only",
+                "interfaces_for_new_linodes": AccountSettingsInterfacesForNewLinodes.linode_only,
             }
 
     def test_get_event(self):

--- a/test/unit/objects/account_test.py
+++ b/test/unit/objects/account_test.py
@@ -97,6 +97,7 @@ class InvoiceTest(ClientBaseCase):
         self.assertEqual(account.balance_uninvoiced, 145)
         self.assertEqual(account.billing_source, "akamai")
         self.assertEqual(account.euuid, "E1AF5EEC-526F-487D-B317EBEB34C87D71")
+        self.assertIn("Linode Interfaces", account.capabilities)
 
     def test_get_login(self):
         """
@@ -121,6 +122,30 @@ class InvoiceTest(ClientBaseCase):
         self.assertEqual(settings.network_helper, False)
         self.assertEqual(settings.object_storage, "active")
         self.assertEqual(settings.backups_enabled, True)
+        self.assertEqual(
+            settings.interfaces_for_new_linodes,
+            "linode_default_but_legacy_config_allowed",
+        )
+
+    def test_post_account_settings(self):
+        """
+        Tests that account settings can be updated successfully
+        """
+        settings = self.client.account.settings()
+        print(settings._raw_json)
+
+        settings.network_helper = True
+        settings.backups_enabled = False
+        settings.interfaces_for_new_linodes = "linode_only"
+
+        with self.mock_put("/account/settings") as m:
+            settings.save()
+
+            assert m.call_data == {
+                "network_helper": True,
+                "backups_enabled": False,
+                "interfaces_for_new_linodes": "linode_only",
+            }
 
     def test_get_event(self):
         """

--- a/test/unit/objects/account_test.py
+++ b/test/unit/objects/account_test.py
@@ -133,7 +133,6 @@ class InvoiceTest(ClientBaseCase):
         Tests that account settings can be updated successfully
         """
         settings = self.client.account.settings()
-        print(settings._raw_json)
 
         settings.network_helper = True
         settings.backups_enabled = False


### PR DESCRIPTION
## 📝 Description

This pull request adds support for Enhanced Interfaces fields relating to the current account.

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally and run `make install`. Additionally, these tests require that your account has access to enhanced/Linode-level interfaces.

### Unit Testing

```
make test-int
```

### Integration Testing

```
make test-int TEST_COMMAND=models/account
```

### Manual Testing (non-destructive)

1. In a linode_api4-python sandbox environment (e.g. dx-devenv), run the following:

```python
import os

from linode_api4 import LinodeClient

client = LinodeClient(os.getenv("LINODE_TOKEN"), base_url="https://api.linode.com/v4beta")

account = client.account()
account_settings = client.account.settings()

print("account.capabilities:", account.capabilities)
print("account_settings.interfaces_for_new_linodes:", account_settings.interfaces_for_new_linodes)
```

2. Ensure the output looks similar to the following:

```
account.capabilities: [..., 'Linode Interfaces']
account_settings.interfaces_for_new_linodes: legacy_config_default_but_linode_allowed
```