### PR TITLE
Configurable DB Params: Add test coverage for nullable fields

### DIFF
--- a/test/integration/models/database/helpers.py
+++ b/test/integration/models/database/helpers.py
@@ -65,6 +65,14 @@ def make_full_mysql_engine_config():
     )
 
 
+def make_mysql_engine_config_w_nullable_field():
+    return MySQLDatabaseConfigOptions(
+        mysql=MySQLDatabaseConfigMySQLOptions(
+            innodb_ft_server_stopword_table=None,
+        ),
+    )
+
+
 def make_full_postgres_engine_config():
     return PostgreSQLDatabaseConfigOptions(
         pg=PostgreSQLDatabaseConfigPGOptions(
@@ -113,4 +121,12 @@ def make_full_postgres_engine_config():
         pg_stat_monitor_enable=True,
         shared_buffers_percentage=25.0,
         work_mem=1024,
+    )
+
+
+def make_postgres_engine_config_w_password_encryption_null():
+    return PostgreSQLDatabaseConfigOptions(
+        pg=PostgreSQLDatabaseConfigPGOptions(
+            password_encryption=None,
+        ),
     )


### PR DESCRIPTION
## 📝 Description

Add test coverage for nullable field:
- MySQL: innodb_ft_server_stopword_table
- PostgreSQL: None

Password Encryption in PG DB will default to "md5" when nothing or null value is specified

## ✔️ How to Test

```
╰─➤  make test-int TEST_CASE=test_create_postgres_db_password_encryption_default_md5 RUN_DB_TESTS=yes
╰─➤  make test-int TEST_CASE=test_create_mysql_db_nullable_field RUN_DB_TESTS=yes 
```

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**