### PR TITLE
Fix firewall device for linode interfaces

### DIFF
--- a/linode_api4/objects/networking.py
+++ b/linode_api4/objects/networking.py
@@ -213,7 +213,7 @@ class FirewallCreateDevicesOptions(JSONObject):
 
     linodes: List[int] = field(default_factory=list)
     nodebalancers: List[int] = field(default_factory=list)
-    interfaces: List[int] = field(default_factory=list)
+    linode_interfaces: List[int] = field(default_factory=list)
 
 
 @dataclass

--- a/test/unit/linode_client_test.py
+++ b/test/unit/linode_client_test.py
@@ -1317,7 +1317,7 @@ class NetworkingGroupTest(ClientBaseCase):
                     "devices": {
                         "linodes": [123],
                         "nodebalancers": [456],
-                        "interfaces": [789],
+                        "linode_interfaces": [789],
                     },
                 },
             )

--- a/test/unit/linode_client_test.py
+++ b/test/unit/linode_client_test.py
@@ -1297,7 +1297,7 @@ class NetworkingGroupTest(ClientBaseCase):
                 "test-firewall-1",
                 rules,
                 devices=FirewallCreateDevicesOptions(
-                    linodes=[123], nodebalancers=[456], interfaces=[789]
+                    linodes=[123], nodebalancers=[456], linode_interfaces=[789]
                 ),
                 status="enabled",
             )


### PR DESCRIPTION
## 📝 Description

The API doesn't accept `interfaces` key but `linode_interfaces`

## ✔️ How to Test
```bash
make test-int TEST_CASE=test_create_firewall_with_linode_device
```