### PR TITLE
TPT-4428: Change assignments type from dict to list in ip_addresses_assign

### DIFF
--- a/linode_api4/groups/networking.py
+++ b/linode_api4/groups/networking.py
@@ -452,10 +452,10 @@ class NetworkingGroup(Group):
         :param assignments: Any number of assignments to make.  See
                             :any:`IPAddress.to` for details on how to construct
                             assignments.
-        :type assignments: dct
+        :type assignments: list
         """
 
-        for a in assignments["assignments"]:
+        for a in assignments:
             if not "address" in a or not "linode_id" in a:
                 raise ValueError("Invalid assignment: {}".format(a))
 

--- a/test/unit/linode_client_test.py
+++ b/test/unit/linode_client_test.py
@@ -1407,13 +1407,13 @@ class NetworkingGroupTest(ClientBaseCase):
 
         with self.mock_post({}) as m:
             self.client.networking.ip_addresses_assign(
-                {"assignments": [{"address": "192.0.2.1", "linode_id": 123}]},
+                [{"address": "192.0.2.1", "linode_id": 123}],
                 "us-east",
             )
             self.assertEqual(m.call_url, "/networking/ips/assign")
             self.assertEqual(
                 m.call_data["assignments"],
-                {"assignments": [{"address": "192.0.2.1", "linode_id": 123}]},
+                [{"address": "192.0.2.1", "linode_id": 123}],
             )
             self.assertEqual(m.call_data["region"], "us-east")
 


### PR DESCRIPTION
## 📝 Description

Current type of "assignments" passed into "ip_addresses_assign" method is dict what causes an API error during IP assignment as it requires array/list.

https://techdocs.akamai.com/linode-api/reference/post-assign-ips 

## ✔️ How to Test

`make test-unit`
