### PR TITLE
updating MonitorService class

### DIFF
--- a/linode_api4/groups/monitor.py
+++ b/linode_api4/groups/monitor.py
@@ -62,32 +62,28 @@ class MonitorGroup(Group):
         )
 
     def services(
-        self, *filters, service_type: Optional[str] = None
-    ) -> list[MonitorService]:
+        self,
+        *filters,
+    ) -> PaginatedList:
         """
         Lists services supported by ACLP.
             supported_services = client.monitor.services()
-            service_details = client.monitor.services(service_type="dbaas")
+            service_details = client.monitor.load(MonitorService, "dbaas")
 
         .. note:: This endpoint is in beta. This will only function if base_url is set to `https://api.linode.com/v4beta`.
 
         API Documentation: https://techdocs.akamai.com/linode-api/reference/get-monitor-services
         API Documentation: https://techdocs.akamai.com/linode-api/reference/get-monitor-services-for-service-type
 
-        :param service_type: The service type to get details for.
-        :type service_type: Optional[str]
         :param filters: Any number of filters to apply to this query.
                         See :doc:`Filtering Collections</linode_api4/objects/filtering>`
                         for more details on filtering.
 
-        :returns: Lists monitor services by a given service_type
+        :returns: Lists monitor services 
         :rtype: PaginatedList of the Services
         """
-        endpoint = (
-            f"/monitor/services/{service_type}"
-            if service_type
-            else "/monitor/services"
-        )
+        endpoint = "/monitor/services"
+
         return self.client._get_and_filter(
             MonitorService,
             *filters,

--- a/linode_api4/objects/monitor.py
+++ b/linode_api4/objects/monitor.py
@@ -157,16 +157,19 @@ class MonitorDashboard(Base):
     }
 
 
-@dataclass
-class MonitorService(JSONObject):
+class MonitorService(Base):
     """
     Represents a single service type.
     API Documentation: https://techdocs.akamai.com/linode-api/reference/get-monitor-services
 
     """
 
-    service_type: ServiceType = ""
-    label: str = ""
+    api_endpoint = "/monitor/services/{service_type}"
+    id_attribute = "service_type"
+    properties = {
+        "service_type": Property(ServiceType),
+        "label": Property(),
+    }
 
 
 @dataclass

--- a/test/fixtures/monitor_services_dbaas.json
+++ b/test/fixtures/monitor_services_dbaas.json
@@ -1,11 +1,15 @@
 {
-    "data": [
-      {
-        "label": "Databases",
-        "service_type": "dbaas"
-      }
-    ],
-    "page": 1,
-    "pages": 1,
-    "results": 1
-  }
+    "service_type": "dbaas",
+    "label": "Databases",
+    "alert": {
+        "polling_interval_seconds": [
+            300
+        ],
+        "evaluation_period_seconds": [
+            300
+        ],
+        "scope": [
+            "entity"
+        ]
+    }
+}

--- a/test/integration/models/monitor/test_monitor.py
+++ b/test/integration/models/monitor/test_monitor.py
@@ -44,11 +44,9 @@ def test_get_supported_services(test_linode_client):
     get_supported_service = supported_services[0].service_type
 
     # Get details for a particular service
-    service_details = client.monitor.services(
-        service_type=get_supported_service
-    )
-    assert isinstance(service_details[0], MonitorService)
-    assert service_details[0].service_type == get_supported_service
+    service_details = client.load(MonitorService, get_supported_service)
+    assert isinstance(service_details, MonitorService)
+    assert service_details.service_type == get_supported_service
 
     # Get Metric definition details for that particular service
     metric_definitions = client.monitor.metric_definitions(

--- a/test/unit/objects/monitor_test.py
+++ b/test/unit/objects/monitor_test.py
@@ -1,7 +1,7 @@
 import datetime
 from test.unit.base import ClientBaseCase
 
-from linode_api4.objects import MonitorDashboard
+from linode_api4.objects import MonitorDashboard, MonitorService
 
 
 class MonitorTest(ClientBaseCase):
@@ -85,9 +85,9 @@ class MonitorTest(ClientBaseCase):
         self.assertEqual(dashboards[0].widgets[0].y_label, "cpu_usage")
 
     def test_specific_service_details(self):
-        data = self.client.monitor.services(service_type="dbaas")
-        self.assertEqual(data[0].label, "Databases")
-        self.assertEqual(data[0].service_type, "dbaas")
+        data = self.client.load(MonitorService, "dbaas")
+        self.assertEqual(data.label, "Databases")
+        self.assertEqual(data.service_type, "dbaas")
 
     def test_metric_definitions(self):
 


### PR DESCRIPTION
## 📝 Description

/monitor/services/{service_type} endpoint was changed to return json instead of list. Updating implementation for the same

## ✔️ How to Test

```
import os
import logging
from linode_api4 import LinodeClient

client = LinodeClient(os.environ.get("MY_PERSONAL_ACCESS_TOKEN"))
client.base_url = "https://api.linode.com/v4beta"

List all services
services = client.monitor.services()
for s in services:
    print("Label:", s.label)
    print("Service Type:", s.service_type)

List a specific service
dbaas = client.load(MonitorService, "dbaas")
print(f"Service Type: {dbaas.service_type}")
print(f"Label: {dbaas.label}")
```

**How do I run the relevant unit/integration tests?**

unit-test: make test-unit TEST_SUITE=monitor
integration tests: make testint TEST_SUITE=monitor