### PR TITLE
TPT-4424: Use e2e firewall in all linode interface tests

### DIFF
--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -16,7 +16,6 @@ import requests
 from requests.exceptions import ConnectionError, RequestException
 
 from linode_api4 import (
-    ExplicitNullValue,
     InterfaceGeneration,
     LinodeInterfaceDefaultRouteOptions,
     LinodeInterfaceOptions,
@@ -645,7 +644,7 @@ def linode_with_linode_interfaces(
                 public=LinodeInterfacePublicOptions(),
             ),
             LinodeInterfaceOptions(
-                firewall_id=ExplicitNullValue,
+                firewall_id=e2e_test_firewall.id,
                 vpc=LinodeInterfaceVPCOptions(
                     subnet_id=subnet.id,
                 ),


### PR DESCRIPTION
## 📝 Description

The API no longer accepts `null` firewall ID so we have to use explicit firewall ID now.

```bash
pytest test/integration/models/linode/interfaces/test_interfaces.py -v
```