### PR TITLE
Remove add_placement_groups from tests

### DIFF
--- a/test/unit/objects/account_test.py
+++ b/test/unit/objects/account_test.py
@@ -379,7 +379,6 @@ def test_user_grants_serialization():
             "add_linodes": True,
             "add_longview": True,
             "add_nodebalancers": True,
-            "add_placement_groups": True,
             "add_stackscripts": True,
             "add_volumes": True,
             "add_vpcs": True,


### PR DESCRIPTION
## 📝 Description

Remove the add_placement_groups user grant, which no longer exists in the API response.

## ✔️ How to Test
```bash
make test-unit
```