### PR TITLE
Enhanced Interfaces: Implement endpoints & fields related to VPCs and non-interface networking

### DIFF
--- a/linode_api4/groups/networking.py
+++ b/linode_api4/groups/networking.py
@@ -120,6 +120,8 @@ class NetworkingGroup(Group):
 
         API Documentation: Not yet available.
 
+        NOTE: This feature may not currently be available to all users.
+
         :returns: An object representing the Linode Firewall settings for the current user.
         :rtype: FirewallSettings
         """

--- a/linode_api4/objects/networking.py
+++ b/linode_api4/objects/networking.py
@@ -1,5 +1,5 @@
-from dataclasses import dataclass
-from typing import Optional
+from dataclasses import dataclass, field
+from typing import List, Optional
 
 from linode_api4.common import Price, RegionPrice
 from linode_api4.errors import UnexpectedResponseError
@@ -87,6 +87,7 @@ class IPAddress(Base):
         "public": Property(),
         "rdns": Property(mutable=True),
         "linode_id": Property(),
+        "interface_id": Property(),
         "region": Property(slug_relationship=Region),
         "vpc_nat_1_1": Property(json_object=InstanceIPNAT1To1),
     }
@@ -98,6 +99,8 @@ class IPAddress(Base):
         if not hasattr(self, "_linode"):
             self._set("_linode", Instance(self._client, self.linode_id))
         return self._linode
+
+    # TODO (Enhanced Interfaces): Add `interface` property method
 
     def to(self, linode):
         """
@@ -173,6 +176,47 @@ class VLAN(Base):
         "created": Property(is_datetime=True),
         "linodes": Property(unordered=True),
         "region": Property(slug_relationship=Region),
+    }
+
+
+@dataclass
+class FirewallCreateDevicesOptions(JSONObject):
+    """
+    Represents devices to create created alongside a Linode Firewall.
+    """
+
+    linodes: List[int] = field(default_factory=list)
+    nodebalancers: List[int] = field(default_factory=list)
+    interfaces: List[int] = field(default_factory=list)
+
+
+@dataclass
+class FirewallSettingsDefaultFirewallIDs(JSONObject):
+    """
+    Contains the IDs of Linode Firewalls that should be used by default
+    when creating various interface types.
+    """
+
+    vpc_interface: Optional[int] = None
+    public_interface: Optional[int] = None
+    linode: Optional[int] = None
+    nodebalancer: Optional[int] = None
+
+
+class FirewallSettings(Base):
+    """
+    Represents the Firewall settings for the current user.
+
+    API Documentation: Not yet available.
+    """
+
+    api_endpoint = "/networking/firewalls/settings"
+
+    properties = {
+        "default_firewall_ids": Property(
+            json_object=FirewallSettingsDefaultFirewallIDs,
+            mutable=True,
+        ),
     }
 
 

--- a/linode_api4/objects/networking.py
+++ b/linode_api4/objects/networking.py
@@ -195,6 +195,8 @@ class FirewallSettingsDefaultFirewallIDs(JSONObject):
     """
     Contains the IDs of Linode Firewalls that should be used by default
     when creating various interface types.
+
+    NOTE: This feature may not currently be available to all users.
     """
 
     vpc_interface: Optional[int] = None
@@ -208,6 +210,8 @@ class FirewallSettings(Base):
     Represents the Firewall settings for the current user.
 
     API Documentation: Not yet available.
+
+    NOTE: This feature may not currently be available to all users.
     """
 
     api_endpoint = "/networking/firewalls/settings"

--- a/linode_api4/objects/vpc.py
+++ b/linode_api4/objects/vpc.py
@@ -11,6 +11,7 @@ from linode_api4.paginated_list import PaginatedList
 @dataclass
 class VPCSubnetLinodeInterface(JSONObject):
     id: int = 0
+    config_id: Optional[int] = None
     active: bool = False
 
 

--- a/test/fixtures/networking_firewalls_123_devices.json
+++ b/test/fixtures/networking_firewalls_123_devices.json
@@ -10,9 +10,20 @@
       },
       "id": 123,
       "updated": "2018-01-02T00:01:01"
+    },
+    {
+      "created": "2018-01-01T00:01:01",
+      "entity": {
+        "id": 123,
+        "label": null,
+        "type": "interface",
+        "url": "/v4/linode/instances/123/interfaces/123"
+      },
+      "id": 456,
+      "updated": "2018-01-02T00:01:01"
     }
   ],
   "page": 1,
   "pages": 1,
-  "results": 1
+  "results": 2
 }

--- a/test/fixtures/networking_firewalls_123_devices_456.json
+++ b/test/fixtures/networking_firewalls_123_devices_456.json
@@ -1,0 +1,11 @@
+{
+  "created": "2018-01-01T00:01:01",
+  "entity": {
+    "id": 123,
+    "label": null,
+    "type": "interface",
+    "url": "/v4/linode/instances/123/interfaces/123"
+  },
+  "id": 456,
+  "updated": "2018-01-02T00:01:01"
+}

--- a/test/fixtures/networking_firewalls_settings.json
+++ b/test/fixtures/networking_firewalls_settings.json
@@ -1,0 +1,8 @@
+{
+   "default_firewall_ids": {
+      "vpc_interface": 123,
+      "public_interface": 456,
+      "linode": 789,
+      "nodebalancer": 321
+   }
+}

--- a/test/fixtures/networking_ips_127.0.0.1.json
+++ b/test/fixtures/networking_ips_127.0.0.1.json
@@ -2,6 +2,7 @@
   "address": "127.0.0.1",
   "gateway": "127.0.0.1",
   "linode_id": 123,
+  "interface_id": 456,
   "prefix": 24,
   "public": true,
   "rdns": "test.example.org",

--- a/test/fixtures/regions.json
+++ b/test/fixtures/regions.json
@@ -6,7 +6,8 @@
       "capabilities": [
         "Linodes",
         "NodeBalancers",
-        "Block Storage"
+        "Block Storage",
+        "Linode Interfaces"
       ],
       "status": "ok",
       "resolvers": {
@@ -26,7 +27,8 @@
       "capabilities": [
         "Linodes",
         "NodeBalancers",
-        "Block Storage"
+        "Block Storage",
+        "Linode Interfaces"
       ],
       "status": "ok",
       "resolvers": {
@@ -46,7 +48,8 @@
       "capabilities": [
         "Linodes",
         "NodeBalancers",
-        "Block Storage"
+        "Block Storage",
+        "Linode Interfaces"
       ],
       "status": "ok",
       "resolvers": {
@@ -62,7 +65,8 @@
       "capabilities": [
         "Linodes",
         "NodeBalancers",
-        "Block Storage"
+        "Block Storage",
+        "Linode Interfaces"
       ],
       "status": "ok",
       "resolvers": {
@@ -82,7 +86,8 @@
       "capabilities": [
         "Linodes",
         "NodeBalancers",
-        "Block Storage"
+        "Block Storage",
+        "Linode Interfaces"
       ],
       "status": "ok",
       "resolvers": {
@@ -102,7 +107,8 @@
       "capabilities": [
         "Linodes",
         "NodeBalancers",
-        "Block Storage"
+        "Block Storage",
+        "Linode Interfaces"
       ],
       "status": "ok",
       "resolvers": {
@@ -123,7 +129,8 @@
         "Linodes",
         "NodeBalancers",
         "Block Storage",
-        "Object Storage"
+        "Object Storage",
+        "Linode Interfaces"
       ],
       "status": "ok",
       "resolvers": {
@@ -143,7 +150,8 @@
       "capabilities": [
         "Linodes",
         "NodeBalancers",
-        "Block Storage"
+        "Block Storage",
+        "Linode Interfaces"
       ],
       "status": "ok",
       "resolvers": {
@@ -164,7 +172,8 @@
         "Linodes",
         "NodeBalancers",
         "Block Storage",
-        "Object Storage"
+        "Object Storage",
+        "Linode Interfaces"
       ],
       "status": "ok",
       "resolvers": {
@@ -185,7 +194,8 @@
         "Linodes",
         "NodeBalancers",
         "Block Storage",
-        "Object Storage"
+        "Object Storage",
+        "Linode Interfaces"
       ],
       "status": "ok",
       "resolvers": {
@@ -205,7 +215,8 @@
       "capabilities": [
         "Linodes",
         "NodeBalancers",
-        "Block Storage"
+        "Block Storage",
+        "Linode Interfaces"
       ],
       "status": "ok",
       "resolvers": {

--- a/test/fixtures/vpcs_123456_subnets.json
+++ b/test/fixtures/vpcs_123456_subnets.json
@@ -10,11 +10,13 @@
           "interfaces": [
             {
               "id": 678,
-              "active": true
+              "active": true,
+              "config_id": null
             },
             {
               "id": 543,
-              "active": false
+              "active": false,
+              "config_id": null
             }
           ]
         }

--- a/test/fixtures/vpcs_123456_subnets_789.json
+++ b/test/fixtures/vpcs_123456_subnets_789.json
@@ -8,11 +8,13 @@
       "interfaces": [
         {
           "id": 678,
-          "active": true
+          "active": true,
+          "config_id": null
         },
         {
           "id": 543,
-          "active": false
+          "active": false,
+          "config_id": null
         }
       ]
     }

--- a/test/integration/linode_client/test_linode_client.py
+++ b/test/integration/linode_client/test_linode_client.py
@@ -6,7 +6,11 @@ from test.integration.helpers import get_test_label
 import pytest
 
 from linode_api4 import ApiError
-from linode_api4.objects import ConfigInterface, ObjectStorageKeys, Region
+from linode_api4.objects import (
+    ConfigInterface,
+    ObjectStorageKeys,
+    Region,
+)
 
 
 @pytest.fixture(scope="session")

--- a/test/unit/linode_client_test.py
+++ b/test/unit/linode_client_test.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from test.unit.base import ClientBaseCase
 
-from linode_api4 import LongviewSubscription
+from linode_api4 import FirewallCreateDevicesOptions, LongviewSubscription
 from linode_api4.objects.beta import BetaProgram
 from linode_api4.objects.linode import Instance
 from linode_api4.objects.networking import IPAddress
@@ -63,12 +63,18 @@ class LinodeClientGeneralTest(ClientBaseCase):
                         "NodeBalancers",
                         "Block Storage",
                         "Object Storage",
+                        "Linode Interfaces",
                     ],
                 )
             else:
                 self.assertEqual(
                     region.capabilities,
-                    ["Linodes", "NodeBalancers", "Block Storage"],
+                    [
+                        "Linodes",
+                        "NodeBalancers",
+                        "Block Storage",
+                        "Linode Interfaces",
+                    ],
                 )
             self.assertEqual(region.status, "ok")
             self.assertIsNotNone(region.resolvers)
@@ -1185,7 +1191,12 @@ class NetworkingGroupTest(ClientBaseCase):
             }
 
             f = self.client.networking.firewall_create(
-                "test-firewall-1", rules, status="enabled"
+                "test-firewall-1",
+                rules,
+                devices=FirewallCreateDevicesOptions(
+                    linodes=[123], nodebalancers=[456], interfaces=[789]
+                ),
+                status="enabled",
             )
 
             self.assertIsNotNone(f)
@@ -1200,6 +1211,11 @@ class NetworkingGroupTest(ClientBaseCase):
                     "label": "test-firewall-1",
                     "status": "enabled",
                     "rules": rules,
+                    "devices": {
+                        "linodes": [123],
+                        "nodebalancers": [456],
+                        "interfaces": [789],
+                    },
                 },
             )
 
@@ -1213,6 +1229,47 @@ class NetworkingGroupTest(ClientBaseCase):
         firewall = f[0]
 
         self.assertEqual(firewall.id, 123)
+
+    def test_get_firewall_settings(self):
+        """
+        Tests that firewall settings can be retrieved
+        """
+        settings = self.client.networking.firewall_settings()
+
+        assert settings.default_firewall_ids.vpc_interface == 123
+        assert settings.default_firewall_ids.public_interface == 456
+        assert settings.default_firewall_ids.linode == 789
+        assert settings.default_firewall_ids.nodebalancer == 321
+
+        settings.invalidate()
+
+        assert settings.default_firewall_ids.vpc_interface == 123
+        assert settings.default_firewall_ids.public_interface == 456
+        assert settings.default_firewall_ids.linode == 789
+        assert settings.default_firewall_ids.nodebalancer == 321
+
+    def test_update_firewall_settings(self):
+        """
+        Tests that firewall settings can be updated
+        """
+        settings = self.client.networking.firewall_settings()
+
+        settings.default_firewall_ids.vpc_interface = 321
+        settings.default_firewall_ids.public_interface = 654
+        settings.default_firewall_ids.linode = 987
+        settings.default_firewall_ids.nodebalancer = 123
+
+        with self.mock_put("networking/firewalls/settings") as m:
+            settings.save()
+
+            assert m.call_data == {
+                "default_firewall_ids": {
+                    "vpc_interface": 321,
+                    "public_interface": 654,
+                    "linode": 987,
+                    "nodebalancer": 123,
+                }
+            }
 
     def test_ip_addresses_share(self):
         """

--- a/test/unit/objects/firewall_test.py
+++ b/test/unit/objects/firewall_test.py
@@ -54,6 +54,21 @@ class FirewallTest(ClientBaseCase):
 
             self.assertEqual(m.call_data, new_rules)
 
+    def test_create_device(self):
+        """
+        Tests that firewall devices can be created successfully
+        """
+
+        firewall = Firewall(self.client, 123)
+
+        with self.mock_post("networking/firewalls/123/devices/123") as m:
+            firewall.device_create(123, "linode")
+            assert m.call_data == {"id": 123, "type": "linode"}
+
+        with self.mock_post("networking/firewalls/123/devices/456") as m:
+            firewall.device_create(123, "interface")
+            assert m.call_data == {"id": 123, "type": "interface"}
+
 
 class FirewallDevicesTest(ClientBaseCase):
     """
@@ -65,7 +80,28 @@ class FirewallDevicesTest(ClientBaseCase):
         Tests that devices can be pulled from a firewall
         """
         firewall = Firewall(self.client, 123)
-        self.assertEqual(len(firewall.devices), 1)
+        assert len(firewall.devices) == 2
+
+        assert firewall.devices[0].created is not None
+        assert firewall.devices[0].id == 123
+        assert firewall.devices[0].updated is not None
+
+        assert firewall.devices[0].entity.id == 123
+        assert firewall.devices[0].entity.label == "my-linode"
+        assert firewall.devices[0].entity.type == "linode"
+        assert firewall.devices[0].entity.url == "/v4/linode/instances/123"
+
+        assert firewall.devices[1].created is not None
+        assert firewall.devices[1].id == 456
+        assert firewall.devices[1].updated is not None
+
+        assert firewall.devices[1].entity.id == 123
+        assert firewall.devices[1].entity.label is None
+        assert firewall.devices[1].entity.type == "interface"
+        assert (
+            firewall.devices[1].entity.url
+            == "/v4/linode/instances/123/interfaces/123"
+        )
 
     def test_get_device(self):
         """

--- a/test/unit/objects/networking_test.py
+++ b/test/unit/objects/networking_test.py
@@ -121,16 +121,31 @@ class NetworkingTest(ClientBaseCase):
 
             self.assertEqual(m.call_data_raw, '{"rdns": null}')
 
-    def test_vpc_nat_1_1(self):
+    def test_get_ip(self):
         """
         Tests that the vpc_nat_1_1 of an IP can be retrieved.
         """
 
         ip = IPAddress(self.client, "127.0.0.1")
 
-        self.assertEqual(ip.vpc_nat_1_1.vpc_id, 242)
-        self.assertEqual(ip.vpc_nat_1_1.subnet_id, 194)
-        self.assertEqual(ip.vpc_nat_1_1.address, "139.144.244.36")
+        def __validate_ip(_ip: IPAddress):
+            assert _ip.address == "127.0.0.1"
+            assert _ip.gateway == "127.0.0.1"
+            assert _ip.linode_id == 123
+            assert _ip.interface_id == 456
+            assert _ip.prefix == 24
+            assert _ip.public
+            assert _ip.rdns == "test.example.org"
+            assert _ip.region.id == "us-east"
+            assert _ip.subnet_mask == "255.255.255.0"
+            assert _ip.type == "ipv4"
+            assert _ip.vpc_nat_1_1.vpc_id == 242
+            assert _ip.vpc_nat_1_1.subnet_id == 194
+            assert _ip.vpc_nat_1_1.address == "139.144.244.36"
+
+        __validate_ip(ip)
+        ip.invalidate()
+        __validate_ip(ip)
 
     def test_delete_ip(self):
         """

--- a/test/unit/objects/region_test.py
+++ b/test/unit/objects/region_test.py
@@ -15,7 +15,6 @@ class RegionTest(ClientBaseCase):
         region = Region(self.client, "us-east")
 
         self.assertEqual(region.id, "us-east")
-        self.assertIsNotNone(region.capabilities)
         self.assertEqual(region.country, "us")
         self.assertEqual(region.label, "label7")
         self.assertEqual(region.status, "ok")
@@ -27,6 +26,9 @@ class RegionTest(ClientBaseCase):
         self.assertEqual(
             region.placement_group_limits.maximum_linodes_per_pg, 5
         )
+
+        self.assertIsNotNone(region.capabilities)
+        self.assertIn("Linode Interfaces", region.capabilities)
 
     def test_region_availability(self):
         """

--- a/test/unit/objects/vpc_test.py
+++ b/test/unit/objects/vpc_test.py
@@ -118,11 +118,19 @@ class VPCTest(ClientBaseCase):
             "2018-01-01T00:01:01", DATE_FORMAT
         )
 
-        self.assertEqual(subnet.label, "test-subnet")
-        self.assertEqual(subnet.ipv4, "10.0.0.0/24")
-        self.assertEqual(subnet.linodes[0].id, 12345)
-        self.assertEqual(subnet.created, expected_dt)
-        self.assertEqual(subnet.updated, expected_dt)
+        assert subnet.label == "test-subnet"
+        assert subnet.ipv4 == "10.0.0.0/24"
+        assert subnet.linodes[0].id == 12345
+        assert subnet.created == expected_dt
+        assert subnet.updated == expected_dt
+
+        assert subnet.linodes[0].interfaces[0].id == 678
+        assert subnet.linodes[0].interfaces[0].active
+        assert subnet.linodes[0].interfaces[0].config_id is None
+
+        assert subnet.linodes[0].interfaces[1].id == 543
+        assert not subnet.linodes[0].interfaces[1].active
+        assert subnet.linodes[0].interfaces[1].config_id is None
 
     def test_list_vpc_ips(self):
         """


### PR DESCRIPTION
## 📝 Description

This pull request adds support for Enhanced Interfaces endpoints and fields related to VPCs and non-interface networking.

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally and run `make install`. Additionally, these test steps require that your Linode account has access to Enhanced Interfaces.

### Unit Testing

```
make test-unit
```

### Integration Testing

```
make test-int TEST_COMMAND=linode_client
make test-int TEST_COMMAND=models/networking
```

### Manual Testing

1. In a linode_api4-python sandbox environment (e.g. dx-devenv), run the following:

```python
import os

from linode_api4 import LinodeClient, FirewallCreateDevicesOptions, IPAddress

client = LinodeClient(os.getenv("LINODE_TOKEN"), base_url="https://api.linode.com/v4beta")

region = next(region for region in client.regions() if "Linode Interfaces" in region.capabilities)

global_firewall_settings = client.networking.firewall_settings()

instance = client.linode.instance_create(
    label="linode-api4-test",
    region=region.id,
    ltype="g6-nanode-1"
)

firewall = client.networking.firewall_create(
    label="linode-api4-test",
    rules={
        "inbound_policy": "DROP",
        "outbound_policy": "DROP"
    },
    devices=FirewallCreateDevicesOptions(
        linodes=[instance.id],
    )
)

instance_ip = client.load(IPAddress, instance.ipv4[0])

print("Region with `Linode Interfaces` capability:", region.id)
print("Global firewall settings:", global_firewall_settings._raw_json)
print("Firewall device entity:", vars(firewall.devices[0].entity))

instance.delete()
firewall.delete()
```

2. Ensure the output looks similar to the following:

```
Region with `Linode Interfaces` capability: ap-west
Global firewall settings: {'default_firewall_ids': {'linode': None, 'nodebalancer': None, 'public_interface': None, 'vpc_interface': None}}
Firewall device entity: {'id': 74954050, 'type': 'linode', 'label': 'linode-api4-test', 'url': '/v4/linode/instances/74954050'}
```
