### PR TITLE
Fix Linode interfaces property

### DIFF
--- a/linode_api4/objects/linode.py
+++ b/linode_api4/objects/linode.py
@@ -2016,7 +2016,7 @@ class Instance(Base):
         :rtype: Optional[list[LinodeInterface]]
         """
 
-        if self.interface_generation != "linode":
+        if self.interface_generation != InterfaceGeneration.LINODE:
             return None
         if not hasattr(self, "_interfaces"):
             result = self._client.get(

--- a/linode_api4/objects/linode.py
+++ b/linode_api4/objects/linode.py
@@ -2006,7 +2006,7 @@ class Instance(Base):
         return self._interfaces_settings
 
     @property
-    def interfaces(self) -> List[LinodeInterface]:
+    def linode_interfaces(self) -> list[LinodeInterface]:
         """
         All interfaces for this Linode.
 

--- a/linode_api4/objects/linode.py
+++ b/linode_api4/objects/linode.py
@@ -2006,7 +2006,7 @@ class Instance(Base):
         return self._interfaces_settings
 
     @property
-    def linode_interfaces(self) -> list[LinodeInterface]:
+    def linode_interfaces(self) -> Optional[list[LinodeInterface]]:
         """
         All interfaces for this Linode.
 
@@ -2015,6 +2015,8 @@ class Instance(Base):
         :returns: An ordered list of interfaces under this Linode.
         """
 
+        if self.interface_generation != "linode":
+            return None
         if not hasattr(self, "_interfaces"):
             result = self._client.get(
                 "{}/interfaces".format(Instance.api_endpoint),

--- a/linode_api4/objects/linode.py
+++ b/linode_api4/objects/linode.py
@@ -2012,7 +2012,8 @@ class Instance(Base):
 
         API Documentation: https://techdocs.akamai.com/linode-api/reference/get-linode-interface
 
-        :returns: An ordered list of interfaces under this Linode.
+        :returns: An ordered list of linode interfaces under this Linode. If the linode is with legacy config interfaces, returns None.
+        :rtype: Optional[list[LinodeInterface]]
         """
 
         if self.interface_generation != "linode":

--- a/test/unit/objects/linode_test.py
+++ b/test/unit/objects/linode_test.py
@@ -481,7 +481,7 @@ class LinodeTest(ClientBaseCase):
 
         assert instance.interface_generation == InterfaceGeneration.LINODE
 
-        interfaces = instance.interfaces
+        interfaces = instance.linode_interfaces
 
         LinodeInterfaceTest.assert_linode_124_interface_123(
             next(iface for iface in interfaces if iface.id == 123)


### PR DESCRIPTION
## 📝 Description

1. Rename `interfaces` property of a Linode instance object to `linode_interfaces` to avoid confusion with legacy config interfaces.
2. Avoid API error by returning `None` from the property getter function when the Linode is with legacy interfaces.


## ✔️ How to Test
```python3
import os
from linode_api4 import LinodeClient, Instance
from linode_api4.objects.linode_interfaces import LinodeInterfacePublicOptions


linode_client = LinodeClient(
    os.getenv("LINODE_TOKEN"),
    base_url="https://api.linode.com/v4beta",
)

created_linode = linode_client.linode.instance_create(
    ltype="g6-nanode-1",
    region="us-mia",
    interface_generation="legacy_config"
)

linode = linode_client.load(Instance, created_linode.id)
print(linode.linode_interfaces) # expecting None
linode.delete()

created_linode2 = linode_client.linode.instance_create(
    ltype="g6-nanode-1",
    region="us-mia",
    interface_generation="linode"
)
created_linode2.interface_create(
    firewall=12345, # replace with your non-prod firewall here
    public=LinodeInterfacePublicOptions(),
)

linode2 = linode_client.load(Instance, created_linode2.id)
print(linode2.linode_interfaces) # expecting a list with one LinodeInterface object
linode2.delete()
```