### PR TITLE
TPT-2980: Add support for firewall rules version and fingerprint

### DIFF
--- a/test/fixtures/networking_firewalls.json
+++ b/test/fixtures/networking_firewalls.json
@@ -3,14 +3,16 @@
       {
          "id":123,
          "label":"test-firewall-1",
-         "created":"2018-01-01T00:01:01",
-         "updated":"2018-01-01T00:01:01",
+         "created":"2018-01-01T00:01:03",
+         "updated":"2018-01-01T00:01:03",
          "status":"enabled",
          "rules":{
             "outbound":[],
             "outbound_policy":"DROP",
             "inbound":[],
-            "inbound_policy":"DROP"
+            "inbound_policy":"DROP",
+            "version":2,
+            "fingerprint":"4ef67a29"
          },
          "tags":[]
       }

--- a/test/fixtures/networking_firewalls_123.json
+++ b/test/fixtures/networking_firewalls_123.json
@@ -1,14 +1,16 @@
 {
    "id":123,
    "label":"test-firewall-1",
-   "created":"2018-01-01T00:01:01",
-   "updated":"2018-01-01T00:01:01",
+   "created":"2018-01-01T00:01:02",
+   "updated":"2018-01-01T00:01:02",
    "status":"enabled",
    "rules":{
       "outbound":[],
       "outbound_policy":"DROP",
       "inbound":[],
-      "inbound_policy":"DROP"
+      "inbound_policy":"DROP",
+      "version":2,
+      "fingerprint":"4ef67a29"
    },
    "tags":[]
 }

--- a/test/fixtures/networking_firewalls_123_rules.json
+++ b/test/fixtures/networking_firewalls_123_rules.json
@@ -2,5 +2,7 @@
   "inbound": [],
   "inbound_policy": "DROP",
   "outbound": [],
-  "outbound_policy": "DROP"
+  "outbound_policy": "DROP",
+  "version": 2,
+  "fingerprint": "4ef67a29"
 }

--- a/test/integration/models/firewall/test_firewall.py
+++ b/test/integration/models/firewall/test_firewall.py
@@ -29,6 +29,10 @@ def test_get_firewall_rules(test_linode_client, test_firewall):
 
     assert rules.inbound_policy in ["ACCEPT", "DROP"]
     assert rules.outbound_policy in ["ACCEPT", "DROP"]
+    assert isinstance(rules.version, int)
+    assert rules.version > 0
+    assert isinstance(rules.fingerprint, str)
+    assert len(rules.fingerprint) > 0
 
 
 @pytest.mark.smoke
@@ -61,6 +65,10 @@ def test_update_firewall_rules(test_linode_client, test_firewall):
 
     assert firewall.rules.inbound_policy == "ACCEPT"
     assert firewall.rules.outbound_policy == "DROP"
+    assert isinstance(firewall.rules.version, int)
+    assert firewall.rules.version > 0
+    assert isinstance(firewall.rules.fingerprint, str)
+    assert len(firewall.rules.fingerprint) > 0
 
 
 def test_get_devices(test_linode_client, linode_fw, test_firewall):

--- a/test/unit/objects/firewall_test.py
+++ b/test/unit/objects/firewall_test.py
@@ -20,6 +20,8 @@ class FirewallTest(ClientBaseCase):
         self.assertEqual(rules.inbound_policy, "DROP")
         self.assertEqual(len(rules.outbound), 0)
         self.assertEqual(rules.outbound_policy, "DROP")
+        self.assertEqual(rules.version, 2)
+        self.assertEqual(rules.fingerprint, "4ef67a29")
 
     def test_update_rules(self):
         """


### PR DESCRIPTION
## 📝 Description

Add support for firewall rules version and fingerprint

## ✔️ How to Test

```bash
python3 -m pytest test/unit/objects/firewall_test.py
```

```bash
python3 -m pytest test/integration/models/firewall/test_firewall.py -k test_get_firewall_rules
```

```bash
python3 -m pytest test/integration/models/firewall/test_firewall.py -k test_update_firewall_rules
```