### PR TITLE
VPC Dual Stack: Support changes related to Linode Interfaces

### DIFF
--- a/linode_api4/objects/linode_interfaces.py
+++ b/linode_api4/objects/linode_interfaces.py
@@ -105,41 +105,6 @@ class LinodeInterfaceVPCIPv4Options(JSONObject):
 
 
 @dataclass
-class LinodeInterfaceVPCOptions(JSONObject):
-    """
-    VPC-exclusive options accepted when creating or updating a Linode Interface.
-
-    NOTE: Linode interfaces may not currently be available to all users.
-    """
-
-    subnet_id: int = 0
-    ipv4: Optional[LinodeInterfaceVPCIPv4Options] = None
-
-
-@dataclass
-class LinodeInterfacePublicIPv4AddressOptions(JSONObject):
-    """
-    Options accepted for a single address when creating or updating the IPv4 configuration of a public Linode Interface.
-
-    NOTE: Linode interfaces may not currently be available to all users.
-    """
-
-    address: str = ""
-    primary: Optional[bool] = None
-
-
-@dataclass
-class LinodeInterfacePublicIPv4Options(JSONObject):
-    """
-    Options accepted when creating or updating the IPv4 configuration of a public Linode Interface.
-
-    NOTE: Linode interfaces may not currently be available to all users.
-    """
-
-    addresses: Optional[List[LinodeInterfacePublicIPv4AddressOptions]] = None
-
-
-@dataclass
 class LinodeInterfaceVPCIPv6SLAACOptions(JSONObject):
     """
     Options accepted for a single SLAAC when creating or updating the IPv6 configuration of a VPC Linode Interface.
@@ -172,6 +137,42 @@ class LinodeInterfaceVPCIPv6Options(JSONObject):
     is_public: Optional[bool] = None
     slaac: Optional[List[LinodeInterfaceVPCIPv6SLAACOptions]] = None
     ranges: Optional[List[LinodeInterfaceVPCIPv6RangeOptions]] = None
+
+
+@dataclass
+class LinodeInterfaceVPCOptions(JSONObject):
+    """
+    VPC-exclusive options accepted when creating or updating a Linode Interface.
+
+    NOTE: Linode interfaces may not currently be available to all users.
+    """
+
+    subnet_id: int = 0
+    ipv4: Optional[LinodeInterfaceVPCIPv4Options] = None
+    ipv6: Optional[LinodeInterfaceVPCIPv6Options] = None
+
+
+@dataclass
+class LinodeInterfacePublicIPv4AddressOptions(JSONObject):
+    """
+    Options accepted for a single address when creating or updating the IPv4 configuration of a public Linode Interface.
+
+    NOTE: Linode interfaces may not currently be available to all users.
+    """
+
+    address: str = ""
+    primary: Optional[bool] = None
+
+
+@dataclass
+class LinodeInterfacePublicIPv4Options(JSONObject):
+    """
+    Options accepted when creating or updating the IPv4 configuration of a public Linode Interface.
+
+    NOTE: Linode interfaces may not currently be available to all users.
+    """
+
+    addresses: Optional[List[LinodeInterfacePublicIPv4AddressOptions]] = None
 
 
 @dataclass
@@ -352,6 +353,7 @@ class LinodeInterfaceVPC(JSONObject):
     subnet_id: int = 0
 
     ipv4: Optional[LinodeInterfaceVPCIPv4] = None
+    ipv6: Optional[LinodeInterfaceVPCIPv6] = None
 
 
 @dataclass

--- a/linode_api4/objects/linode_interfaces.py
+++ b/linode_api4/objects/linode_interfaces.py
@@ -140,6 +140,41 @@ class LinodeInterfacePublicIPv4Options(JSONObject):
 
 
 @dataclass
+class LinodeInterfaceVPCIPv6SLAACOptions(JSONObject):
+    """
+    Options accepted for a single SLAAC when creating or updating the IPv6 configuration of a VPC Linode Interface.
+
+    NOTE: Linode interfaces may not currently be available to all users.
+    """
+
+    range: Optional[str] = None
+
+
+@dataclass
+class LinodeInterfaceVPCIPv6RangeOptions(JSONObject):
+    """
+    Options accepted for a single range when creating or updating the IPv6 configuration of a VPC Linode Interface.
+
+    NOTE: Linode interfaces may not currently be available to all users.
+    """
+
+    range: Optional[str] = None
+
+
+@dataclass
+class LinodeInterfaceVPCIPv6Options(JSONObject):
+    """
+    Options accepted when creating or updating the IPv6 configuration of a VPC Linode Interface.
+
+    NOTE: Linode interfaces may not currently be available to all users.
+    """
+
+    is_public: Optional[bool] = None
+    slaac: Optional[List[LinodeInterfaceVPCIPv6SLAACOptions]] = None
+    ranges: Optional[List[LinodeInterfaceVPCIPv6RangeOptions]] = None
+
+
+@dataclass
 class LinodeInterfacePublicIPv6RangeOptions(JSONObject):
     """
     Options accepted for a single range when creating or updating the IPv6 configuration of a public Linode Interface.
@@ -263,6 +298,44 @@ class LinodeInterfaceVPCIPv4(JSONObject):
 
     addresses: List[LinodeInterfaceVPCIPv4Address] = field(default_factory=list)
     ranges: List[LinodeInterfaceVPCIPv4Range] = field(default_factory=list)
+
+
+@dataclass
+class LinodeInterfaceVPCIPv6SLAAC(JSONObject):
+    """
+    A single SLAAC entry under the IPv6 configuration of a VPC Linode Interface.
+
+    NOTE: Linode interfaces may not currently be available to all users.
+    """
+
+    range: str = ""
+    address: str = ""
+
+
+@dataclass
+class LinodeInterfaceVPCIPv6Range(JSONObject):
+    """
+    A single range under the IPv6 configuration of a VPC Linode Interface.
+
+    NOTE: Linode interfaces may not currently be available to all users.
+    """
+
+    range: str = ""
+
+
+@dataclass
+class LinodeInterfaceVPCIPv6(JSONObject):
+    """
+    A single address under the IPv6 configuration of a VPC Linode Interface.
+
+    NOTE: Linode interfaces may not currently be available to all users.
+    """
+
+    put_class = LinodeInterfaceVPCIPv6Options
+
+    is_public: bool = False
+    slaac: List[LinodeInterfaceVPCIPv6SLAAC] = field(default_factory=list)
+    ranges: List[LinodeInterfaceVPCIPv6Range] = field(default_factory=list)
 
 
 @dataclass

--- a/test/fixtures/linode_instances_124_interfaces.json
+++ b/test/fixtures/linode_instances_124_interfaces.json
@@ -80,6 +80,20 @@
               "range": "192.168.22.32/28"
             }
           ]
+        },
+        "ipv6": {
+            "is_public": true,
+            "slaac": [
+                {
+                    "range": "1234::/64",
+                    "address": "1234::5678"
+                }
+            ],
+            "ranges": [
+                {
+                    "range": "4321::/64"
+                }
+            ]
         }
       },
       "public": null,

--- a/test/fixtures/linode_instances_124_interfaces_456.json
+++ b/test/fixtures/linode_instances_124_interfaces_456.json
@@ -10,7 +10,7 @@
     "vpc": {
         "vpc_id": 123456,
         "subnet_id": 789,
-        "ipv4" : {
+        "ipv4": {
             "addresses": [
                 {
                     "address": "192.168.22.3",
@@ -21,6 +21,20 @@
                 { "range": "192.168.22.16/28"},
                 { "range": "192.168.22.32/28"}
             ] 
+        },
+        "ipv6": {
+            "is_public": true,
+            "slaac": [
+                {
+                    "range": "1234::/64",
+                    "address": "1234::5678"
+                }
+            ],
+            "ranges": [
+                {
+                    "range": "4321::/64"
+                }
+            ]
         }
     },
     "public": null,

--- a/test/fixtures/linode_instances_124_upgrade-interfaces.json
+++ b/test/fixtures/linode_instances_124_upgrade-interfaces.json
@@ -82,6 +82,20 @@
               "range": "192.168.22.32/28"
             }
           ]
+        },
+        "ipv6": {
+            "is_public": true,
+            "slaac": [
+                {
+                    "range": "1234::/64",
+                    "address": "1234::5678"
+                }
+            ],
+            "ranges": [
+                {
+                    "range": "4321::/64"
+                }
+            ]
         }
       },
       "public": null,

--- a/test/unit/objects/linode_interface_test.py
+++ b/test/unit/objects/linode_interface_test.py
@@ -14,6 +14,7 @@ from linode_api4 import (
     LinodeInterfaceVPCIPv4AddressOptions,
     LinodeInterfaceVPCIPv4Options,
     LinodeInterfaceVPCIPv4RangeOptions,
+    LinodeInterfaceVPCIPv6SLAACOptions,
     LinodeInterfaceVPCOptions,
 )
 
@@ -149,6 +150,13 @@ class LinodeInterfaceTest(ClientBaseCase):
         assert iface.vpc.ipv4.ranges[0].range == "192.168.22.16/28"
         assert iface.vpc.ipv4.ranges[1].range == "192.168.22.32/28"
 
+        assert iface.vpc.ipv6.is_public
+
+        assert iface.vpc.ipv6.slaac[0].range == "1234::/64"
+        assert iface.vpc.ipv6.slaac[0].address == "1234::5678"
+
+        assert iface.vpc.ipv6.ranges[0].range == "4321::/64"
+
     @staticmethod
     def assert_linode_124_interface_789(iface: LinodeInterface):
         assert iface.id == 789
@@ -261,6 +269,18 @@ class LinodeInterfaceTest(ClientBaseCase):
             )
         ]
 
+        iface.vpc.ipv6.is_public = False
+
+        iface.vpc.ipv6.slaac = [
+            LinodeInterfaceVPCIPv6SLAACOptions(
+                range="1233::/64",
+            )
+        ]
+
+        iface.vpc.ipv6.ranges = [
+            LinodeInterfacePublicIPv6RangeOptions(range="9876::/64")
+        ]
+
         with self.mock_put("/linode/instances/124/interfaces/456") as m:
             iface.save()
 
@@ -281,6 +301,11 @@ class LinodeInterfaceTest(ClientBaseCase):
                             },
                         ],
                         "ranges": [{"range": "192.168.22.17/28"}],
+                    },
+                    "ipv6": {
+                        "is_public": False,
+                        "slaac": [{"range": "1233::/64"}],
+                        "ranges": [{"range": "9876::/64"}],
                     },
                 },
             }


### PR DESCRIPTION
## 📝 Description

This pull request implements the VPC Dual Stack changes related to Linode Interfaces. This was not previously implemented because Linode Interface/Python SDK support was not ready at the time of the initial PR.

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally.

### Unit Testing

```
make test-unit
```

### Integration Testing

N/A pending API availability

### Manual Testing

N/A pending API availability