### PR TITLE
TPT-4418: Remove outdated note about Linode interfaces availability

### DIFF
--- a/linode_api4/objects/linode.py
+++ b/linode_api4/objects/linode.py
@@ -2055,8 +2055,6 @@ class Instance(Base):
         Creates a new interface under this Linode.
         Linode interfaces are not interchangeable with Config interfaces.
 
-        NOTE: Linode interfaces may not currently be available to all users.
-
         API Documentation: https://techdocs.akamai.com/linode-api/reference/post-linode-interface
 
         Example: Creating a simple public interface for this Linode::
@@ -2132,8 +2130,6 @@ class Instance(Base):
         """
         The settings for all interfaces under this Linode.
 
-        NOTE: Linode interfaces may not currently be available to all users.
-
         :returns: The settings for instance-level interface settings for this Linode.
         :rtype: LinodeInterfacesSettings
         """
@@ -2201,8 +2197,6 @@ class Instance(Base):
 
         NOTE: If dry_run is True, interfaces in the result will be
               of type MappedObject rather than LinodeInterface.
-
-        NOTE: Linode interfaces may not currently be available to all users.
 
         API Documentation: https://techdocs.akamai.com/linode-api/reference/post-upgrade-linode-interfaces
 

--- a/linode_api4/objects/linode_interfaces.py
+++ b/linode_api4/objects/linode_interfaces.py
@@ -11,8 +11,6 @@ from linode_api4.objects.serializable import JSONObject
 class LinodeInterfacesSettingsDefaultRouteOptions(JSONObject):
     """
     The options used to configure the default route settings for a Linode's network interfaces.
-
-    NOTE: Linode interfaces may not currently be available to all users.
     """
 
     ipv4_interface_id: Optional[int] = None
@@ -23,8 +21,6 @@ class LinodeInterfacesSettingsDefaultRouteOptions(JSONObject):
 class LinodeInterfacesSettingsDefaultRoute(JSONObject):
     """
     The default route settings for a Linode's network interfaces.
-
-    NOTE: Linode interfaces may not currently be available to all users.
     """
 
     put_class = LinodeInterfacesSettingsDefaultRouteOptions
@@ -40,8 +36,6 @@ class LinodeInterfacesSettings(Base):
     The settings related to a Linode's network interfaces.
 
     API Documentation: https://techdocs.akamai.com/linode-api/reference/get-linode-interface-settings
-
-    NOTE: Linode interfaces may not currently be available to all users.
     """
 
     api_endpoint = "/linode/instances/{id}/interfaces/settings"
@@ -60,8 +54,6 @@ class LinodeInterfacesSettings(Base):
 class LinodeInterfaceDefaultRouteOptions(JSONObject):
     """
     Options accepted when creating or updating a Linode Interface's default route settings.
-
-    NOTE: Linode interfaces may not currently be available to all users.
     """
 
     ipv4: Optional[bool] = None
@@ -72,8 +64,6 @@ class LinodeInterfaceDefaultRouteOptions(JSONObject):
 class LinodeInterfaceVPCIPv4AddressOptions(JSONObject):
     """
     Options accepted for a single address when creating or updating the IPv4 configuration of a VPC Linode Interface.
-
-    NOTE: Linode interfaces may not currently be available to all users.
     """
 
     address: Optional[str] = None
@@ -85,8 +75,6 @@ class LinodeInterfaceVPCIPv4AddressOptions(JSONObject):
 class LinodeInterfaceVPCIPv4RangeOptions(JSONObject):
     """
     Options accepted for a single range when creating or updating the IPv4 configuration of a VPC Linode Interface.
-
-    NOTE: Linode interfaces may not currently be available to all users.
     """
 
     range: str = ""
@@ -96,8 +84,6 @@ class LinodeInterfaceVPCIPv4RangeOptions(JSONObject):
 class LinodeInterfaceVPCIPv4Options(JSONObject):
     """
     Options accepted when creating or updating the IPv4 configuration of a VPC Linode Interface.
-
-    NOTE: Linode interfaces may not currently be available to all users.
     """
 
     addresses: Optional[List[LinodeInterfaceVPCIPv4AddressOptions]] = None
@@ -108,8 +94,6 @@ class LinodeInterfaceVPCIPv4Options(JSONObject):
 class LinodeInterfaceVPCIPv6SLAACOptions(JSONObject):
     """
     Options accepted for a single SLAAC when creating or updating the IPv6 configuration of a VPC Linode Interface.
-
-    NOTE: Linode interfaces may not currently be available to all users.
     """
 
     range: Optional[str] = None
@@ -119,8 +103,6 @@ class LinodeInterfaceVPCIPv6SLAACOptions(JSONObject):
 class LinodeInterfaceVPCIPv6RangeOptions(JSONObject):
     """
     Options accepted for a single range when creating or updating the IPv6 configuration of a VPC Linode Interface.
-
-    NOTE: Linode interfaces may not currently be available to all users.
     """
 
     range: Optional[str] = None
@@ -130,8 +112,6 @@ class LinodeInterfaceVPCIPv6RangeOptions(JSONObject):
 class LinodeInterfaceVPCIPv6Options(JSONObject):
     """
     Options accepted when creating or updating the IPv6 configuration of a VPC Linode Interface.
-
-    NOTE: Linode interfaces may not currently be available to all users.
     """
 
     is_public: Optional[bool] = None
@@ -143,8 +123,6 @@ class LinodeInterfaceVPCIPv6Options(JSONObject):
 class LinodeInterfaceVPCOptions(JSONObject):
     """
     VPC-exclusive options accepted when creating or updating a Linode Interface.
-
-    NOTE: Linode interfaces may not currently be available to all users.
     """
 
     subnet_id: int = 0
@@ -156,8 +134,6 @@ class LinodeInterfaceVPCOptions(JSONObject):
 class LinodeInterfacePublicIPv4AddressOptions(JSONObject):
     """
     Options accepted for a single address when creating or updating the IPv4 configuration of a public Linode Interface.
-
-    NOTE: Linode interfaces may not currently be available to all users.
     """
 
     address: str = ""
@@ -168,8 +144,6 @@ class LinodeInterfacePublicIPv4AddressOptions(JSONObject):
 class LinodeInterfacePublicIPv4Options(JSONObject):
     """
     Options accepted when creating or updating the IPv4 configuration of a public Linode Interface.
-
-    NOTE: Linode interfaces may not currently be available to all users.
     """
 
     addresses: Optional[List[LinodeInterfacePublicIPv4AddressOptions]] = None
@@ -179,8 +153,6 @@ class LinodeInterfacePublicIPv4Options(JSONObject):
 class LinodeInterfacePublicIPv6RangeOptions(JSONObject):
     """
     Options accepted for a single range when creating or updating the IPv6 configuration of a public Linode Interface.
-
-    NOTE: Linode interfaces may not currently be available to all users.
     """
 
     range: str = ""
@@ -190,8 +162,6 @@ class LinodeInterfacePublicIPv6RangeOptions(JSONObject):
 class LinodeInterfacePublicIPv6Options(JSONObject):
     """
     Options accepted when creating or updating the IPv6 configuration of a public Linode Interface.
-
-    NOTE: Linode interfaces may not currently be available to all users.
     """
 
     ranges: Optional[List[LinodeInterfacePublicIPv6RangeOptions]] = None
@@ -201,8 +171,6 @@ class LinodeInterfacePublicIPv6Options(JSONObject):
 class LinodeInterfacePublicOptions(JSONObject):
     """
     Public-exclusive options accepted when creating or updating a Linode Interface.
-
-    NOTE: Linode interfaces may not currently be available to all users.
     """
 
     ipv4: Optional[LinodeInterfacePublicIPv4Options] = None
@@ -213,8 +181,6 @@ class LinodeInterfacePublicOptions(JSONObject):
 class LinodeInterfaceVLANOptions(JSONObject):
     """
     VLAN-exclusive options accepted when creating or updating a Linode Interface.
-
-    NOTE: Linode interfaces may not currently be available to all users.
     """
 
     vlan_label: str = ""
@@ -225,8 +191,6 @@ class LinodeInterfaceVLANOptions(JSONObject):
 class LinodeInterfaceOptions(JSONObject):
     """
     Options accepted when creating or updating a Linode Interface.
-
-    NOTE: Linode interfaces may not currently be available to all users.
     """
 
     always_include = {
@@ -249,8 +213,6 @@ class LinodeInterfaceOptions(JSONObject):
 class LinodeInterfaceDefaultRoute(JSONObject):
     """
     The default route configuration of a Linode Interface.
-
-    NOTE: Linode interfaces may not currently be available to all users.
     """
 
     put_class = LinodeInterfaceDefaultRouteOptions
@@ -263,8 +225,6 @@ class LinodeInterfaceDefaultRoute(JSONObject):
 class LinodeInterfaceVPCIPv4Address(JSONObject):
     """
     A single address under the IPv4 configuration of a VPC Linode Interface.
-
-    NOTE: Linode interfaces may not currently be available to all users.
     """
 
     put_class = LinodeInterfaceVPCIPv4AddressOptions
@@ -278,8 +238,6 @@ class LinodeInterfaceVPCIPv4Address(JSONObject):
 class LinodeInterfaceVPCIPv4Range(JSONObject):
     """
     A single range under the IPv4 configuration of a VPC Linode Interface.
-
-    NOTE: Linode interfaces may not currently be available to all users.
     """
 
     put_class = LinodeInterfaceVPCIPv4RangeOptions
@@ -291,8 +249,6 @@ class LinodeInterfaceVPCIPv4Range(JSONObject):
 class LinodeInterfaceVPCIPv4(JSONObject):
     """
     A single address under the IPv4 configuration of a VPC Linode Interface.
-
-    NOTE: Linode interfaces may not currently be available to all users.
     """
 
     put_class = LinodeInterfaceVPCIPv4Options
@@ -305,8 +261,6 @@ class LinodeInterfaceVPCIPv4(JSONObject):
 class LinodeInterfaceVPCIPv6SLAAC(JSONObject):
     """
     A single SLAAC entry under the IPv6 configuration of a VPC Linode Interface.
-
-    NOTE: Linode interfaces may not currently be available to all users.
     """
 
     range: str = ""
@@ -317,8 +271,6 @@ class LinodeInterfaceVPCIPv6SLAAC(JSONObject):
 class LinodeInterfaceVPCIPv6Range(JSONObject):
     """
     A single range under the IPv6 configuration of a VPC Linode Interface.
-
-    NOTE: Linode interfaces may not currently be available to all users.
     """
 
     range: str = ""
@@ -328,8 +280,6 @@ class LinodeInterfaceVPCIPv6Range(JSONObject):
 class LinodeInterfaceVPCIPv6(JSONObject):
     """
     A single address under the IPv6 configuration of a VPC Linode Interface.
-
-    NOTE: Linode interfaces may not currently be available to all users.
     """
 
     put_class = LinodeInterfaceVPCIPv6Options
@@ -343,8 +293,6 @@ class LinodeInterfaceVPCIPv6(JSONObject):
 class LinodeInterfaceVPC(JSONObject):
     """
     VPC-specific configuration field for a Linode Interface.
-
-    NOTE: Linode interfaces may not currently be available to all users.
     """
 
     put_class = LinodeInterfaceVPCOptions
@@ -360,8 +308,6 @@ class LinodeInterfaceVPC(JSONObject):
 class LinodeInterfacePublicIPv4Address(JSONObject):
     """
     A single address under the IPv4 configuration of a public Linode Interface.
-
-    NOTE: Linode interfaces may not currently be available to all users.
     """
 
     put_class = LinodeInterfacePublicIPv4AddressOptions
@@ -374,8 +320,6 @@ class LinodeInterfacePublicIPv4Address(JSONObject):
 class LinodeInterfacePublicIPv4Shared(JSONObject):
     """
     A single shared address under the IPv4 configuration of a public Linode Interface.
-
-    NOTE: Linode interfaces may not currently be available to all users.
     """
 
     address: str = ""
@@ -386,8 +330,6 @@ class LinodeInterfacePublicIPv4Shared(JSONObject):
 class LinodeInterfacePublicIPv4(JSONObject):
     """
     The IPv4 configuration of a public Linode Interface.
-
-    NOTE: Linode interfaces may not currently be available to all users.
     """
 
     put_class = LinodeInterfacePublicIPv4Options
@@ -402,8 +344,6 @@ class LinodeInterfacePublicIPv4(JSONObject):
 class LinodeInterfacePublicIPv6SLAAC(JSONObject):
     """
     A single SLAAC entry under the IPv6 configuration of a public Linode Interface.
-
-    NOTE: Linode interfaces may not currently be available to all users.
     """
 
     address: str = ""
@@ -414,8 +354,6 @@ class LinodeInterfacePublicIPv6SLAAC(JSONObject):
 class LinodeInterfacePublicIPv6Shared(JSONObject):
     """
     A single shared range under the IPv6 configuration of a public Linode Interface.
-
-    NOTE: Linode interfaces may not currently be available to all users.
     """
 
     range: str = ""
@@ -426,8 +364,6 @@ class LinodeInterfacePublicIPv6Shared(JSONObject):
 class LinodeInterfacePublicIPv6Range(JSONObject):
     """
     A single range under the IPv6 configuration of a public Linode Interface.
-
-    NOTE: Linode interfaces may not currently be available to all users.
     """
 
     put_class = LinodeInterfacePublicIPv6RangeOptions
@@ -440,8 +376,6 @@ class LinodeInterfacePublicIPv6Range(JSONObject):
 class LinodeInterfacePublicIPv6(JSONObject):
     """
     The IPv6 configuration of a Linode Interface.
-
-    NOTE: Linode interfaces may not currently be available to all users.
     """
 
     put_class = LinodeInterfacePublicIPv6Options
@@ -455,8 +389,6 @@ class LinodeInterfacePublicIPv6(JSONObject):
 class LinodeInterfacePublic(JSONObject):
     """
     Public-specific configuration fields for a Linode Interface.
-
-    NOTE: Linode interfaces may not currently be available to all users.
     """
 
     put_class = LinodeInterfacePublicOptions
@@ -469,8 +401,6 @@ class LinodeInterfacePublic(JSONObject):
 class LinodeInterfaceVLAN(JSONObject):
     """
     VLAN-specific configuration fields for a Linode Interface.
-
-    NOTE: Linode interfaces may not currently be available to all users.
     """
 
     put_class = LinodeInterfaceVLANOptions
@@ -482,8 +412,6 @@ class LinodeInterfaceVLAN(JSONObject):
 class LinodeInterface(DerivedBase):
     """
     A Linode's network interface.
-
-    NOTE: Linode interfaces may not currently be available to all users.
 
     NOTE: When using the ``save()`` method, certain local fields with computed values will
           not be refreshed on the local object until after ``invalidate()`` has been called::
@@ -527,8 +455,6 @@ class LinodeInterface(DerivedBase):
         """
         Retrieves a list of Firewalls for this Linode Interface.
         Linode interfaces are not interchangeable with Config interfaces.
-
-        NOTE: Linode interfaces may not currently be available to all users.
 
         :param filters: Any number of filters to apply to this query.
                         See :doc:`Filtering Collections</linode_api4/objects/filtering>`

--- a/linode_api4/objects/networking.py
+++ b/linode_api4/objects/networking.py
@@ -108,8 +108,6 @@ class IPAddress(Base):
 
         NOTE: This function will only return Linode interfaces, not Config interfaces.
 
-        NOTE: Linode interfaces may not currently be available to all users.
-
         :returns: The Linode Interface associated with this IP address.
         :rtype: LinodeInterface
         """


### PR DESCRIPTION
## 📝 Description

Remove the LA note because the project is in GA now.