### PR TITLE
Update Images in integration tests

### DIFF
--- a/linode_api4/objects/database.py
+++ b/linode_api4/objects/database.py
@@ -1,12 +1,7 @@
 from dataclasses import dataclass, field
 from typing import Optional
 
-from linode_api4.objects import (
-    Base,
-    JSONObject,
-    MappedObject,
-    Property,
-)
+from linode_api4.objects import Base, JSONObject, MappedObject, Property
 
 
 class DatabaseType(Base):

--- a/test/integration/linode_client/test_linode_client.py
+++ b/test/integration/linode_client/test_linode_client.py
@@ -116,12 +116,11 @@ def test_fails_to_create_image_with_non_existing_disk_id(
     disk_id = 111111
 
     try:
-        image_page = client.image_create(
+        client.image_create(
             disk=disk_id, label=label, description=description
         )
     except ApiError as e:
-        assert "Not found" in str(e.json)
-        assert e.status == 404
+        assert 400 <= e.status < 500
 
 
 def test_fails_to_delete_predefined_images(setup_client_and_linode):

--- a/test/integration/linode_client/test_linode_client.py
+++ b/test/integration/linode_client/test_linode_client.py
@@ -116,9 +116,7 @@ def test_fails_to_create_image_with_non_existing_disk_id(
     disk_id = 111111
 
     try:
-        client.image_create(
-            disk=disk_id, label=label, description=description
-        )
+        client.image_create(disk=disk_id, label=label, description=description)
     except ApiError as e:
         assert 400 <= e.status < 500
 

--- a/test/integration/models/linode/test_linode.py
+++ b/test/integration/models/linode/test_linode.py
@@ -141,7 +141,7 @@ def linode_for_disk_tests(test_linode_client, e2e_test_firewall):
     linode_instance, password = client.linode.instance_create(
         "g6-nanode-1",
         region,
-        image="linode/alpine3.19",
+        image="linode/ubuntu24.04",
         label=label + "_long_tests",
         firewall=e2e_test_firewall,
     )
@@ -174,7 +174,7 @@ def linode_with_block_storage_encryption(test_linode_client, e2e_test_firewall):
     linode_instance, password = client.linode.instance_create(
         "g6-nanode-1",
         region,
-        image="linode/alpine3.19",
+        image="linode/ubuntu24.04",
         label=label + "block-storage-encryption",
         firewall=e2e_test_firewall,
     )
@@ -215,7 +215,7 @@ def linode_with_disk_encryption(test_linode_client, request):
     linode_instance, password = client.linode.instance_create(
         "g6-nanode-1",
         target_region,
-        image="linode/ubuntu24.10",
+        image="linode/ubuntu24.04",
         label=label,
         booted=False,
         disk_encryption=disk_encryption,

--- a/test/integration/models/sharegroups/test_sharegroups.py
+++ b/test/integration/models/sharegroups/test_sharegroups.py
@@ -1,8 +1,6 @@
 import datetime
 from test.integration.conftest import get_region
-from test.integration.helpers import (
-    get_test_label,
-)
+from test.integration.helpers import get_test_label
 
 import pytest
 

--- a/test/integration/models/sharegroups/test_sharegroups.py
+++ b/test/integration/models/sharegroups/test_sharegroups.py
@@ -44,7 +44,7 @@ def sample_linode(test_linode_client, e2e_test_firewall):
     linode_instance, password = client.linode.instance_create(
         "g6-nanode-1",
         region,
-        image="linode/alpine3.19",
+        image="linode/ubuntu24.04",
         label=label + "_modlinode",
     )
     yield linode_instance


### PR DESCRIPTION
## 📝 Description

Fixing integration test issues seeing in workflow: https://github.com/linode/linode_api4-python/actions/runs/25501433562/job/74835124597?pr=691 

Update to use LTS images in test cases instead of invalid ones. Change the error code assertion to match the API change. 

## ✔️ How to Test

```
make TEST_CASE=test_fails_to_create_image_with_non_existing_disk_id test-int
make TEST_CASE=test_linode_with_disk_encryption_disabled test-int
make TEST_CASE=test_disk_resize_and_duplicate test-int
make TEST_CASE=test_add_get_update_revoke_image_to_share_group test-int
make TEST_CASE=test_linode_create_disk test-int
```
