### PR TITLE
Enhanced Interfaces: Add support for Firewall templates

### DIFF
--- a/linode_api4/groups/networking.py
+++ b/linode_api4/groups/networking.py
@@ -4,6 +4,7 @@ from linode_api4.objects import (
     VLAN,
     Base,
     Firewall,
+    FirewallTemplate,
     Instance,
     IPAddress,
     IPv6Pool,
@@ -93,6 +94,21 @@ class NetworkingGroup(Group):
 
         f = Firewall(self.client, result["id"], result)
         return f
+
+    def firewall_templates(self, *filters):
+        """
+        Returns a list of Firewall Templates available to the current user.
+
+        API Documentation: Not yet available.
+
+        :param filters: Any number of filters to apply to this query.
+                        See :doc:`Filtering Collections</linode_api4/objects/filtering>`
+                        for more details on filtering.
+
+        :returns: A list of Firewall Templates available to the current user.
+        :rtype: PaginatedList of FirewallTemplate
+        """
+        return self.client._get_and_filter(FirewallTemplate, *filters)
 
     def ips(self, *filters):
         """

--- a/linode_api4/groups/networking.py
+++ b/linode_api4/groups/networking.py
@@ -101,6 +101,8 @@ class NetworkingGroup(Group):
 
         API Documentation: Not yet available.
 
+        NOTE: This feature may not currently be available to all users.
+
         :param filters: Any number of filters to apply to this query.
                         See :doc:`Filtering Collections</linode_api4/objects/filtering>`
                         for more details on filtering.

--- a/linode_api4/objects/networking.py
+++ b/linode_api4/objects/networking.py
@@ -307,6 +307,20 @@ class Firewall(Base):
         return c
 
 
+class FirewallTemplate(Base):
+    """
+    Represents a single Linode Firewall template.
+
+    API documentation: Not yet available.
+    """
+
+    api_endpoint = "/networking/firewalls/templates/{slug}"
+
+    id_attribute = "slug"
+
+    properties = {"slug": Property(identifier=True), "rules": Property()}
+
+
 class NetworkTransferPrice(Base):
     """
     An NetworkTransferPrice represents the structure of a valid network transfer price.

--- a/linode_api4/objects/networking.py
+++ b/linode_api4/objects/networking.py
@@ -312,6 +312,8 @@ class FirewallTemplate(Base):
     Represents a single Linode Firewall template.
 
     API documentation: Not yet available.
+
+    NOTE: This feature may not currently be available to all users.
     """
 
     api_endpoint = "/networking/firewalls/templates/{slug}"

--- a/test/fixtures/networking_firewalls_templates.json
+++ b/test/fixtures/networking_firewalls_templates.json
@@ -1,0 +1,93 @@
+{
+  "data": [
+    {
+      "slug": "public",
+      "rules": {
+        "outbound": [
+          {
+            "action": "ACCEPT",
+            "addresses": {
+              "ipv4": [
+                "192.0.2.0/24",
+                "198.51.100.2/32"
+              ],
+              "ipv6": [
+                "2001:DB8::/128"
+              ]
+            },
+            "description": "test",
+            "label": "test-rule",
+            "ports": "22-24, 80, 443",
+            "protocol": "TCP"
+          }
+        ],
+        "outbound_policy": "DROP",
+        "inbound": [
+          {
+            "action": "ACCEPT",
+            "addresses": {
+              "ipv4": [
+                "192.0.2.0/24",
+                "198.51.100.2/32"
+              ],
+              "ipv6": [
+                "2001:DB8::/128"
+              ]
+            },
+            "description": "test",
+            "label": "test-rule",
+            "ports": "22-24, 80, 443",
+            "protocol": "TCP"
+          }
+        ],
+        "inbound_policy": "DROP"
+      }
+    },
+    {
+      "slug": "vpc",
+      "rules": {
+        "outbound": [
+          {
+            "action": "ACCEPT",
+            "addresses": {
+              "ipv4": [
+                "192.0.2.0/24",
+                "198.51.100.2/32"
+              ],
+              "ipv6": [
+                "2001:DB8::/128"
+              ]
+            },
+            "description": "test",
+            "label": "test-rule",
+            "ports": "22-24, 80, 443",
+            "protocol": "TCP"
+          }
+        ],
+        "outbound_policy": "DROP",
+        "inbound": [
+          {
+            "action": "ACCEPT",
+            "addresses": {
+              "ipv4": [
+                "192.0.2.0/24",
+                "198.51.100.2/32"
+              ],
+              "ipv6": [
+                "2001:DB8::/128"
+              ]
+            },
+            "description": "test",
+            "label": "test-rule",
+            "ports": "22-24, 80, 443",
+            "protocol": "TCP"
+          }
+        ],
+        "inbound_policy": "DROP"
+      }
+    }
+  ],
+  "page": 1,
+  "pages": 1,
+  "results": 2
+}

--- a/test/fixtures/networking_firewalls_templates_public.json
+++ b/test/fixtures/networking_firewalls_templates_public.json
@@ -1,0 +1,43 @@
+{
+  "slug": "public",
+  "rules": {
+    "outbound": [
+      {
+        "action": "ACCEPT",
+        "addresses": {
+          "ipv4": [
+            "192.0.2.0/24",
+            "198.51.100.2/32"
+          ],
+          "ipv6": [
+            "2001:DB8::/128"
+          ]
+        },
+        "description": "test",
+        "label": "test-rule",
+        "ports": "22-24, 80, 443",
+        "protocol": "TCP"
+      }
+    ],
+    "outbound_policy": "DROP",
+    "inbound": [
+      {
+        "action": "ACCEPT",
+        "addresses": {
+          "ipv4": [
+            "192.0.2.0/24",
+            "198.51.100.2/32"
+          ],
+          "ipv6": [
+            "2001:DB8::/128"
+          ]
+        },
+        "description": "test",
+        "label": "test-rule",
+        "ports": "22-24, 80, 443",
+        "protocol": "TCP"
+      }
+    ],
+    "inbound_policy": "DROP"
+  }
+}

--- a/test/fixtures/networking_firewalls_templates_vpc.json
+++ b/test/fixtures/networking_firewalls_templates_vpc.json
@@ -1,0 +1,43 @@
+{
+  "slug": "vpc",
+  "rules": {
+    "outbound": [
+      {
+        "action": "ACCEPT",
+        "addresses": {
+          "ipv4": [
+            "192.0.2.0/24",
+            "198.51.100.2/32"
+          ],
+          "ipv6": [
+            "2001:DB8::/128"
+          ]
+        },
+        "description": "test",
+        "label": "test-rule",
+        "ports": "22-24, 80, 443",
+        "protocol": "TCP"
+      }
+    ],
+    "outbound_policy": "DROP",
+    "inbound": [
+      {
+        "action": "ACCEPT",
+        "addresses": {
+          "ipv4": [
+            "192.0.2.0/24",
+            "198.51.100.2/32"
+          ],
+          "ipv6": [
+            "2001:DB8::/128"
+          ]
+        },
+        "description": "test",
+        "label": "test-rule",
+        "ports": "22-24, 80, 443",
+        "protocol": "TCP"
+      }
+    ],
+    "inbound_policy": "DROP"
+  }
+}

--- a/test/integration/models/firewall/test_firewall_templates.py
+++ b/test/integration/models/firewall/test_firewall_templates.py
@@ -11,7 +11,7 @@ def __assert_firewall_template_rules(rules: MappedObject):
     assert len(rules.outbound_policy) > 0
 
     assert isinstance(rules.outbound, list)
-    assert (rules.inbound, list)
+    assert isinstance(rules.inbound, list)
 
 
 def test_list_firewall_templates(test_linode_client):

--- a/test/integration/models/firewall/test_firewall_templates.py
+++ b/test/integration/models/firewall/test_firewall_templates.py
@@ -1,0 +1,33 @@
+from linode_api4 import FirewallTemplate, MappedObject
+
+
+def __assert_firewall_template_rules(rules: MappedObject):
+    # We can't confidently say that these rules will not be changed
+    # in the future, so we can just do basic assertions here.
+    assert isinstance(rules.inbound_policy, str)
+    assert len(rules.inbound_policy) > 0
+
+    assert isinstance(rules.outbound_policy, str)
+    assert len(rules.outbound_policy) > 0
+
+    assert isinstance(rules.outbound, list)
+    assert (rules.inbound, list)
+
+
+def test_list_firewall_templates(test_linode_client):
+    templates = test_linode_client.networking.firewall_templates()
+    assert len(templates) > 0
+
+    for template in templates:
+        assert isinstance(template.slug, str)
+        assert len(template.slug) > 0
+
+        __assert_firewall_template_rules(template.rules)
+
+
+def test_get_firewall_template(test_linode_client):
+    template = test_linode_client.load(FirewallTemplate, "vpc")
+
+    assert template.slug == "vpc"
+
+    __assert_firewall_template_rules(template.rules)

--- a/test/unit/groups/networking_test.py
+++ b/test/unit/groups/networking_test.py
@@ -1,0 +1,17 @@
+from test.unit.base import ClientBaseCase
+from test.unit.objects.firewall_test import FirewallTemplatesTest
+
+
+class NetworkingGroupTest(ClientBaseCase):
+    """
+    Tests methods under the NetworkingGroup class.
+    """
+
+    def test_get_templates(self):
+        templates = self.client.networking.firewall_templates()
+
+        assert templates[0].slug == "public"
+        FirewallTemplatesTest.assert_rules(templates[0].rules)
+
+        assert templates[1].slug == "vpc"
+        FirewallTemplatesTest.assert_rules(templates[1].rules)

--- a/test/unit/objects/firewall_test.py
+++ b/test/unit/objects/firewall_test.py
@@ -1,5 +1,6 @@
 from test.unit.base import ClientBaseCase
 
+from linode_api4 import FirewallTemplate, MappedObject
 from linode_api4.objects import Firewall, FirewallDevice
 
 
@@ -81,3 +82,43 @@ class FirewallDevicesTest(ClientBaseCase):
         self.assertEqual(device.entity.url, "/v4/linode/instances/123")
 
         self.assertEqual(device._populated, True)
+
+
+class FirewallTemplatesTest(ClientBaseCase):
+    @staticmethod
+    def assert_rules(rules: MappedObject):
+        assert rules.outbound_policy == "DROP"
+        assert len(rules.outbound) == 1
+
+        assert rules.inbound_policy == "DROP"
+        assert len(rules.inbound) == 1
+
+        outbound_rule = rules.outbound[0]
+        assert outbound_rule.action == "ACCEPT"
+        assert outbound_rule.addresses.ipv4[0] == "192.0.2.0/24"
+        assert outbound_rule.addresses.ipv4[1] == "198.51.100.2/32"
+        assert outbound_rule.addresses.ipv6[0] == "2001:DB8::/128"
+        assert outbound_rule.description == "test"
+        assert outbound_rule.label == "test-rule"
+        assert outbound_rule.ports == "22-24, 80, 443"
+        assert outbound_rule.protocol == "TCP"
+
+        inbound_rule = rules.outbound[0]
+        assert inbound_rule.action == "ACCEPT"
+        assert inbound_rule.addresses.ipv4[0] == "192.0.2.0/24"
+        assert inbound_rule.addresses.ipv4[1] == "198.51.100.2/32"
+        assert inbound_rule.addresses.ipv6[0] == "2001:DB8::/128"
+        assert inbound_rule.description == "test"
+        assert inbound_rule.label == "test-rule"
+        assert inbound_rule.ports == "22-24, 80, 443"
+        assert inbound_rule.protocol == "TCP"
+
+    def test_get_public(self):
+        template = self.client.load(FirewallTemplate, "public")
+        assert template.slug == "public"
+        self.assert_rules(template.rules)
+
+    def test_get_vpc(self):
+        template = self.client.load(FirewallTemplate, "vpc")
+        assert template.slug == "vpc"
+        self.assert_rules(template.rules)


### PR DESCRIPTION
## 📝 Description

This pull requests adds support for Firewall Templates, which allow API consumers to access Akamai-defined common Firewall rule sets.

**NOTE: As of now,Firewall templates are only intended to be accessed by the user and are not intended to be specified at resource creation.**

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally and run `make install`. Additionally, your Linode account must have access to Enhanced Interfaces.

### Unit Testing

```
make test-unit
```

### Integration Testing

```
make test-int TEST_COMMAND=models/firewall/test_firewall_templates.py
```

### Manual Testing

1. In a linode_api4-python sandbox environment (e.g. dx-devenv), run the following:

```python
import json
import os

from linode_api4 import LinodeClient

client = LinodeClient(os.getenv("LINODE_TOKEN"), base_url="https://api.linode.com/v4beta")

templates = client.networking.firewall_templates()

for template in templates:
    print(f"{template.slug}:\n{json.dumps(template.rules.dict, indent=4)}\n\n")
```

2. Ensure the output contains all API-exposed Firewall Templates and their rules.