### PR TITLE
Linode Interfaces: Allow specifying ExplicitNullValue for LinodeInterfaceOptions firewall ID

### DIFF
--- a/linode_api4/objects/linode_interfaces.py
+++ b/linode_api4/objects/linode_interfaces.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
-from typing import List, Optional
+from typing import List, Optional, Union
 
-from linode_api4.objects.base import Base, Property
+from linode_api4.objects.base import Base, ExplicitNullValue, Property
 from linode_api4.objects.dbase import DerivedBase
 from linode_api4.objects.networking import Firewall
 from linode_api4.objects.serializable import JSONObject
@@ -193,13 +193,10 @@ class LinodeInterfaceOptions(JSONObject):
     NOTE: Linode interfaces may not currently be available to all users.
     """
 
-    always_include = {
-        # If a default firewall_id isn't configured, the API requires that
-        # firewall_id is defined in the LinodeInterface POST body.
-        "firewall_id"
-    }
+    # If a default firewall_id isn't configured, the API requires that
+    # firewall_id is defined in the LinodeInterface POST body.
+    firewall_id: Union[int, ExplicitNullValue, None] = None
 
-    firewall_id: Optional[int] = None
     default_route: Optional[LinodeInterfaceDefaultRouteOptions] = None
     vpc: Optional[LinodeInterfaceVPCOptions] = None
     public: Optional[LinodeInterfacePublicOptions] = None

--- a/linode_api4/objects/serializable.py
+++ b/linode_api4/objects/serializable.py
@@ -186,6 +186,16 @@ class JSONObject(metaclass=JSONFilterableMetaclass):
             if issubclass(type(value), JSONObject):
                 return value._serialize(is_put=is_put)
 
+            # Needed to avoid circular imports without a breaking change
+            from linode_api4.objects.base import (  # pylint: disable=import-outside-toplevel
+                ExplicitNullValue,
+            )
+
+            if value == ExplicitNullValue or isinstance(
+                value, ExplicitNullValue
+            ):
+                return None
+
             return value
 
         def should_include(key: str, value: Any) -> bool:

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -13,6 +13,7 @@ import requests
 from requests.exceptions import ConnectionError, RequestException
 
 from linode_api4 import (
+    ExplicitNullValue,
     InterfaceGeneration,
     LinodeInterfaceDefaultRouteOptions,
     LinodeInterfaceOptions,
@@ -585,6 +586,7 @@ def linode_with_linode_interfaces(
                 public=LinodeInterfacePublicOptions(),
             ),
             LinodeInterfaceOptions(
+                firewall_id=ExplicitNullValue,
                 vpc=LinodeInterfaceVPCOptions(
                     subnet_id=subnet.id,
                 ),


### PR DESCRIPTION
## 📝 Description

This pull request adds support for users specifying an `ExplicitNullValue` for the `firewall_id` field when creating a Linode interface. This is necessary when specifying a Linode interface with no firewall because an unspecified/implicit null value will cause the API to use the account-wide default firewall or raise an error if no default firewall has been configured.

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally and run `make install`.

### Unit Testing

```
make test-unit
```

### Integration Testing

```
make test-int TEST_COMMAND=models/linode
```

### Manual Testing

