### PR TITLE
Add label to nodepool

### DIFF
--- a/linode_api4/objects/lke.py
+++ b/linode_api4/objects/lke.py
@@ -13,7 +13,7 @@ from linode_api4.objects import (
     Property,
     Region,
     Type,
-)
+) 
 from linode_api4.objects.base import _flatten_request_body_recursive
 from linode_api4.util import drop_null_keys
 
@@ -187,6 +187,7 @@ class LKENodePool(DerivedBase):
     properties = {
         "id": Property(identifier=True),
         "cluster_id": Property(identifier=True),
+        "label": Property(mutable=True),
         "type": Property(slug_relationship=Type),
         "disks": Property(),
         "disk_encryption": Property(),
@@ -419,6 +420,7 @@ class LKECluster(Base):
             Union[str, KubeVersion, TieredKubeVersion]
         ] = None,
         update_strategy: Optional[str] = None,
+        label: str = None,
         **kwargs,
     ):
         """
@@ -444,24 +446,25 @@ class LKECluster(Base):
                        for possible values.
 
         :returns: The new Node Pool
+        :param label: The name of the node pool.
+        :type label: str
         :rtype: LKENodePool
         """
         params = {
             "type": node_type,
+            "label": label,
             "count": node_count,
             "labels": labels,
             "taints": taints,
             "k8s_version": k8s_version,
             "update_strategy": update_strategy,
         }
-
-        if labels is not None:
-            params["labels"] = labels
-
-        if taints is not None:
-            params["taints"] = taints
-
         params.update(kwargs)
+
+        print(params)
+        print("-----")
+        print(drop_null_keys(_flatten_request_body_recursive(params)))
+        # exit(0)
 
         result = self._client.post(
             "{}/pools".format(LKECluster.api_endpoint),

--- a/linode_api4/objects/lke.py
+++ b/linode_api4/objects/lke.py
@@ -13,7 +13,7 @@ from linode_api4.objects import (
     Property,
     Region,
     Type,
-) 
+)
 from linode_api4.objects.base import _flatten_request_body_recursive
 from linode_api4.util import drop_null_keys
 
@@ -460,11 +460,6 @@ class LKECluster(Base):
             "update_strategy": update_strategy,
         }
         params.update(kwargs)
-
-        print(params)
-        print("-----")
-        print(drop_null_keys(_flatten_request_body_recursive(params)))
-        # exit(0)
 
         result = self._client.post(
             "{}/pools".format(LKECluster.api_endpoint),

--- a/test/fixtures/lke_clusters_18881_pools_456.json
+++ b/test/fixtures/lke_clusters_18881_pools_456.json
@@ -34,6 +34,7 @@
       "foo": "bar",
       "bar": "foo"
     },
+    "label": "example-node-pool",
     "type": "g6-standard-4",
     "disk_encryption": "enabled"
   }

--- a/test/fixtures/lke_clusters_18882_pools_789.json
+++ b/test/fixtures/lke_clusters_18882_pools_789.json
@@ -1,6 +1,7 @@
 {
     "id": 789,
     "type": "g6-standard-2",
+    "label": "enterprise-node-pool",
     "count": 3,
     "nodes": [],
     "disks": [],

--- a/test/unit/objects/lke_test.py
+++ b/test/unit/objects/lke_test.py
@@ -269,8 +269,6 @@ class LKETest(ClientBaseCase):
         with self.mock_put("lke/clusters/18881/pools/456") as m:
             pool.save()
 
-            print(m.call_data)
-
             assert m.call_data == {
                 "tags": ["foobar"],
                 "count": 5,

--- a/test/unit/objects/lke_test.py
+++ b/test/unit/objects/lke_test.py
@@ -51,6 +51,7 @@ class LKETest(ClientBaseCase):
         assert pool.id == 456
         assert pool.cluster_id == 18881
         assert pool.type.id == "g6-standard-4"
+        assert pool.label == "example-node-pool"
         assert pool.disk_encryption == InstanceDiskEncryptionType.enabled
 
         assert pool.disks is not None
@@ -162,6 +163,7 @@ class LKETest(ClientBaseCase):
         self.assertEqual(pool.id, 456)
         self.assertEqual(pool.cluster_id, 18881)
         self.assertEqual(pool.type.id, "g6-standard-4")
+        self.assertEqual(pool.label, "example-node-pool")
         self.assertIsNotNone(pool.disks)
         self.assertIsNotNone(pool.nodes)
         self.assertIsNotNone(pool.autoscaler)
@@ -251,6 +253,7 @@ class LKETest(ClientBaseCase):
 
         pool.tags = ["foobar"]
         pool.count = 5
+        pool.label = "testing-label"
         pool.autoscaler = {
             "enabled": True,
             "min": 2,
@@ -266,6 +269,8 @@ class LKETest(ClientBaseCase):
         with self.mock_put("lke/clusters/18881/pools/456") as m:
             pool.save()
 
+            print(m.call_data)
+
             assert m.call_data == {
                 "tags": ["foobar"],
                 "count": 5,
@@ -274,6 +279,7 @@ class LKETest(ClientBaseCase):
                     "min": 2,
                     "max": 10,
                 },
+                "label": "testing-label",
                 "labels": {
                     "updated-key": "updated-value",
                 },
@@ -546,6 +552,7 @@ class LKETest(ClientBaseCase):
         pool = LKENodePool(self.client, 789, 18882)
         assert pool.k8s_version == "1.31.1+lke1"
         assert pool.update_strategy == "rolling_update"
+        assert pool.label == "enterprise-node-pool"
 
     def test_lke_tiered_version(self):
         version = TieredKubeVersion(self.client, "1.32", "standard")


### PR DESCRIPTION
## 📝 Description

- Add label to nodepool
- Remove redundant assigning of label and taint while creation

## ✔️ How to Test

**What are the steps to reproduce the issue or verify the changes?**
- Run `pip install .` to install the PR in the local environment.
- Create an LKE-E Cluster and use the below config to create a nodePool with a label.
- Create a NodePool with a label using the following code and ensure created nodes contain the label in their name.
```
client = LinodeClient("<api-token>", "https://api.linode.com/v4beta")
cluster = LKECluster(client, <cluster-id>)
node_pool = cluster.node_pool_create("g6-dedicated-2", 3, label="my-node-pool")
print(node_pool)
```
- Update the nodePool, set label to some other value using the following code and ensure the newly created linodes are reflected accordingly.
```
# set node pool to any other value and increase count so that newly booted machine comes up with updated value
client = LinodeClient("<api-token>", "https://api.linode.com/v4beta")
cluster = LKECluster(client, <cluster-id>)
node_pool = LKENodePool(client,<cluster-id>, <nodepool-id>)
node_pool.label = "other-123-label"
node_pool.count = 4
node_pool.save()
```
- Update the nodePool, set label to some other value using the following code and ensure the newly created linodes are reflected accordingly.
```
# set node pool to any other value and increase count so that newly booted machine comes up with <cluster-id>-<nodepool-id>-<hash>
cluster = LKECluster(client, <cluster-id>)
node_pool = LKENodePool(client,<cluster-id>, <nodepool-id>)
node_pool.label = ""
node_pool.count = 5
node_pool.save()
```

**How do I run the relevant unit/integration tests?**
- Run `tox`

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**