### PR TITLE
Fix failing integration test

### DIFF
--- a/test/integration/models/volume/test_blockstorage.py
+++ b/test/integration/models/volume/test_blockstorage.py
@@ -1,3 +1,4 @@
+from linode_api4 import Instance
 from test.integration.conftest import get_region
 from test.integration.helpers import get_test_label, retry_sending_request
 
@@ -52,7 +53,7 @@ def test_config_create_with_device_map(test_linode_client):
         region,
         image="linode/debian12",
         label=label,
-        root_pass="aComplex@Password123",
+        root_pass=Instance.generate_root_password(),
     )
 
     disk_id = linode.disks[0].id

--- a/test/integration/models/volume/test_blockstorage.py
+++ b/test/integration/models/volume/test_blockstorage.py
@@ -47,11 +47,12 @@ def test_config_create_with_device_map(test_linode_client):
     region = get_region(client, {"Linodes", "Block Storage"}, site_type="core")
     label = get_test_label()
 
-    linode, _ = client.linode.instance_create(
+    linode = client.linode.instance_create(
         "g6-standard-6",
         region,
         image="linode/debian12",
         label=label,
+        root_pass="aComplex@Password123",
     )
 
     disk_id = linode.disks[0].id

--- a/test/integration/models/volume/test_blockstorage.py
+++ b/test/integration/models/volume/test_blockstorage.py
@@ -1,6 +1,7 @@
-from linode_api4 import Instance
 from test.integration.conftest import get_region
 from test.integration.helpers import get_test_label, retry_sending_request
+
+from linode_api4 import Instance
 
 
 def test_config_create_with_extended_volume_limit(test_linode_client):


### PR DESCRIPTION
## 📝 Description

Fixed integration test that was failing due to breaking changes introduced in SLADE + CLEO.

## ✔️ How to Test

`make test-int TEST_CASE=test_config_create_with_device_map`