### PR TITLE
TPT-4368: Update integration tests due to deprecated "vpcs" for NB create

### DIFF
--- a/test/integration/models/nodebalancer/test_nodebalancer.py
+++ b/test/integration/models/nodebalancer/test_nodebalancer.py
@@ -305,7 +305,7 @@ def test_nb_with_backend_only(test_linode_client, create_vpc_with_subnet):
     nb = client.nodebalancer_create(
         region=create_vpc_with_subnet[0].region,
         label=label,
-        vpcs=[
+        backend_vpcs=[
             {
                 "vpc_id": create_vpc_with_subnet[0].id,
                 "subnet_id": create_vpc_with_subnet[1].id,
@@ -471,7 +471,7 @@ def test_nb_with_frontend_and_backend_in_different_vpcs(
     nb = client.nodebalancer_create(
         region=region,
         label=label,
-        vpcs=[{"vpc_id": vpc_backend, "subnet_id": subnet_backend}],
+        backend_vpcs=[{"vpc_id": vpc_backend, "subnet_id": subnet_backend}],
         frontend_vpcs=[
             {
                 "subnet_id": subnet_frontend.id,

--- a/test/integration/models/nodebalancer/test_nodebalancer.py
+++ b/test/integration/models/nodebalancer/test_nodebalancer.py
@@ -508,3 +508,30 @@ def test_nb_with_frontend_and_backend_in_different_vpcs(
 
     nb.delete()
     vpc_frontend.delete()
+
+
+def test_nb_with_deprecated_vpcs_attribute(
+    test_linode_client, create_vpc_with_subnet
+):
+    # TODO: The test will be deleted when a deprecated vpcs attribute can no longer be used
+    client = test_linode_client
+    label = get_test_label(8)
+
+    nb = client.nodebalancer_create(
+        region=create_vpc_with_subnet[0].region,
+        label=label,
+        vpcs=[
+            {
+                "subnet_id": create_vpc_with_subnet[1].id,
+            }
+        ],
+    )
+
+    assert isinstance(
+        ipaddress.ip_address(nb.ipv4.address), ipaddress.IPv4Address
+    )
+    assert isinstance(ipaddress.ip_address(nb.ipv6), ipaddress.IPv6Address)
+    assert nb.frontend_address_type == "public"
+    assert nb.frontend_vpc_subnet_id is None
+
+    nb.delete()


### PR DESCRIPTION
## 📝 Description

Changes related to the fact that "vpcs" attribute is deprecated (but still valid) in favor of "backend_vpcs" in POST /nodebalancers

## ✔️ How to Test

`make test-int TEST_SUITE=nodebalancer TEST_ARGS="-k test_nb_with"`