### PR TITLE
TPT-4275: Resolve failings tests blocking release

### DIFF
--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -2,6 +2,7 @@ import ipaddress
 import logging
 import os
 import random
+import subprocess
 import time
 from test.integration.helpers import (
     get_test_label,
@@ -262,20 +263,18 @@ def create_linode_for_pass_reset(test_linode_client, e2e_test_firewall):
 
 
 @pytest.fixture(scope="session")
-def ssh_key_gen():
-    output = os.popen("ssh-keygen -q -t rsa -f ./sdk-sshkey  -q -N ''")
+def ssh_key_gen(tmp_path_factory):
+    key_path = tmp_path_factory.mktemp("ssh-key-gen") / "sdk-sshkey"
 
-    time.sleep(1)
+    subprocess.run(
+        ["ssh-keygen", "-q", "-t", "rsa", "-f", str(key_path), "-N", ""],
+        check=True,
+    )
 
-    pub_file = open("./sdk-sshkey.pub", "r")
-    pub_key = pub_file.read().rstrip()
-
-    priv_file = open("./sdk-sshkey", "r")
-    priv_key = priv_file.read().rstrip()
+    pub_key = key_path.with_suffix(".pub").read_text().rstrip()
+    priv_key = key_path.read_text().rstrip()
 
     yield pub_key, priv_key
-
-    os.popen("rm ./sdk-sshkey*")
 
 
 @pytest.fixture(scope="session")

--- a/test/integration/models/linode/interfaces/test_interfaces.py
+++ b/test/integration/models/linode/interfaces/test_interfaces.py
@@ -43,27 +43,33 @@ def build_interface_public_ipv4(firewall, ip_address):
     )
 
 
-def create_linode_with_legacy_config(client, ip_address, label, firewall):
-    linode, _ = client.linode.instance_create(
+def create_linode_with_legacy_config(
+    client, ip_address, label, firewall, authorized_key
+):
+    linode = client.linode.instance_create(
         "g6-nanode-1",
         ip_address.region,
         image="linode/debian12",
         label=label,
         firewall=firewall,
         interface_generation=InterfaceGeneration.LEGACY_CONFIG,
+        authorized_keys=authorized_key,
         ipv4=[ip_address.address],
     )
     return linode
 
 
-def create_linode_with_standard_interfaces(client, ip_address, label, firewall):
+def create_linode_with_standard_interfaces(
+    client, ip_address, label, firewall, authorized_key
+):
     interface = build_interface_public_ipv4(firewall.id, ip_address.address)
-    linode, _ = client.linode.instance_create(
+    linode = client.linode.instance_create(
         "g6-nanode-1",
         ip_address.region,
         image="linode/debian12",
         label=label,
         interface_generation=InterfaceGeneration.LINODE,
+        authorized_keys=authorized_key,
         interfaces=[interface],
     )
     return linode
@@ -415,13 +421,19 @@ def test_linode_interface_firewalls(e2e_test_firewall, linode_interface_public):
     ids=["legacy_config", "standard_interfaces"],
 )
 def test_linode_interfaces_with_reserved_ips(
-    test_linode_client, e2e_test_firewall, create_reserved_ip, create_linode_fn
+    test_linode_client,
+    e2e_test_firewall,
+    create_reserved_ip,
+    create_linode_fn,
+    ssh_key_gen,
 ):
     client = test_linode_client
     reserved_ip = create_reserved_ip
     label = get_test_label(length=8)
 
-    linode = create_linode_fn(client, reserved_ip, label, e2e_test_firewall)
+    linode = create_linode_fn(
+        client, reserved_ip, label, e2e_test_firewall, ssh_key_gen[0]
+    )
 
     try:
         linode_ips = linode.ips.ipv4.public

--- a/test/integration/models/linode/test_linode.py
+++ b/test/integration/models/linode/test_linode.py
@@ -1247,18 +1247,19 @@ def test_create_linode_with_kernel_and_boot_size_then_add_disk_and_rebuild(
 
 
 def test_update_linode_with_reserved_ip_in_address(
-    test_linode_client, e2e_test_firewall, create_reserved_ip
+    test_linode_client, e2e_test_firewall, create_reserved_ip, ssh_key_gen
 ):
     label = get_test_label(length=8)
     client = test_linode_client
     reserved_ip = create_reserved_ip
 
-    linode, _ = client.linode.instance_create(
+    linode = client.linode.instance_create(
         "g6-nanode-1",
         reserved_ip.region,
         image="linode/debian12",
         label=label,
         firewall=e2e_test_firewall,
+        authorized_keys=ssh_key_gen[0],
     )
 
     linode_ips = linode.ips.ipv4.public

--- a/test/integration/models/vpc/test_vpc.py
+++ b/test/integration/models/vpc/test_vpc.py
@@ -67,9 +67,10 @@ def test_get_all_vpcs(test_linode_client, create_multiple_vpcs):
     vpc_1, vpc_2 = create_multiple_vpcs
 
     all_vpcs = test_linode_client.vpcs()
+    all_vpc_ids = {vpc.id for vpc in all_vpcs}
 
-    assert str(vpc_1) in str(all_vpcs.lists)
-    assert str(vpc_2) in str(all_vpcs.lists)
+    assert vpc_1.id in all_vpc_ids
+    assert vpc_2.id in all_vpc_ids
 
 
 def test_fails_update_vpc_invalid_data(create_vpc):


### PR DESCRIPTION
## 📝 Description

This pull request resolves the CI integration test failures that are blocking the release for Reserved IPv4.

## ✔️ How to Test

```shell
make test-int TEST_ARGS='-k "test_get_all_vpcs or test_update_linode_with_reserved_ip_in_address or test_create_linode_with_kernel_and_boot_size_then_add_disk_and_rebuild or test_linode_interfaces_with_reserved_ips"
```