### PR TITLE
Add retry to flaky test and bucket delete in obj fixtures

### DIFF
--- a/test/integration/models/linode/test_linode.py
+++ b/test/integration/models/linode/test_linode.py
@@ -364,6 +364,7 @@ def test_linode_resize(create_linode_for_long_running_tests):
     assert linode.status == "running"
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
 def test_linode_resize_with_class(
     test_linode_client, create_linode_for_long_running_tests
 ):

--- a/test/integration/models/object_storage/test_obj.py
+++ b/test/integration/models/object_storage/test_obj.py
@@ -1,5 +1,6 @@
 import time
 from test.integration.conftest import get_region
+from test.integration.helpers import send_request_when_resource_available
 
 import pytest
 
@@ -38,7 +39,7 @@ def bucket(
     )
 
     yield bucket
-    bucket.delete()
+    send_request_when_resource_available(timeout=100, func=bucket.delete)
 
 
 @pytest.fixture(scope="session")
@@ -63,7 +64,8 @@ def bucket_with_endpoint(
     )
 
     yield bucket
-    bucket.delete()
+
+    send_request_when_resource_available(timeout=100, func=bucket.delete)
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## 📝 Description

Address flaky resize test and Add retry block around bucket delete in obj fixtures. E.g. 500 Errors in obj tests on bucket delete

## ✔️ How to Test

`make test-int TEST_SUITE=object_storage`
`make test-int TEST_CASE=test_linode_resize_with_class`

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**