### PR TITLE
fix: Add / prefix to path in mysql_config_options(...) and postgresql_config_options(...) API calls

### DIFF
--- a/linode_api4/groups/database.py
+++ b/linode_api4/groups/database.py
@@ -77,7 +77,7 @@ class DatabaseGroup(Group):
 
         :returns: The JSON configuration options for MySQL Databases.
         """
-        return self.client.get("databases/mysql/config", model=self)
+        return self.client.get("/databases/mysql/config", model=self)
 
     def postgresql_config_options(self):
         """
@@ -87,7 +87,7 @@ class DatabaseGroup(Group):
 
         :returns: The JSON configuration options for PostgreSQL Databases.
         """
-        return self.client.get("databases/postgresql/config", model=self)
+        return self.client.get("/databases/postgresql/config", model=self)
 
     def instances(self, *filters):
         """


### PR DESCRIPTION
## 📝 Description

This pull request adds a `/` prefix to the API request paths in the `DatabaseGroup(...).mysql_config_options(...) ` and `DatabaseGroup(...).postgresql_config_options(...)`, which resolves the following error that occurs when attempting to call these methods from an external consumer:

```
Failed to get Configuration with Database Engine mysql: GET /v4betadatabases/mysql/config: [404] Not found
```

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally and run `make install`.

### Unit Testing

```
make test-unit
```

### Integration Testing

```
make test-int TEST_COMMAND=models/database/test_database_engine_config.py RUN_DB_TESTS=true
```
