### PR TITLE
TPT-4527: Implemented changes for SLADE and CLEO projects

### DIFF
--- a/linode_api4/groups/linode.py
+++ b/linode_api4/groups/linode.py
@@ -290,13 +290,13 @@ class LinodeGroup(Group):
         :param region: The Region in which we are creating the Instance
         :type region: str or Region
         :param image: The Image to deploy to this Instance. If this is provided,
-                      at least one of root_pass or authorized_keys must also be
+                      at least one of root_pass, authorized_users, or authorized_keys must also be
                       provided.
         :type image: str or Image
         :param root_pass: The root password for the new Instance. If an image is
                           provided and root_pass is given, the Instance and password
-                          will be returned as a tuple. If neither root_pass nor
-                          authorized_keys is provided when an image is specified,
+                          will be returned as a tuple. If all of root_pass, authorized_users,and
+                          authorized_keys are not provided when an image is specified,
                           a ValueError will be raised.
         :type root_pass: str
         :param stackscript: The StackScript to deploy to the new Instance.  If

--- a/linode_api4/groups/linode.py
+++ b/linode_api4/groups/linode.py
@@ -162,6 +162,9 @@ class LinodeGroup(Group):
         interface_generation: Optional[Union[InterfaceGeneration, str]] = None,
         network_helper: Optional[bool] = None,
         maintenance_policy: Optional[str] = None,
+        root_pass: Optional[str] = None,
+        kernel: Optional[str] = None,
+        boot_size: Optional[int] = None,
         **kwargs,
     ):
         """
@@ -172,26 +175,29 @@ class LinodeGroup(Group):
         To create an Instance from an :any:`Image`, call `instance_create` with
         a :any:`Type`, a :any:`Region`, and an :any:`Image`.  All three of
         these fields may be provided as either the ID or the appropriate object.
-        In this mode, a root password will be generated and returned with the
-        new Instance object.
+        When an Image is provided, at least one of ``root_pass`` or
+        ``authorized_keys`` must also be given.  If ``root_pass`` is provided,
+        the Instance and the password are returned as a tuple.
 
         For example::
 
            new_linode, password = client.linode.instance_create(
                "g6-standard-2",
                "us-east",
-               image="linode/debian9")
+               image="linode/debian9",
+               root_pass="aComplex@Password123")
 
            ltype = client.linode.types().first()
            region = client.regions().first()
            image = client.images().first()
 
-           another_linode, password = client.linode.instance_create(
+           another_linode = client.linode.instance_create(
                ltype,
                region,
-               image=image)
+               image=image,
+               authorized_keys="ssh-rsa AAAA")
 
-        To output the password from the above example:
+        To output the password from the first example above:
             print(password)
 
         To output the first IPv4 address of the new Linode:
@@ -214,6 +220,7 @@ class LinodeGroup(Group):
               "g6-standard-2",
               "us-east",
               image="linode/debian9",
+              root_pass="aComplex@Password123",
               stackscript=stackscript,
               stackscript_data={"gh_username": "example"})
 
@@ -248,6 +255,7 @@ class LinodeGroup(Group):
             "g6-standard-1",
             "us-mia",
             image="linode/ubuntu24.04",
+            root_pass="aComplex@Password123",
 
             # This can be configured as an account-wide default
             interface_generation=InterfaceGeneration.LINODE,
@@ -280,10 +288,16 @@ class LinodeGroup(Group):
         :type ltype: str or Type
         :param region: The Region in which we are creating the Instance
         :type region: str or Region
-        :param image: The Image to deploy to this Instance. If this is provided
-                      and no root_pass is given, a password will be generated
-                      and returned along with the new Instance.
+        :param image: The Image to deploy to this Instance. If this is provided,
+                      at least one of root_pass or authorized_keys must also be
+                      provided.
         :type image: str or Image
+        :param root_pass: The root password for the new Instance. If an image is
+                          provided and root_pass is given, the Instance and password
+                          will be returned as a tuple. If neither root_pass nor
+                          authorized_keys is provided when an image is specified,
+                          a ValueError will be raised.
+        :type root_pass: str
         :param stackscript: The StackScript to deploy to the new Instance.  If
                             provided, "image" is required and must be compatible
                             with the chosen StackScript.
@@ -336,9 +350,15 @@ class LinodeGroup(Group):
         :param maintenance_policy: The slug of the maintenance policy to apply during maintenance.
                                       If not provided, the default policy (linode/migrate) will be applied.
         :type maintenance_policy: str
+        :param kernel: The kernel to boot the Instance with. If provided, this will be used as the
+                       kernel for the default configuration profile.
+        :type kernel: str
+        :param boot_size: The size of the boot disk in MB. If provided, this will be used to create
+                          the boot disk for the Instance.
+        :type boot_size: int
 
         :returns: A new Instance object, or a tuple containing the new Instance and
-                  the generated password.
+                  the password if root_pass was provided.
         :rtype: Instance or tuple(Instance, str)
         :raises ApiError: If contacting the API fails
         :raises UnexpectedResponseError: If the API response is somehow malformed.
@@ -346,15 +366,17 @@ class LinodeGroup(Group):
                                          an outdated library.
         """
 
-        ret_pass = None
-        if image and not "root_pass" in kwargs:
-            ret_pass = Instance.generate_root_password()
-            kwargs["root_pass"] = ret_pass
+        if image and not root_pass and not authorized_keys:
+            raise ValueError(
+                "When creating an Instance from an Image, at least one of "
+                "root_pass or authorized_keys must be provided."
+            )
 
         params = {
             "type": ltype,
             "region": region,
             "image": image,
+            "root_pass": root_pass,
             "authorized_keys": load_and_validate_keys(authorized_keys),
             # These will automatically be flattened below
             "firewall_id": firewall,
@@ -373,6 +395,8 @@ class LinodeGroup(Group):
             "interfaces": interfaces,
             "interface_generation": interface_generation,
             "network_helper": network_helper,
+            "kernel": kernel,
+            "boot_size": boot_size,
         }
 
         params.update(kwargs)
@@ -388,9 +412,9 @@ class LinodeGroup(Group):
             )
 
         l = Instance(self.client, result["id"], result)
-        if not ret_pass:
+        if not root_pass:
             return l
-        return l, ret_pass
+        return l, root_pass
 
     @staticmethod
     def build_instance_metadata(user_data=None, encode_user_data=True):
@@ -403,6 +427,7 @@ class LinodeGroup(Group):
                 "g6-standard-2",
                 "us-east",
                 image="linode/ubuntu22.04",
+                root_pass=""aComplex@Password123",
                 metadata=client.linode.build_instance_metadata(user_data="myuserdata")
             )
         :param user_data: User-defined data to provide to the Linode Instance through

--- a/linode_api4/groups/linode.py
+++ b/linode_api4/groups/linode.py
@@ -177,12 +177,11 @@ class LinodeGroup(Group):
         a :any:`Type`, a :any:`Region`, and an :any:`Image`.  All three of
         these fields may be provided as either the ID or the appropriate object.
         When an Image is provided, at least one of ``root_pass``, ``authorized_users``, or
-        ``authorized_keys`` must also be given.  If ``root_pass`` is provided,
-        the Instance and the password are returned as a tuple.
+        ``authorized_keys`` must also be given.
 
         For example::
 
-           new_linode, password = client.linode.instance_create(
+           new_linode = client.linode.instance_create(
                "g6-standard-2",
                "us-east",
                image="linode/debian13",
@@ -197,9 +196,6 @@ class LinodeGroup(Group):
                region,
                image=image,
                authorized_keys="ssh-rsa AAAA")
-
-        To output the password from the first example above:
-            print(password)
 
         To output the first IPv4 address of the new Linode:
             print(new_linode.ipv4[0])
@@ -217,7 +213,7 @@ class LinodeGroup(Group):
 
            stackscript = StackScript(client, 10079)
 
-           new_linode, password = client.linode.instance_create(
+           new_linode = client.linode.instance_create(
               "g6-standard-2",
               "us-east",
               image="linode/debian13",
@@ -252,7 +248,7 @@ class LinodeGroup(Group):
         To create a new Instance with explicit interfaces, provide list of
         LinodeInterfaceOptions objects or dicts to the "interfaces" field::
 
-        linode, password = client.linode.instance_create(
+        linode = client.linode.instance_create(
             "g6-standard-1",
             "us-mia",
             image="linode/ubuntu24.04",
@@ -293,11 +289,9 @@ class LinodeGroup(Group):
                       at least one of root_pass, authorized_users, or authorized_keys must also be
                       provided.
         :type image: str or Image
-        :param root_pass: The root password for the new Instance. If an image is
-                          provided and root_pass is given, the Instance and password
-                          will be returned as a tuple. If all of root_pass, authorized_users, and
-                          authorized_keys are not provided when an image is specified,
-                          a ValueError will be raised.
+        :param root_pass: The root password for the new Instance. Required when
+                          an image is provided and neither authorized_users nor
+                          authorized_keys are given.
         :type root_pass: str
         :param stackscript: The StackScript to deploy to the new Instance.  If
                             provided, "image" is required and must be compatible
@@ -363,9 +357,8 @@ class LinodeGroup(Group):
                           the boot disk for the Instance.
         :type boot_size: int
 
-        :returns: A new Instance object, or a tuple containing the new Instance and
-                  the password if both image and root_pass were provided.
-        :rtype: Instance or tuple(Instance, str)
+        :returns: A new Instance object
+        :rtype: Instance
         :raises ApiError: If contacting the API fails
         :raises UnexpectedResponseError: If the API response is somehow malformed.
                                          This usually indicates that you are using
@@ -423,10 +416,7 @@ class LinodeGroup(Group):
                 "Unexpected response when creating linode!", json=result
             )
 
-        l = Instance(self.client, result["id"], result)
-        if not (image and root_pass):
-            return l
-        return l, root_pass
+        return Instance(self.client, result["id"], result)
 
     @staticmethod
     def build_instance_metadata(user_data=None, encode_user_data=True):
@@ -435,7 +425,7 @@ class LinodeGroup(Group):
         the :any:`instance_create` method. This helper can also be used
         when cloning and rebuilding Instances.
         **Creating an Instance with User Data**::
-            new_linode, password = client.linode.instance_create(
+            new_linode = client.linode.instance_create(
                 "g6-standard-2",
                 "us-east",
                 image="linode/ubuntu22.04",

--- a/linode_api4/groups/linode.py
+++ b/linode_api4/groups/linode.py
@@ -184,7 +184,7 @@ class LinodeGroup(Group):
            new_linode, password = client.linode.instance_create(
                "g6-standard-2",
                "us-east",
-               image="linode/debian9",
+               image="linode/debian13",
                root_pass="aComplex@Password123")
 
            ltype = client.linode.types().first()
@@ -219,7 +219,7 @@ class LinodeGroup(Group):
            new_linode, password = client.linode.instance_create(
               "g6-standard-2",
               "us-east",
-              image="linode/debian9",
+              image="linode/debian13",
               root_pass="aComplex@Password123",
               stackscript=stackscript,
               stackscript_data={"gh_username": "example"})

--- a/linode_api4/groups/linode.py
+++ b/linode_api4/groups/linode.py
@@ -358,7 +358,7 @@ class LinodeGroup(Group):
         :type boot_size: int
 
         :returns: A new Instance object, or a tuple containing the new Instance and
-                  the password if root_pass was provided.
+                  the password if both image and root_pass were provided.
         :rtype: Instance or tuple(Instance, str)
         :raises ApiError: If contacting the API fails
         :raises UnexpectedResponseError: If the API response is somehow malformed.
@@ -412,7 +412,7 @@ class LinodeGroup(Group):
             )
 
         l = Instance(self.client, result["id"], result)
-        if not root_pass:
+        if not (image and root_pass):
             return l
         return l, root_pass
 
@@ -427,7 +427,7 @@ class LinodeGroup(Group):
                 "g6-standard-2",
                 "us-east",
                 image="linode/ubuntu22.04",
-                root_pass=""aComplex@Password123",
+                root_pass="aComplex@Password123",
                 metadata=client.linode.build_instance_metadata(user_data="myuserdata")
             )
         :param user_data: User-defined data to provide to the Linode Instance through

--- a/linode_api4/groups/linode.py
+++ b/linode_api4/groups/linode.py
@@ -295,7 +295,7 @@ class LinodeGroup(Group):
         :type image: str or Image
         :param root_pass: The root password for the new Instance. If an image is
                           provided and root_pass is given, the Instance and password
-                          will be returned as a tuple. If all of root_pass, authorized_users,and
+                          will be returned as a tuple. If all of root_pass, authorized_users, and
                           authorized_keys are not provided when an image is specified,
                           a ValueError will be raised.
         :type root_pass: str

--- a/linode_api4/groups/linode.py
+++ b/linode_api4/groups/linode.py
@@ -165,6 +165,7 @@ class LinodeGroup(Group):
         root_pass: Optional[str] = None,
         kernel: Optional[str] = None,
         boot_size: Optional[int] = None,
+        authorized_users: Optional[List[str]] = None,
         **kwargs,
     ):
         """
@@ -175,7 +176,7 @@ class LinodeGroup(Group):
         To create an Instance from an :any:`Image`, call `instance_create` with
         a :any:`Type`, a :any:`Region`, and an :any:`Image`.  All three of
         these fields may be provided as either the ID or the appropriate object.
-        When an Image is provided, at least one of ``root_pass`` or
+        When an Image is provided, at least one of ``root_pass``, ``authorized_users``, or
         ``authorized_keys`` must also be given.  If ``root_pass`` is provided,
         the Instance and the password are returned as a tuple.
 
@@ -314,6 +315,11 @@ class LinodeGroup(Group):
                                 be a single key, or a path to a file containing
                                 the key.
         :type authorized_keys: list or str
+        :param authorized_users: A list of usernames whose keys should be installed
+                                 as trusted for the root user.  These user's keys
+                                 should already be set up, see :any:`ProfileGroup.ssh_keys`
+                                 for details.
+        :type authorized_users: list[str]
         :param label: The display label for the new Instance
         :type label: str
         :param group: The display group for the new Instance
@@ -366,10 +372,10 @@ class LinodeGroup(Group):
                                          an outdated library.
         """
 
-        if image and not root_pass and not authorized_keys:
+        if image and not root_pass and not authorized_keys and not authorized_users:
             raise ValueError(
                 "When creating an Instance from an Image, at least one of "
-                "root_pass or authorized_keys must be provided."
+                "root_pass, authorized_users, or authorized_keys must be provided."
             )
 
         params = {
@@ -378,6 +384,7 @@ class LinodeGroup(Group):
             "image": image,
             "root_pass": root_pass,
             "authorized_keys": load_and_validate_keys(authorized_keys),
+            "authorized_users": authorized_users,
             # These will automatically be flattened below
             "firewall_id": firewall,
             "backup_id": backup,

--- a/linode_api4/groups/linode.py
+++ b/linode_api4/groups/linode.py
@@ -372,7 +372,12 @@ class LinodeGroup(Group):
                                          an outdated library.
         """
 
-        if image and not root_pass and not authorized_keys and not authorized_users:
+        if (
+            image
+            and not root_pass
+            and not authorized_keys
+            and not authorized_users
+        ):
             raise ValueError(
                 "When creating an Instance from an Image, at least one of "
                 "root_pass, authorized_users, or authorized_keys must be provided."

--- a/linode_api4/objects/linode.py
+++ b/linode_api4/objects/linode.py
@@ -1396,7 +1396,7 @@ class Instance(Base):
                            if creating a disk without an image.
         :param read_only: If True, creates a read-only disk
         :param image: The Image to deploy to the disk.  If provided, at least one of
-                      root_pass or authorized_keys must also be given.
+                      root_pass, authorized_users or authorized_keys must also be given.
         :param root_pass: The password to configure for the root user when deploying an
                           image to this disk.  Not used if image is not given.  If an
                           image is given and root_pass is provided, it will be returned
@@ -1419,10 +1419,10 @@ class Instance(Base):
         :rtype: Disk or tuple(Disk, str)
         """
 
-        if image and not root_pass and not authorized_keys:
+        if image and not root_pass and not authorized_keys and not authorized_users:
             raise ValueError(
                 "When creating a Disk from an Image, at least one of "
-                "root_pass or authorized_keys must be provided."
+                "root_pass, authorized_users, or authorized_keys must be provided."
             )
 
         authorized_keys = load_and_validate_keys(authorized_keys)
@@ -1586,6 +1586,7 @@ class Instance(Base):
         disk_encryption: Optional[
             Union[InstanceDiskEncryptionType, str]
         ] = None,
+        authorized_users: Optional[List[str]] = None,
         **kwargs,
     ):
         """
@@ -1598,13 +1599,18 @@ class Instance(Base):
         :param image: The Image to deploy to this Instance
         :type image: str or Image
         :param root_pass: The root password for the newly rebuilt Instance.  At least
-                          one of root_pass or authorized_keys must be provided.
+                          one of root_pass, authorized_users, or authorized_keys must be provided.
         :type root_pass: str
         :param authorized_keys: The ssh public keys to install in the linode's
                                 /root/.ssh/authorized_keys file.  Each entry may
                                 be a single key, or a path to a file containing
                                 the key.
         :type authorized_keys: list or str
+        :param authorized_users: A list of usernames whose keys should be installed
+                                 as trusted for the root user.  These user's keys
+                                 should already be set up, see :any:`ProfileGroup.ssh_keys`
+                                 for details.
+        :type authorized_users: list[str]
         :param disk_encryption: The disk encryption policy for this Linode.
                                 NOTE: Disk encryption may not currently be available to all users.
         :type disk_encryption: InstanceDiskEncryptionType or str
@@ -1612,10 +1618,10 @@ class Instance(Base):
         :returns: The root_pass if provided, otherwise True.
         :rtype: str or bool
         """
-        if not root_pass and not authorized_keys:
+        if not root_pass and not authorized_keys and not authorized_users:
             raise ValueError(
                 "When rebuilding an Instance, at least one of "
-                "root_pass or authorized_keys must be provided."
+                "root_pass, authorized_users, or authorized_keys must be provided."
             )
 
         authorized_keys = load_and_validate_keys(authorized_keys)
@@ -1627,6 +1633,7 @@ class Instance(Base):
             "disk_encryption": (
                 str(disk_encryption) if disk_encryption else None
             ),
+            "authorized_users": authorized_users,
         }
 
         params.update(kwargs)

--- a/linode_api4/objects/linode.py
+++ b/linode_api4/objects/linode.py
@@ -1398,9 +1398,7 @@ class Instance(Base):
         :param image: The Image to deploy to the disk.  If provided, at least one of
                       root_pass, authorized_users or authorized_keys must also be given.
         :param root_pass: The password to configure for the root user when deploying an
-                          image to this disk.  Not used if image is not given.  If an
-                          image is given and root_pass is provided, it will be returned
-                          alongside the new disk as a tuple.
+                          image to this disk.  Not used if image is not given.
         :param authorized_keys: A list of SSH keys to install as trusted for the root user.
         :param authorized_users: A list of usernames whose keys should be installed
                                  as trusted for the root user.  These user's keys
@@ -1414,9 +1412,8 @@ class Instance(Base):
         :param **stackscript_args: Any arguments to pass to the StackScript, as defined
                                    by its User Defined Fields.
 
-        :returns: A new Disk object, or a tuple containing the new Disk and the
-                  password if both image and root_pass were provided.
-        :rtype: Disk or tuple(Disk, str)
+        :returns: A new Disk object.
+        :rtype: Disk
         """
 
         if (
@@ -1475,11 +1472,7 @@ class Instance(Base):
                 "Unexpected response creating disk!", json=result
             )
 
-        d = Disk(self._client, result["id"], self.id, result)
-
-        if image and root_pass:
-            return d, root_pass
-        return d
+        return Disk(self._client, result["id"], self.id, result)
 
     def enable_backups(self):
         """
@@ -1620,8 +1613,8 @@ class Instance(Base):
                                 NOTE: Disk encryption may not currently be available to all users.
         :type disk_encryption: InstanceDiskEncryptionType or str
 
-        :returns: The root_pass if provided, otherwise True.
-        :rtype: str or bool
+        :returns: True.
+        :rtype: bool
         """
         if not root_pass and not authorized_keys and not authorized_users:
             raise ValueError(
@@ -1657,8 +1650,6 @@ class Instance(Base):
         # update ourself with the newly-returned information
         self._populate(result)
 
-        if root_pass:
-            return root_pass
         return True
 
     def rescue(self, *disks):

--- a/linode_api4/objects/linode.py
+++ b/linode_api4/objects/linode.py
@@ -1419,7 +1419,12 @@ class Instance(Base):
         :rtype: Disk or tuple(Disk, str)
         """
 
-        if image and not root_pass and not authorized_keys and not authorized_users:
+        if (
+            image
+            and not root_pass
+            and not authorized_keys
+            and not authorized_users
+        ):
             raise ValueError(
                 "When creating a Disk from an Image, at least one of "
                 "root_pass, authorized_users, or authorized_keys must be provided."

--- a/linode_api4/objects/linode.py
+++ b/linode_api4/objects/linode.py
@@ -1395,11 +1395,12 @@ class Instance(Base):
                            for the image deployed the disk will be used.  Required
                            if creating a disk without an image.
         :param read_only: If True, creates a read-only disk
-        :param image: The Image to deploy to the disk.
+        :param image: The Image to deploy to the disk.  If provided, at least one of
+                      root_pass or authorized_keys must also be given.
         :param root_pass: The password to configure for the root user when deploying an
                           image to this disk.  Not used if image is not given.  If an
-                          image is given and root_pass is not, a password will be
-                          generated and returned alongside the new disk.
+                          image is given and root_pass is provided, it will be returned
+                          alongside the new disk as a tuple.
         :param authorized_keys: A list of SSH keys to install as trusted for the root user.
         :param authorized_users: A list of usernames whose keys should be installed
                                  as trusted for the root user.  These user's keys
@@ -1412,12 +1413,17 @@ class Instance(Base):
                             disk.  Requires deploying a compatible image.
         :param **stackscript_args: Any arguments to pass to the StackScript, as defined
                                    by its User Defined Fields.
+
+        :returns: A new Disk object, or a tuple containing the new Disk and the
+                  password if root_pass was provided.
+        :rtype: Disk or tuple(Disk, str)
         """
 
-        gen_pass = None
-        if image and not root_pass:
-            gen_pass = Instance.generate_root_password()
-            root_pass = gen_pass
+        if image and not root_pass and not authorized_keys:
+            raise ValueError(
+                "When creating a Disk from an Image, at least one of "
+                "root_pass or authorized_keys must be provided."
+            )
 
         authorized_keys = load_and_validate_keys(authorized_keys)
 
@@ -1466,8 +1472,8 @@ class Instance(Base):
 
         d = Disk(self._client, result["id"], self.id, result)
 
-        if gen_pass:
-            return d, gen_pass
+        if root_pass:
+            return d, root_pass
         return d
 
     def enable_backups(self):
@@ -1591,8 +1597,8 @@ class Instance(Base):
 
         :param image: The Image to deploy to this Instance
         :type image: str or Image
-        :param root_pass: The root password for the newly rebuilt Instance.  If
-                          omitted, a password will be generated and returned.
+        :param root_pass: The root password for the newly rebuilt Instance.  At least
+                          one of root_pass or authorized_keys must be provided.
         :type root_pass: str
         :param authorized_keys: The ssh public keys to install in the linode's
                                 /root/.ssh/authorized_keys file.  Each entry may
@@ -1603,14 +1609,14 @@ class Instance(Base):
                                 NOTE: Disk encryption may not currently be available to all users.
         :type disk_encryption: InstanceDiskEncryptionType or str
 
-        :returns: The newly generated password, if one was not provided
-                  (otherwise True)
+        :returns: The root_pass if provided, otherwise True.
         :rtype: str or bool
         """
-        ret_pass = None
-        if not root_pass:
-            ret_pass = Instance.generate_root_password()
-            root_pass = ret_pass
+        if not root_pass and not authorized_keys:
+            raise ValueError(
+                "When rebuilding an Instance, at least one of "
+                "root_pass or authorized_keys must be provided."
+            )
 
         authorized_keys = load_and_validate_keys(authorized_keys)
 
@@ -1639,10 +1645,9 @@ class Instance(Base):
         # update ourself with the newly-returned information
         self._populate(result)
 
-        if not ret_pass:
-            return True
-        else:
-            return ret_pass
+        if root_pass:
+            return root_pass
+        return True
 
     def rescue(self, *disks):
         """

--- a/linode_api4/objects/linode.py
+++ b/linode_api4/objects/linode.py
@@ -1415,7 +1415,7 @@ class Instance(Base):
                                    by its User Defined Fields.
 
         :returns: A new Disk object, or a tuple containing the new Disk and the
-                  password if root_pass was provided.
+                  password if both image and root_pass were provided.
         :rtype: Disk or tuple(Disk, str)
         """
 
@@ -1472,7 +1472,7 @@ class Instance(Base):
 
         d = Disk(self._client, result["id"], self.id, result)
 
-        if root_pass:
+        if image and root_pass:
             return d, root_pass
         return d
 

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -223,12 +223,13 @@ def create_linode(test_linode_client, e2e_test_firewall):
     region = get_region(client, {"Linodes", "Cloud Firewall"}, site_type="core")
     label = get_test_label(length=8)
 
-    linode_instance, password = client.linode.instance_create(
+    linode_instance = client.linode.instance_create(
         "g6-nanode-1",
         region,
         image="linode/debian12",
         label=label,
         firewall=e2e_test_firewall,
+        root_pass="aComplex@Password123",
     )
 
     yield linode_instance
@@ -242,13 +243,15 @@ def create_linode_for_pass_reset(test_linode_client, e2e_test_firewall):
 
     region = get_region(client, {"Linodes", "Cloud Firewall"}, site_type="core")
     label = get_test_label(length=8)
+    password = "aComplex@Password123"
 
-    linode_instance, password = client.linode.instance_create(
+    linode_instance = client.linode.instance_create(
         "g6-nanode-1",
         region,
         image="linode/debian12",
         label=label,
         firewall=e2e_test_firewall,
+        root_pass=password,
     )
 
     yield linode_instance, password
@@ -488,15 +491,16 @@ def create_vpc_with_subnet_and_linode(
 
     label = get_test_label(length=8)
 
-    instance, password = test_linode_client.linode.instance_create(
+    instance = test_linode_client.linode.instance_create(
         "g6-standard-1",
         vpc.region,
         image="linode/debian11",
         label=label,
         firewall=e2e_test_firewall,
+        root_pass="aComplex@Password123",
     )
 
-    yield vpc, subnet, instance, password
+    yield vpc, subnet, instance
 
     instance.delete()
 
@@ -579,12 +583,13 @@ def linode_for_vlan_tests(test_linode_client, e2e_test_firewall):
     region = get_region(client, {"Linodes", "Vlans"}, site_type="core")
     label = get_test_label(length=8)
 
-    linode_instance, password = client.linode.instance_create(
+    linode_instance = client.linode.instance_create(
         "g6-nanode-1",
         region,
         image="linode/debian12",
         label=label,
         firewall=e2e_test_firewall,
+        root_pass="aComplex@Password123",
     )
 
     yield linode_instance
@@ -628,13 +633,14 @@ def linode_with_linode_interfaces(
     region = vpc.region
     label = get_test_label()
 
-    instance, _ = client.linode.instance_create(
+    instance = client.linode.instance_create(
         "g6-nanode-1",
         region,
         image="linode/debian12",
         label=label,
         booted=False,
         interface_generation=InterfaceGeneration.LINODE,
+        root_pass="aComplex@Password123",
         interfaces=[
             LinodeInterfaceOptions(
                 firewall_id=e2e_test_firewall.id,

--- a/test/integration/linode_client/test_linode_client.py
+++ b/test/integration/linode_client/test_linode_client.py
@@ -16,12 +16,13 @@ def setup_client_and_linode(test_linode_client, e2e_test_firewall):
 
     label = get_test_label()
 
-    linode_instance, password = client.linode.instance_create(
+    linode_instance = client.linode.instance_create(
         "g6-nanode-1",
         region,
         image="linode/debian12",
         label=label,
         firewall=e2e_test_firewall,
+        root_pass="aComplex@Password123"
     )
 
     yield client, linode_instance
@@ -258,7 +259,7 @@ def test_create_linode_with_interfaces(test_linode_client):
     region = get_region(client, {"Vlans", "Linodes"}, site_type="core").id
     label = get_test_label()
 
-    linode_instance, password = client.linode.instance_create(
+    linode_instance = client.linode.instance_create(
         "g6-nanode-1",
         region,
         label=label,
@@ -269,6 +270,7 @@ def test_create_linode_with_interfaces(test_linode_client):
                 purpose="vlan", label="cool-vlan", ipam_address="10.0.0.4/32"
             ),
         ],
+        root_pass="aComplex@Password123",
     )
 
     assert len(linode_instance.configs[0].interfaces) == 2

--- a/test/integration/linode_client/test_linode_client.py
+++ b/test/integration/linode_client/test_linode_client.py
@@ -22,7 +22,7 @@ def setup_client_and_linode(test_linode_client, e2e_test_firewall):
         image="linode/debian12",
         label=label,
         firewall=e2e_test_firewall,
-        root_pass="aComplex@Password123"
+        root_pass="aComplex@Password123",
     )
 
     yield client, linode_instance

--- a/test/integration/models/account/test_account.py
+++ b/test/integration/models/account/test_account.py
@@ -98,12 +98,13 @@ def test_latest_get_event(test_linode_client, e2e_test_firewall):
     region = get_region(client, {"Linodes", "Cloud Firewall"}, site_type="core")
     label = get_test_label()
 
-    linode, password = client.linode.instance_create(
+    linode = client.linode.instance_create(
         "g6-nanode-1",
         region,
         image="linode/debian12",
         label=label,
         firewall=e2e_test_firewall,
+        root_pass="aComplex@Password123",
     )
 
     def get_linode_status():

--- a/test/integration/models/firewall/test_firewall.py
+++ b/test/integration/models/firewall/test_firewall.py
@@ -14,7 +14,10 @@ def linode_fw(test_linode_client):
     label = get_test_label()
 
     linode_instance = client.linode.instance_create(
-        "g6-nanode-1", region, image="linode/debian12", label=label,
+        "g6-nanode-1",
+        region,
+        image="linode/debian12",
+        label=label,
         root_pass="aComplex@Password123",
     )
 

--- a/test/integration/models/firewall/test_firewall.py
+++ b/test/integration/models/firewall/test_firewall.py
@@ -13,8 +13,9 @@ def linode_fw(test_linode_client):
     region = get_region(client, {"Linodes", "Cloud Firewall"}, site_type="core")
     label = get_test_label()
 
-    linode_instance, password = client.linode.instance_create(
-        "g6-nanode-1", region, image="linode/debian12", label=label
+    linode_instance = client.linode.instance_create(
+        "g6-nanode-1", region, image="linode/debian12", label=label,
+        root_pass="aComplex@Password123",
     )
 
     yield linode_instance

--- a/test/integration/models/linode/test_linode.py
+++ b/test/integration/models/linode/test_linode.py
@@ -275,7 +275,10 @@ def test_linode_rebuild(test_linode_client):
     label = get_test_label() + "_rebuild"
 
     linode = client.linode.instance_create(
-        "g6-nanode-1", region, image="linode/debian12", label=label,
+        "g6-nanode-1",
+        region,
+        image="linode/debian12",
+        label=label,
         root_pass="aComplex@Password123",
     )
 
@@ -921,9 +924,7 @@ class TestNetworkInterface:
         test_linode_client,
         linode_and_vpc_for_legacy_interface_tests_offline,
     ):
-        vpc, subnet, linode = (
-            linode_and_vpc_for_legacy_interface_tests_offline
-        )
+        vpc, subnet, linode = linode_and_vpc_for_legacy_interface_tests_offline
 
         config: Config = linode.configs[0]
 
@@ -1031,9 +1032,7 @@ class TestNetworkInterface:
         self,
         linode_and_vpc_for_legacy_interface_tests_offline,
     ):
-        vpc, subnet, linode = (
-            linode_and_vpc_for_legacy_interface_tests_offline
-        )
+        vpc, subnet, linode = linode_and_vpc_for_legacy_interface_tests_offline
 
         config: Config = linode.configs[0]
 

--- a/test/integration/models/linode/test_linode.py
+++ b/test/integration/models/linode/test_linode.py
@@ -37,11 +37,12 @@ def linode_with_volume_firewall(test_linode_client):
         "inbound_policy": "DROP",
     }
 
-    linode_instance, password = client.linode.instance_create(
+    linode_instance = client.linode.instance_create(
         "g6-nanode-1",
         region,
         image="linode/debian12",
         label=label + "_modlinode",
+        root_pass="aComplex@Password123",
     )
 
     volume = client.volume_create(
@@ -75,13 +76,14 @@ def linode_for_legacy_interface_tests(test_linode_client, e2e_test_firewall):
     region = get_region(client, {"Linodes", "Cloud Firewall"}, site_type="core")
     label = get_test_label(length=8)
 
-    linode_instance, password = client.linode.instance_create(
+    linode_instance = client.linode.instance_create(
         "g6-nanode-1",
         region,
         image="linode/debian12",
         label=label,
         firewall=e2e_test_firewall,
         interface_generation=InterfaceGeneration.LEGACY_CONFIG,
+        root_pass="aComplex@Password123",
     )
 
     yield linode_instance
@@ -97,7 +99,7 @@ def linode_and_vpc_for_legacy_interface_tests_offline(
 
     label = get_test_label(length=8)
 
-    instance, password = test_linode_client.linode.instance_create(
+    instance = test_linode_client.linode.instance_create(
         "g6-standard-1",
         vpc.region,
         booted=False,
@@ -105,9 +107,10 @@ def linode_and_vpc_for_legacy_interface_tests_offline(
         label=label,
         firewall=e2e_test_firewall,
         interface_generation=InterfaceGeneration.LEGACY_CONFIG,
+        root_pass="aComplex@Password123",
     )
 
-    yield vpc, subnet, instance, password
+    yield vpc, subnet, instance
 
     instance.delete()
 
@@ -119,12 +122,13 @@ def linode_for_vpu_tests(test_linode_client, e2e_test_firewall):
 
     label = get_test_label(length=8)
 
-    linode_instance, password = client.linode.instance_create(
+    linode_instance = client.linode.instance_create(
         "g1-accelerated-netint-vpu-t1u1-s",
         region,
         image="linode/debian12",
         label=label,
         firewall=e2e_test_firewall,
+        root_pass="aComplex@Password123",
     )
 
     yield linode_instance
@@ -138,12 +142,13 @@ def linode_for_disk_tests(test_linode_client, e2e_test_firewall):
     region = get_region(client, {"Linodes", "Cloud Firewall"}, site_type="core")
     label = get_test_label()
 
-    linode_instance, password = client.linode.instance_create(
+    linode_instance = client.linode.instance_create(
         "g6-nanode-1",
         region,
         image="linode/alpine3.19",
         label=label + "_long_tests",
         firewall=e2e_test_firewall,
+        root_pass="aComplex@Password123",
     )
 
     # Provisioning time
@@ -171,12 +176,13 @@ def linode_with_block_storage_encryption(test_linode_client, e2e_test_firewall):
     region = get_region(client, {"Linodes", "Block Storage Encryption"})
     label = get_test_label()
 
-    linode_instance, password = client.linode.instance_create(
+    linode_instance = client.linode.instance_create(
         "g6-nanode-1",
         region,
         image="linode/alpine3.19",
         label=label + "block-storage-encryption",
         firewall=e2e_test_firewall,
+        root_pass="aComplex@Password123",
     )
 
     yield linode_instance
@@ -190,12 +196,13 @@ def create_linode_for_long_running_tests(test_linode_client, e2e_test_firewall):
     region = get_region(client, {"Linodes", "Cloud Firewall"}, site_type="core")
     label = get_test_label()
 
-    linode_instance, password = client.linode.instance_create(
+    linode_instance = client.linode.instance_create(
         "g6-nanode-1",
         region,
         image="linode/debian12",
         label=label + "_long_tests",
         firewall=e2e_test_firewall,
+        root_pass="aComplex@Password123",
     )
 
     yield linode_instance
@@ -212,13 +219,14 @@ def linode_with_disk_encryption(test_linode_client, request):
 
     disk_encryption = request.param
 
-    linode_instance, password = client.linode.instance_create(
+    linode_instance = client.linode.instance_create(
         "g6-nanode-1",
         target_region,
         image="linode/ubuntu24.10",
         label=label,
         booted=False,
         disk_encryption=disk_encryption,
+        root_pass="aComplex@Password123",
     )
 
     yield linode_instance
@@ -266,8 +274,9 @@ def test_linode_rebuild(test_linode_client):
 
     label = get_test_label() + "_rebuild"
 
-    linode, password = client.linode.instance_create(
-        "g6-nanode-1", region, image="linode/debian12", label=label
+    linode = client.linode.instance_create(
+        "g6-nanode-1", region, image="linode/debian12", label=label,
+        root_pass="aComplex@Password123",
     )
 
     wait_for_condition(10, 100, get_status, linode, "running")
@@ -276,6 +285,7 @@ def test_linode_rebuild(test_linode_client):
         3,
         linode.rebuild,
         "linode/debian12",
+        root_pass="aComplex@Password123",
         disk_encryption=InstanceDiskEncryptionType.disabled,
     )
 
@@ -322,11 +332,12 @@ def test_delete_linode(test_linode_client):
     region = get_region(client, {"Linodes", "Cloud Firewall"}, site_type="core")
     label = get_test_label()
 
-    linode_instance, password = client.linode.instance_create(
+    linode_instance = client.linode.instance_create(
         "g6-nanode-1",
         region,
         image="linode/debian12",
         label=label + "_linode",
+        root_pass="aComplex@Password123",
     )
 
     linode_instance.delete()
@@ -595,12 +606,13 @@ def test_linode_initate_migration(test_linode_client, e2e_test_firewall):
     region = get_region(client, {"Linodes", "Cloud Firewall"}, site_type="core")
     label = get_test_label() + "_migration"
 
-    linode, _ = client.linode.instance_create(
+    linode = client.linode.instance_create(
         "g6-nanode-1",
         region,
         image="linode/debian12",
         label=label,
         firewall=e2e_test_firewall,
+        root_pass="aComplex@Password123",
     )
 
     # Says it could take up to ~6 hrs for migration to fully complete
@@ -626,7 +638,7 @@ def test_linode_upgrade_interfaces(
     linode_for_legacy_interface_tests,
     linode_and_vpc_for_legacy_interface_tests_offline,
 ):
-    vpc, subnet, linode, _ = linode_and_vpc_for_legacy_interface_tests_offline
+    vpc, subnet, linode = linode_and_vpc_for_legacy_interface_tests_offline
     config = linode.configs[0]
 
     new_interfaces = [
@@ -909,7 +921,7 @@ class TestNetworkInterface:
         test_linode_client,
         linode_and_vpc_for_legacy_interface_tests_offline,
     ):
-        vpc, subnet, linode, _ = (
+        vpc, subnet, linode = (
             linode_and_vpc_for_legacy_interface_tests_offline
         )
 
@@ -1019,7 +1031,7 @@ class TestNetworkInterface:
         self,
         linode_and_vpc_for_legacy_interface_tests_offline,
     ):
-        vpc, subnet, linode, _ = (
+        vpc, subnet, linode = (
             linode_and_vpc_for_legacy_interface_tests_offline
         )
 
@@ -1082,7 +1094,7 @@ class TestNetworkInterface:
     def test_delete_interface_containing_vpc(
         self, create_vpc_with_subnet_and_linode
     ):
-        vpc, subnet, linode, _ = create_vpc_with_subnet_and_linode
+        vpc, subnet, linode = create_vpc_with_subnet_and_linode
 
         config: Config = linode.configs[0]
 
@@ -1116,12 +1128,13 @@ def test_create_linode_with_maintenance_policy(test_linode_client):
     non_default_policy = next((p for p in policies if not p.is_default), None)
     assert non_default_policy, "No non-default maintenance policy available"
 
-    linode_instance, password = client.linode.instance_create(
+    linode_instance = client.linode.instance_create(
         "g6-nanode-1",
         region,
         image="linode/debian12",
         label=label + "_with_policy",
         maintenance_policy=non_default_policy.slug,
+        root_pass="aComplex@Password123",
     )
 
     assert linode_instance.id is not None

--- a/test/integration/models/lock/test_lock.py
+++ b/test/integration/models/lock/test_lock.py
@@ -18,12 +18,13 @@ def linode_for_lock(test_linode_client, e2e_test_firewall):
     region = get_region(client, {"Linodes", "Cloud Firewall"}, site_type="core")
     label = get_test_label(length=8)
 
-    linode_instance, _ = client.linode.instance_create(
+    linode_instance = client.linode.instance_create(
         "g6-nanode-1",
         region,
         image="linode/debian12",
         label=label,
         firewall=e2e_test_firewall,
+        root_pass="aComplex@Password123",
     )
 
     yield linode_instance

--- a/test/integration/models/networking/test_networking.py
+++ b/test/integration/models/networking/test_networking.py
@@ -37,11 +37,12 @@ def create_linode_func(test_linode_client):
 
     label = get_test_label()
 
-    linode_instance, _ = client.linode.instance_create(
+    linode_instance = client.linode.instance_create(
         "g6-nanode-1",
         TEST_REGION,
         image="linode/debian12",
         label=label,
+        root_pass="aComplex@Password123",
     )
 
     return linode_instance
@@ -220,7 +221,7 @@ def test_ip_addresses_unshare(
 
 
 def test_ip_info_vpc(test_linode_client, create_vpc_with_subnet_and_linode):
-    vpc, subnet, linode, _ = create_vpc_with_subnet_and_linode
+    vpc, subnet, linode = create_vpc_with_subnet_and_linode
 
     config: Config = linode.configs[0]
 

--- a/test/integration/models/nodebalancer/test_nodebalancer.py
+++ b/test/integration/models/nodebalancer/test_nodebalancer.py
@@ -33,13 +33,14 @@ def linode_with_private_ip(test_linode_client, e2e_test_firewall):
     client = test_linode_client
     label = get_test_label(8)
 
-    linode_instance, password = client.linode.instance_create(
+    linode_instance = client.linode.instance_create(
         "g6-nanode-1",
         TEST_REGION,
         image="linode/debian12",
         label=label,
         private_ip=True,
         firewall=e2e_test_firewall,
+        root_pass="aComplex@Password123",
     )
 
     yield linode_instance

--- a/test/integration/models/sharegroups/test_sharegroups.py
+++ b/test/integration/models/sharegroups/test_sharegroups.py
@@ -41,11 +41,12 @@ def sample_linode(test_linode_client, e2e_test_firewall):
     region = get_region(client, {"Linodes", "Cloud Firewall"}, site_type="core")
     label = get_test_label(length=8)
 
-    linode_instance, password = client.linode.instance_create(
+    linode_instance = client.linode.instance_create(
         "g6-nanode-1",
         region,
         image="linode/alpine3.19",
         label=label + "_modlinode",
+        root_pass="aComplex@Password123",
     )
     yield linode_instance
     linode_instance.delete()

--- a/test/integration/models/volume/test_blockstorage.py
+++ b/test/integration/models/volume/test_blockstorage.py
@@ -8,11 +8,12 @@ def test_config_create_with_extended_volume_limit(test_linode_client):
     region = get_region(client, {"Linodes", "Block Storage"}, site_type="core")
     label = get_test_label()
 
-    linode, _ = client.linode.instance_create(
+    linode = client.linode.instance_create(
         "g6-standard-6",
         region,
         image="linode/debian12",
         label=label,
+        root_pass="aComplex@Password123",
     )
 
     volumes = [

--- a/test/integration/models/volume/test_volume.py
+++ b/test/integration/models/volume/test_volume.py
@@ -46,12 +46,13 @@ def linode_for_volume(test_linode_client, e2e_test_firewall):
 
     label = get_test_label(length=8)
 
-    linode_instance, password = client.linode.instance_create(
+    linode_instance = client.linode.instance_create(
         "g6-nanode-1",
         TEST_REGION,
         image="linode/debian12",
         label=label,
         firewall=e2e_test_firewall,
+        root_pass="aComplex@Password123",
     )
 
     yield linode_instance

--- a/test/unit/linode_client_test.py
+++ b/test/unit/linode_client_test.py
@@ -686,11 +686,14 @@ class LinodeGroupTest(ClientBaseCase):
 
     def test_instance_create_with_image(self):
         """
-        Tests that a Linode Instance can be created with an image, and a password generated
+        Tests that a Linode Instance can be created with an image and root_pass
         """
         with self.mock_post("linode/instances/123") as m:
             l, pw = self.client.linode.instance_create(
-                "g6-standard-1", "us-east-1a", image="linode/debian9"
+                "g6-standard-1",
+                "us-east-1a",
+                image="linode/debian9",
+                root_pass="aComplex@Password123",
             )
 
             self.assertIsNotNone(l)
@@ -704,7 +707,133 @@ class LinodeGroupTest(ClientBaseCase):
                     "region": "us-east-1a",
                     "type": "g6-standard-1",
                     "image": "linode/debian9",
-                    "root_pass": pw,
+                    "root_pass": "aComplex@Password123",
+                },
+            )
+
+    def test_instance_create_with_image_authorized_keys(self):
+        """
+        Tests that a Linode Instance can be created with an image and authorized_keys only
+        """
+        with self.mock_post("linode/instances/123") as m:
+            l = self.client.linode.instance_create(
+                "g6-standard-1",
+                "us-east-1a",
+                image="linode/debian9",
+                authorized_keys="ssh-rsa AAAA",
+            )
+
+            self.assertIsNotNone(l)
+            self.assertEqual(l.id, 123)
+
+            self.assertEqual(m.call_url, "/linode/instances")
+
+            self.assertEqual(
+                m.call_data,
+                {
+                    "region": "us-east-1a",
+                    "type": "g6-standard-1",
+                    "image": "linode/debian9",
+                    "authorized_keys": ["ssh-rsa AAAA"],
+                },
+            )
+
+    def test_instance_create_with_image_requires_auth(self):
+        """
+        Tests that creating an Instance from an Image without root_pass or
+        authorized_keys raises a ValueError
+        """
+        with self.assertRaises(ValueError):
+            self.client.linode.instance_create(
+                "g6-standard-1", "us-east-1a", image="linode/debian9"
+            )
+
+    def test_instance_create_with_kernel(self):
+        """
+        Tests that a Linode Instance can be created with a kernel
+        """
+        with self.mock_post("linode/instances/123") as m:
+            l, pw = self.client.linode.instance_create(
+                "g6-standard-1",
+                "us-east-1a",
+                image="linode/debian9",
+                root_pass="aComplex@Password123",
+                kernel="linode/latest-64bit",
+            )
+
+            self.assertIsNotNone(l)
+            self.assertEqual(l.id, 123)
+
+            self.assertEqual(m.call_url, "/linode/instances")
+
+            self.assertEqual(
+                m.call_data,
+                {
+                    "region": "us-east-1a",
+                    "type": "g6-standard-1",
+                    "image": "linode/debian9",
+                    "root_pass": "aComplex@Password123",
+                    "kernel": "linode/latest-64bit",
+                },
+            )
+
+    def test_instance_create_with_boot_size(self):
+        """
+        Tests that a Linode Instance can be created with a boot_size
+        """
+        with self.mock_post("linode/instances/123") as m:
+            l, pw = self.client.linode.instance_create(
+                "g6-standard-1",
+                "us-east-1a",
+                image="linode/debian9",
+                root_pass="aComplex@Password123",
+                boot_size=5000,
+            )
+
+            self.assertIsNotNone(l)
+            self.assertEqual(l.id, 123)
+
+            self.assertEqual(m.call_url, "/linode/instances")
+
+            self.assertEqual(
+                m.call_data,
+                {
+                    "region": "us-east-1a",
+                    "type": "g6-standard-1",
+                    "image": "linode/debian9",
+                    "root_pass": "aComplex@Password123",
+                    "boot_size": 5000,
+                },
+            )
+
+    def test_instance_create_with_kernel_and_boot_size(self):
+        """
+        Tests that a Linode Instance can be created with both kernel and boot_size
+        """
+        with self.mock_post("linode/instances/123") as m:
+            l, pw = self.client.linode.instance_create(
+                "g6-standard-1",
+                "us-east-1a",
+                image="linode/debian9",
+                root_pass="aComplex@Password123",
+                kernel="linode/latest-64bit",
+                boot_size=5000,
+            )
+
+            self.assertIsNotNone(l)
+            self.assertEqual(l.id, 123)
+
+            self.assertEqual(m.call_url, "/linode/instances")
+
+            self.assertEqual(
+                m.call_data,
+                {
+                    "region": "us-east-1a",
+                    "type": "g6-standard-1",
+                    "image": "linode/debian9",
+                    "root_pass": "aComplex@Password123",
+                    "kernel": "linode/latest-64bit",
+                    "boot_size": 5000,
                 },
             )
 

--- a/test/unit/linode_client_test.py
+++ b/test/unit/linode_client_test.py
@@ -689,7 +689,7 @@ class LinodeGroupTest(ClientBaseCase):
         Tests that a Linode Instance can be created with an image and root_pass
         """
         with self.mock_post("linode/instances/123") as m:
-            l, pw = self.client.linode.instance_create(
+            l = self.client.linode.instance_create(
                 "g6-standard-1",
                 "us-east-1a",
                 image="linode/debian9",
@@ -753,7 +753,7 @@ class LinodeGroupTest(ClientBaseCase):
         Tests that a Linode Instance can be created with a kernel
         """
         with self.mock_post("linode/instances/123") as m:
-            l, pw = self.client.linode.instance_create(
+            l = self.client.linode.instance_create(
                 "g6-standard-1",
                 "us-east-1a",
                 image="linode/debian9",
@@ -782,7 +782,7 @@ class LinodeGroupTest(ClientBaseCase):
         Tests that a Linode Instance can be created with a boot_size
         """
         with self.mock_post("linode/instances/123") as m:
-            l, pw = self.client.linode.instance_create(
+            l = self.client.linode.instance_create(
                 "g6-standard-1",
                 "us-east-1a",
                 image="linode/debian9",
@@ -811,7 +811,7 @@ class LinodeGroupTest(ClientBaseCase):
         Tests that a Linode Instance can be created with both kernel and boot_size
         """
         with self.mock_post("linode/instances/123") as m:
-            l, pw = self.client.linode.instance_create(
+            l = self.client.linode.instance_create(
                 "g6-standard-1",
                 "us-east-1a",
                 image="linode/debian9",

--- a/test/unit/linode_client_test.py
+++ b/test/unit/linode_client_test.py
@@ -787,7 +787,7 @@ class LinodeGroupTest(ClientBaseCase):
                 "us-east-1a",
                 image="linode/debian9",
                 root_pass="aComplex@Password123",
-                boot_size=5000,
+                boot_size=8192,
             )
 
             self.assertIsNotNone(l)
@@ -802,7 +802,7 @@ class LinodeGroupTest(ClientBaseCase):
                     "type": "g6-standard-1",
                     "image": "linode/debian9",
                     "root_pass": "aComplex@Password123",
-                    "boot_size": 5000,
+                    "boot_size": 8192,
                 },
             )
 
@@ -817,7 +817,7 @@ class LinodeGroupTest(ClientBaseCase):
                 image="linode/debian9",
                 root_pass="aComplex@Password123",
                 kernel="linode/latest-64bit",
-                boot_size=5000,
+                boot_size=8192,
             )
 
             self.assertIsNotNone(l)
@@ -833,7 +833,7 @@ class LinodeGroupTest(ClientBaseCase):
                     "image": "linode/debian9",
                     "root_pass": "aComplex@Password123",
                     "kernel": "linode/latest-64bit",
-                    "boot_size": 5000,
+                    "boot_size": 8192,
                 },
             )
 

--- a/test/unit/objects/linode_test.py
+++ b/test/unit/objects/linode_test.py
@@ -93,13 +93,11 @@ class LinodeTest(ClientBaseCase):
         linode = Instance(self.client, 123)
 
         with self.mock_post("/linode/instances/123") as m:
-            pw = linode.rebuild(
+            linode.rebuild(
                 "linode/debian9",
                 root_pass="aComplex@Password123",
                 disk_encryption=InstanceDiskEncryptionType.enabled,
             )
-
-            self.assertEqual(pw, "aComplex@Password123")
 
             self.assertEqual(m.call_url, "/linode/instances/123/rebuild")
 
@@ -471,7 +469,7 @@ class LinodeTest(ClientBaseCase):
         linode = Instance(self.client, 123)
 
         with self.mock_post("/linode/instances/123/disks/12345") as m:
-            disk, pw = linode.disk_create(
+            disk = linode.disk_create(
                 1234,
                 label="test",
                 authorized_users=["test"],
@@ -491,7 +489,6 @@ class LinodeTest(ClientBaseCase):
                 },
             )
 
-        assert pw == "aComplex@Password123"
         assert disk.id == 12345
         assert disk.disk_encryption == InstanceDiskEncryptionType.disabled
 

--- a/test/unit/objects/linode_test.py
+++ b/test/unit/objects/linode_test.py
@@ -88,18 +88,18 @@ class LinodeTest(ClientBaseCase):
 
     def test_rebuild(self):
         """
-        Tests that you can rebuild with an image
+        Tests that you can rebuild with an image and root_pass
         """
         linode = Instance(self.client, 123)
 
         with self.mock_post("/linode/instances/123") as m:
             pw = linode.rebuild(
                 "linode/debian9",
+                root_pass="aComplex@Password123",
                 disk_encryption=InstanceDiskEncryptionType.enabled,
             )
 
-            self.assertIsNotNone(pw)
-            self.assertTrue(isinstance(pw, str))
+            self.assertEqual(pw, "aComplex@Password123")
 
             self.assertEqual(m.call_url, "/linode/instances/123/rebuild")
 
@@ -107,10 +107,44 @@ class LinodeTest(ClientBaseCase):
                 m.call_data,
                 {
                     "image": "linode/debian9",
-                    "root_pass": pw,
+                    "root_pass": "aComplex@Password123",
                     "disk_encryption": "enabled",
                 },
             )
+
+    def test_rebuild_with_authorized_keys(self):
+        """
+        Tests that you can rebuild with an image and authorized_keys only
+        """
+        linode = Instance(self.client, 123)
+
+        with self.mock_post("/linode/instances/123") as m:
+            result = linode.rebuild(
+                "linode/debian9",
+                authorized_keys="ssh-rsa AAAA",
+            )
+
+            self.assertTrue(result)
+
+            self.assertEqual(m.call_url, "/linode/instances/123/rebuild")
+
+            self.assertEqual(
+                m.call_data,
+                {
+                    "image": "linode/debian9",
+                    "authorized_keys": ["ssh-rsa AAAA"],
+                },
+            )
+
+    def test_rebuild_requires_auth(self):
+        """
+        Tests that rebuild raises ValueError when neither root_pass nor
+        authorized_keys is provided
+        """
+        linode = Instance(self.client, 123)
+
+        with self.assertRaises(ValueError):
+            linode.rebuild("linode/debian9")
 
     def test_available_backups(self):
         """
@@ -437,11 +471,12 @@ class LinodeTest(ClientBaseCase):
         linode = Instance(self.client, 123)
 
         with self.mock_post("/linode/instances/123/disks/12345") as m:
-            disk, gen_pass = linode.disk_create(
+            disk, pw = linode.disk_create(
                 1234,
                 label="test",
                 authorized_users=["test"],
                 image="linode/debian12",
+                root_pass="aComplex@Password123",
             )
             self.assertEqual(m.call_url, "/linode/instances/123/disks")
             self.assertEqual(
@@ -449,15 +484,57 @@ class LinodeTest(ClientBaseCase):
                 {
                     "size": 1234,
                     "label": "test",
-                    "root_pass": gen_pass,
+                    "root_pass": "aComplex@Password123",
                     "image": "linode/debian12",
                     "authorized_users": ["test"],
                     "read_only": False,
                 },
             )
 
+        assert pw == "aComplex@Password123"
         assert disk.id == 12345
         assert disk.disk_encryption == InstanceDiskEncryptionType.disabled
+
+    def test_create_disk_with_authorized_keys(self):
+        """
+        Tests that disk_create works with authorized_keys and no root_pass
+        """
+        linode = Instance(self.client, 123)
+
+        with self.mock_post("/linode/instances/123/disks/12345") as m:
+            disk = linode.disk_create(
+                1234,
+                label="test",
+                image="linode/debian12",
+                authorized_keys="ssh-rsa AAAA",
+            )
+            self.assertEqual(m.call_url, "/linode/instances/123/disks")
+            self.assertEqual(
+                m.call_data,
+                {
+                    "size": 1234,
+                    "label": "test",
+                    "image": "linode/debian12",
+                    "authorized_keys": ["ssh-rsa AAAA"],
+                    "read_only": False,
+                },
+            )
+
+        assert disk.id == 12345
+
+    def test_create_disk_with_image_requires_auth(self):
+        """
+        Tests that disk_create raises ValueError when image is provided
+        without root_pass or authorized_keys
+        """
+        linode = Instance(self.client, 123)
+
+        with self.assertRaises(ValueError):
+            linode.disk_create(
+                1234,
+                label="test",
+                image="linode/debian12",
+            )
 
     def test_get_placement_group(self):
         """


### PR DESCRIPTION
## 📝 Description

Added new kernel and boot_size fields to Linode Create options. Also made `root_pass` optional when `image` is provided (if `authorized_keys` is provided instead) for Linode creation and rebulding, and Linode Disk creation.

Removed `root_pass` from returned fields for instance creation, disk creation, and instance rebuilding as root passwords are no longer automatically generated.

## ✔️ How to Test

`make test-unit`
`make test-int`
