### PR TITLE
Disable image tests in no-osl-1

### DIFF
--- a/test/integration/models/image/test_image.py
+++ b/test/integration/models/image/test_image.py
@@ -13,6 +13,7 @@ DISALLOWED_IMAGE_REGIONS = {
     "au-mel",
     "sg-sin-2",
     "jp-tyo-3",
+    "no-osl-1",
 }
 
 


### PR DESCRIPTION
## 📝 Description

This pull request adds `no-osl-1` to the disallowed region list for image tests.

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally and run `make install`.

### Integration Testing

```
make test-int TEST_COMMAND=models/image
```