### PR TITLE
Add model filter Integration test coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ lint: build
 # TEST_CASE: Optional, specify a test case (e.g. 'test_image_replication')
 # TEST_ARGS: Optional, additional arguments for pytest (e.g. '-v' for verbose mode)
 
-TEST_COMMAND = $(if $(TEST_SUITE),$(if $(filter $(TEST_SUITE),linode_client login_client),$(TEST_SUITE),models/$(TEST_SUITE)))
+TEST_COMMAND = $(if $(TEST_SUITE),$(if $(filter $(TEST_SUITE),linode_client login_client filters),$(TEST_SUITE),models/$(TEST_SUITE)))
 
 .PHONY: test-int
 test-int:

--- a/test/integration/filters/fixtures.py
+++ b/test/integration/filters/fixtures.py
@@ -1,0 +1,39 @@
+from test.integration.conftest import get_region
+from test.integration.helpers import get_test_label
+
+import pytest
+
+
+@pytest.fixture(scope="package")
+def domain_instance(test_linode_client):
+    client = test_linode_client
+
+    domain_addr = get_test_label(5) + "-example.com"
+    soa_email = "dx-test-email@linode.com"
+
+    domain = client.domain_create(domain=domain_addr, soa_email=soa_email)
+
+    yield domain
+
+    domain.delete()
+
+
+@pytest.fixture(scope="package")
+def lke_cluster_instance(test_linode_client):
+    node_type = test_linode_client.linode.types()[1]  # g6-standard-1
+    version = test_linode_client.lke.versions()[0]
+
+    region = get_region(
+        test_linode_client, {"Kubernetes", "LA Disk Encryption"}
+    )
+
+    node_pools = test_linode_client.lke.node_pool(node_type, 3)
+    label = get_test_label() + "_cluster"
+
+    cluster = test_linode_client.lke.cluster_create(
+        region, label, node_pools, version
+    )
+
+    yield cluster
+
+    cluster.delete()

--- a/test/integration/filters/model_filters_test.py
+++ b/test/integration/filters/model_filters_test.py
@@ -1,0 +1,84 @@
+from test.integration.filters.fixtures import (  # noqa: F401
+    domain_instance,
+    lke_cluster_instance,
+)
+
+from linode_api4.objects import (
+    DatabaseEngine,
+    DatabaseType,
+    Domain,
+    Firewall,
+    Image,
+    LKECluster,
+    Type,
+)
+
+
+def test_database_type_model_filter(test_linode_client):
+    client = test_linode_client
+
+    db_disk = client.database.types()[0].disk
+
+    filtered_db_type = client.database.types(DatabaseType.disk == db_disk)
+
+    assert db_disk == filtered_db_type[0].disk
+
+
+def test_database_engine_model_filter(test_linode_client):
+    client = test_linode_client
+
+    engine = "mysql"
+
+    filtered_db_engine = client.database.engines(
+        DatabaseEngine.engine == engine
+    )
+
+    assert len(client.database.engines()) > len(filtered_db_engine)
+
+
+def test_domain_model_filter(test_linode_client, domain_instance):
+    client = test_linode_client
+
+    filtered_domain = client.domains(Domain.domain == domain_instance.domain)
+
+    assert domain_instance.id == filtered_domain[0].id
+
+
+def test_image_model_filter(test_linode_client):
+    client = test_linode_client
+
+    filtered_images = client.images(Image.label.contains("Debian"))
+
+    assert len(client.images()) > len(filtered_images)
+
+
+def test_linode_type_model_filter(test_linode_client):
+    client = test_linode_client
+
+    filtered_types = client.linode.types(Type.label.contains("Linode"))
+
+    assert len(filtered_types) > 0
+    assert "Linode" in filtered_types[0].label
+
+
+def test_lke_cluster_model_filter(test_linode_client, lke_cluster_instance):
+    client = test_linode_client
+
+    filtered_cluster = client.lke.clusters(
+        LKECluster.label.contains(lke_cluster_instance.label)
+    )
+
+    assert filtered_cluster[0].id == lke_cluster_instance.id
+
+
+def test_networking_firewall_model_filter(
+    test_linode_client, e2e_test_firewall
+):
+    client = test_linode_client
+
+    filtered_firewall = client.networking.firewalls(
+        Firewall.label.contains(e2e_test_firewall.label)
+    )
+
+    assert len(filtered_firewall) > 0
+    assert e2e_test_firewall.label in filtered_firewall[0].label


### PR DESCRIPTION
## 📝 Description

This PR adds basic integration test coverage for uses of filters per models

## ✔️ How to Test

`make test-int TEST_SUITE=filters`

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**