### PR TITLE
Implement JSONObject `put_class` ClassVar

### DIFF
--- a/linode_api4/objects/account.py
+++ b/linode_api4/objects/account.py
@@ -601,7 +601,7 @@ class Grant:
             )
         return self.cls(self._client, self.id)
 
-    def _serialize(self):
+    def _serialize(self, *args, **kwargs):
         """
         Returns this grant in as JSON the api will accept.  This is only relevant
         in the context of UserGrants.save
@@ -668,7 +668,7 @@ class UserGrants:
 
         return grants
 
-    def _serialize(self):
+    def _serialize(self, *args, **kwargs):
         """
         Returns the user grants in as JSON the api will accept.
         This is only relevant in the context of UserGrants.save

--- a/linode_api4/objects/linode.py
+++ b/linode_api4/objects/linode.py
@@ -400,7 +400,7 @@ class ConfigInterface(JSONObject):
     def __repr__(self):
         return f"Interface: {self.purpose}"
 
-    def _serialize(self):
+    def _serialize(self, *args, **kwargs):
         purpose_formats = {
             "public": {"purpose": "public", "primary": self.primary},
             "vlan": {
@@ -510,16 +510,16 @@ class Config(DerivedBase):
 
         self._set("devices", MappedObject(**devices))
 
-    def _serialize(self):
+    def _serialize(self, is_put: bool = False):
         """
         Overrides _serialize to transform interfaces into json
         """
-        partial = DerivedBase._serialize(self)
+        partial = DerivedBase._serialize(self, is_put=is_put)
         interfaces = []
 
         for c in self.interfaces:
             if isinstance(c, ConfigInterface):
-                interfaces.append(c._serialize())
+                interfaces.append(c._serialize(is_put=is_put))
             else:
                 interfaces.append(c)
 
@@ -1927,8 +1927,8 @@ class StackScript(Base):
         ndist = [Image(self._client, d) for d in self.images]
         self._set("images", ndist)
 
-    def _serialize(self):
-        dct = Base._serialize(self)
+    def _serialize(self, is_put: bool = False):
+        dct = Base._serialize(self, is_put=is_put)
         dct["images"] = [d.id for d in self.images]
         return dct
 

--- a/test/unit/objects/serializable_test.py
+++ b/test/unit/objects/serializable_test.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from test.unit.base import ClientBaseCase
 from typing import Optional
 
-from linode_api4 import JSONObject
+from linode_api4 import Base, JSONObject, Property
 
 
 class JSONObjectTest(ClientBaseCase):
@@ -47,3 +47,56 @@ class JSONObjectTest(ClientBaseCase):
         assert foo["foo"] == "test"
         assert foo["bar"] == "test2"
         assert foo["baz"] == "test3"
+
+    def test_serialize_put_class(self):
+        """
+        Ensures that the JSONObject put_class ClassVar functions as expected.
+        """
+
+        @dataclass
+        class SubStructOptions(JSONObject):
+            test1: Optional[str] = None
+
+        @dataclass
+        class SubStruct(JSONObject):
+            put_class = SubStructOptions
+
+            test1: str = ""
+            test2: int = 0
+
+        class Model(Base):
+            api_endpoint = "/foo/bar"
+
+            properties = {
+                "id": Property(identifier=True),
+                "substruct": Property(mutable=True, json_object=SubStruct),
+            }
+
+        mock_response = {
+            "id": 123,
+            "substruct": {
+                "test1": "abc",
+                "test2": 321,
+            },
+        }
+
+        with self.mock_get(mock_response) as mock:
+            obj = self.client.load(Model, 123)
+
+            assert mock.called
+
+        assert obj.id == 123
+        assert obj.substruct.test1 == "abc"
+        assert obj.substruct.test2 == 321
+
+        obj.substruct.test1 = "cba"
+
+        with self.mock_put(mock_response) as mock:
+            obj.save()
+
+            assert mock.called
+            assert mock.call_data == {
+                "substruct": {
+                    "test1": "cba",
+                }
+            }


### PR DESCRIPTION
## 📝 Description

This pull request implements a new `put_class` JSONObject ClassVar, which allows JSONObject classes to specify an alternate JSONObject class to use as the schema when serializing for PUT requests. 

This prevents read-only fields under mutable substructs from being included in PUT request bodies.

## ✔️ How to Test

The following changes expected you have pulled down this PR locally and run `make install`.

### Unit Testing

```
make test-unit
```

### Integration Testing

**Not Applicable.**

### Manual Testing

1. In a linode_api4-python sandbox environment (e.g. dx-devenv), run the following:

```python
from dataclasses import dataclass
from typing import Optional
from linode_api4 import JSONObject


@dataclass
class SubStructOptions(JSONObject):
    test1: Optional[str] = None


@dataclass
class SubStruct(JSONObject):
    put_class = SubStructOptions

    test1: str = ""
    test2: int = 0


substruct_value = SubStruct(test1="abc", test2=123)

print("is_put=False:", substruct_value._serialize())
print("is_put=True:", substruct_value._serialize(is_put=True))

```

2. Ensure the output matches the following:

```
is_put=False: {'test1': 'abc', 'test2': 123}
is_put=True: {'test1': 'abc'}
```