### PR TITLE
Maintenance Policy integration test

### DIFF
--- a/test/integration/models/account/test_account.py
+++ b/test/integration/models/account/test_account.py
@@ -151,17 +151,3 @@ def test_get_payments(test_linode_client):
     if len(payments) > 0:
         assert isinstance(payments[0].date, datetime)
         assert isinstance(payments[0].usd, float)
-
-
-def test_get_maintenance_policies(test_linode_client):
-    client = test_linode_client
-
-    policies = client.maintenance.maintenance_policies()
-
-    assert isinstance(policies, list)
-    assert all(hasattr(p, "slug") for p in policies)
-
-    slugs = [p.slug for p in policies]
-    assert any(
-        slug in slugs for slug in ["linode/migrate", "linode/power_off_on"]
-    )

--- a/test/integration/models/account/test_account.py
+++ b/test/integration/models/account/test_account.py
@@ -59,6 +59,25 @@ def test_get_account_settings(test_linode_client):
     assert "longview_subscription" in str(account_settings._raw_json)
     assert "backups_enabled" in str(account_settings._raw_json)
     assert "object_storage" in str(account_settings._raw_json)
+    assert "maintenance_policy" in str(account_settings._raw_json)
+
+
+def test_update_maintenance_policy(test_linode_client):
+    client = test_linode_client
+    settings = client.load(AccountSettings(client, ""), "")
+
+    original_policy = settings.maintenance_policy
+    new_policy = (
+        "linode/power_off_on"
+        if original_policy == "linode/migrate"
+        else "linode/migrate"
+    )
+
+    settings.maintenance_policy = new_policy
+    settings.save()
+
+    updated = client.load(AccountSettings(client, ""), "")
+    assert updated.maintenance_policy == new_policy
 
 
 @pytest.mark.smoke
@@ -132,3 +151,17 @@ def test_get_payments(test_linode_client):
     if len(payments) > 0:
         assert isinstance(payments[0].date, datetime)
         assert isinstance(payments[0].usd, float)
+
+
+def test_get_maintenance_policies(test_linode_client):
+    client = test_linode_client
+
+    policies = client.maintenance.maintenance_policies()
+
+    assert isinstance(policies, list)
+    assert all(hasattr(p, "slug") for p in policies)
+
+    slugs = [p.slug for p in policies]
+    assert any(
+        slug in slugs for slug in ["linode/migrate", "linode/power_off_on"]
+    )

--- a/test/integration/models/maintenance/test_maintenance.py
+++ b/test/integration/models/maintenance/test_maintenance.py
@@ -1,0 +1,12 @@
+def test_get_maintenance_policies(test_linode_client):
+    client = test_linode_client
+
+    policies = client.maintenance.maintenance_policies()
+
+    assert isinstance(policies, list)
+    assert all(hasattr(p, "slug") for p in policies)
+
+    slugs = [p.slug for p in policies]
+    assert any(
+        slug in slugs for slug in ["linode/migrate", "linode/power_off_on"]
+    )


### PR DESCRIPTION
## 📝 Description
Add Integration test to Maintenance Policy 
Test Against Devcloud - api.devcloud.linode.com
## ✔️ How to Test
make TEST_SUITE="account" test-int  
make test-int TEST_CASE=test_create_linode_maintenance_policy
make test-int TEST_CASE=test_update_linode_maintenance_policy

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**