### PR TITLE
Fix Tests for v5.33 release

### DIFF
--- a/test/integration/helpers.py
+++ b/test/integration/helpers.py
@@ -43,7 +43,7 @@ def send_request_when_resource_available(
     timeout: int, func: Callable, *args, **kwargs
 ) -> object:
     start_time = time.time()
-    retry_statuses = {400, 500}
+    retry_statuses = {400, 500, 503}
 
     while True:
         try:

--- a/test/integration/models/vpc/test_vpc.py
+++ b/test/integration/models/vpc/test_vpc.py
@@ -56,7 +56,6 @@ def test_fails_create_vpc_invalid_data(test_linode_client):
             description="test description",
         )
     assert excinfo.value.status == 400
-    assert "Label must include only ASCII" in str(excinfo.value.json)
 
 
 def test_get_all_vpcs(test_linode_client, create_multiple_vpcs):
@@ -78,7 +77,6 @@ def test_fails_update_vpc_invalid_data(create_vpc):
         vpc.save()
 
     assert excinfo.value.status == 400
-    assert "Label must include only ASCII" in str(excinfo.value.json)
 
 
 def test_fails_create_subnet_invalid_data(create_vpc):
@@ -88,7 +86,6 @@ def test_fails_create_subnet_invalid_data(create_vpc):
         create_vpc.subnet_create("test-subnet", ipv4=invalid_ipv4)
 
     assert excinfo.value.status == 400
-    assert "ipv4 must be an IPv4 network" in str(excinfo.value.json)
 
 
 def test_fails_update_subnet_invalid_data(create_vpc_with_subnet):
@@ -100,4 +97,3 @@ def test_fails_update_subnet_invalid_data(create_vpc_with_subnet):
         subnet.save()
 
     assert excinfo.value.status == 400
-    assert "Label must include only ASCII" in str(excinfo.value.json)


### PR DESCRIPTION
- Add 503 to the `retry_statuses` because kubeconfig unavailable is now a 503 error.
- Remove error message assertion because one error message has been modified, and they may also be updated again in the future.