### PR TITLE
ref: update monitor API docstring

### DIFF
--- a/linode_api4/groups/monitor.py
+++ b/linode_api4/groups/monitor.py
@@ -37,8 +37,6 @@ class MonitorGroup(Group):
             dashboard = client.load(MonitorDashboard, 1)
             dashboards_by_service = client.monitor.dashboards(service_type="dbaas")
 
-        .. note:: This endpoint is in beta. This will only function if base_url is set to `https://api.linode.com/v4beta`.
-
         API Documentation:
         - All Dashboards: https://techdocs.akamai.com/linode-api/reference/get-dashboards-all
         - Dashboards by Service: https://techdocs.akamai.com/linode-api/reference/get-dashboards
@@ -73,8 +71,6 @@ class MonitorGroup(Group):
             supported_services = client.monitor.services()
             service_details = client.monitor.load(MonitorService, "dbaas")
 
-        .. note:: This endpoint is in beta. This will only function if base_url is set to `https://api.linode.com/v4beta`.
-
         API Documentation: https://techdocs.akamai.com/linode-api/reference/get-monitor-services
         API Documentation: https://techdocs.akamai.com/linode-api/reference/get-monitor-services-for-service-type
 
@@ -100,7 +96,6 @@ class MonitorGroup(Group):
         Returns metrics for a specific service type.
 
             metrics = client.monitor.list_metric_definitions(service_type="dbaas")
-        .. note:: This endpoint is in beta. This will only function if base_url is set to `https://api.linode.com/v4beta`.
 
         API Documentation: https://techdocs.akamai.com/linode-api/reference/get-monitor-information
 
@@ -125,8 +120,6 @@ class MonitorGroup(Group):
         """
         Returns a JWE Token for a specific service type.
             token = client.monitor.create_token(service_type="dbaas", entity_ids=[1234])
-
-        .. note:: This endpoint is in beta. This will only function if base_url is set to `https://api.linode.com/v4beta`.
 
         API Documentation: https://techdocs.akamai.com/linode-api/reference/post-get-token
 
@@ -165,7 +158,6 @@ class MonitorGroup(Group):
 
             alerts = client.monitor.alert_definitions()
             alerts_by_service = client.monitor.alert_definitions(service_type="dbaas")
-        .. note:: This endpoint is in beta and requires using the v4beta base URL.
 
         API Documentation:
             https://techdocs.akamai.com/linode-api/reference/get-alert-definitions
@@ -202,8 +194,6 @@ class MonitorGroup(Group):
         Examples:
             channels = client.monitor.alert_channels()
 
-        .. note:: This endpoint is in beta and requires using the v4beta base URL.
-
         API Documentation: https://techdocs.akamai.com/linode-api/reference/get-notification-channels
 
         :param filters: Optional filter expressions to apply to the collection.
@@ -231,8 +221,6 @@ class MonitorGroup(Group):
 
         The alert definition configures when alerts are fired and which channels
         are notified.
-
-        .. note:: This endpoint is in beta and requires using the v4beta base URL.
 
         API Documentation: https://techdocs.akamai.com/linode-api/reference/post-alert-definition-for-service-type
 
@@ -309,9 +297,7 @@ class MonitorGroup(Group):
 
         This endpoint supports pagination fields (`page`, `page_size`) in the API.
 
-        .. note:: This endpoint is in beta and requires using the v4beta base URL.
-
-        API Documentation: TODO
+        API Documentation: https://techdocs.akamai.com/linode-api/reference/get-alert-definition-entities
 
         :param service_type: Service type for the alert definition (e.g. `dbaas`).
         :type service_type: str


### PR DESCRIPTION
## 📝 Description

Update ACLP monitor group doc strings.
Monitor APIs support both v4beta & v4 versions

## ✔️ How to Test

**What are the steps to reproduce the issue or verify the changes?**
NA

**How do I run the relevant unit/integration tests?**
Unit tests:
Run all unit tests:
python -m pytest test/unit -q
452 passed, 7 warnings in 1.11s

Run Monitor alert unit tests:
=================================================== test session starts ===================================================
platform linux -- Python 3.10.12, pytest-9.0.3, pluggy-1.6.0
rootdir: /home/shkaruna/sdk/linode_api4-python
configfile: pyproject.toml
plugins: rerunfailures-16.1, anyio-4.13.0
collected 4 items                                                                                                         

test/unit/groups/monitor_api_test.py ....

==================================================== 4 passed in 0.14s ====================================================

Integration tests with v4 & v4beta

v4beta
python -m pytest test/integration/models/monitor/test_monitor.py::test_alert_definition_entities -q -s
.
1 passed in 3.00s

python -m pytest test/integration/models/monitor/test_monitor.py::test_integration_create_get_update_delete_alert_definition -q -s
.
1 passed in 10.66s



v4
export LINODE_API_URL=https://api.linode.com/v4
python -m pytest test/integration/models/monitor/test_monitor.py::test_integration_create_get_update_delete_alert_definition -q -s
Running monitor alert-definition integration test against base_url: https://api.linode.com/v4
.
1 passed in 11.88s