### PR TITLE
Trusted publisher for PyPI

### DIFF
--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -5,7 +5,11 @@ on:
     types: [ published ]
 jobs:
   pypi-release:
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
     runs-on: ubuntu-latest
+    environment: pypi-release
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -25,5 +29,3 @@ jobs:
 
       - name: Publish the release artifacts to PyPI
         uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # pin@release/v1.12.4
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## 📝 Description

Migrate to trusted publisher to avoid token usage.

Sample release: https://github.com/zliang-akamai/linode-cli/actions/runs/14677674503/job/41196302382

Do we want to configure [some protection rules for the `pypi-release` environment](https://github.com/linode/linode_api4-python/settings/environments/6488536621/edit)?