### PR TITLE
Integration test fixes

### DIFF
--- a/linode_api4/groups/object_storage.py
+++ b/linode_api4/groups/object_storage.py
@@ -429,8 +429,8 @@ class ObjectStorageGroup(Group):
                 json=result,
             )
 
-        return ObjectStorageBucket(
-            self.client, result["label"], result["cluster"], result
+        return ObjectStorageBucket.make_instance(
+            result["label"], self.client, json=result
         )
 
     def object_acl_config(self, cluster_or_region_id: str, bucket, name=None):

--- a/test/integration/models/linode/test_linode.py
+++ b/test/integration/models/linode/test_linode.py
@@ -854,8 +854,8 @@ def test_get_linode_types(test_linode_client):
         if len(v.region_prices) > 0 and v.region_prices[0].hourly > 0
     ]
 
-    any(v.region_prices[0].hourly > 0 for v in regional_priced_types)
-    any(v.region_prices[0].monthly > 0 for v in regional_priced_types)
+    assert any(v.region_prices[0].hourly > 0 for v in regional_priced_types)
+    assert any(v.region_prices[0].monthly > 0 for v in regional_priced_types)
 
 
 @pytest.mark.flaky(reruns=3, reruns_delay=2)

--- a/test/integration/models/linode/test_linode.py
+++ b/test/integration/models/linode/test_linode.py
@@ -848,21 +848,14 @@ def test_get_linode_types(test_linode_client):
     for linode_type in types:
         assert hasattr(linode_type, "accelerated_devices")
 
-
-def test_get_linode_types_overrides(test_linode_client):
-    types = test_linode_client.linode.types()
-
-    target_types = [
+    regional_priced_types = [
         v
         for v in types
         if len(v.region_prices) > 0 and v.region_prices[0].hourly > 0
     ]
 
-    assert len(target_types) > 0
-
-    for linode_type in target_types:
-        assert linode_type.region_prices[0].hourly >= 0
-        assert linode_type.region_prices[0].monthly >= 0
+    any(v.region_prices[0].hourly > 0 for v in regional_priced_types)
+    any(v.region_prices[0].monthly > 0 for v in regional_priced_types)
 
 
 @pytest.mark.flaky(reruns=3, reruns_delay=2)

--- a/test/integration/models/lke/test_lke.py
+++ b/test/integration/models/lke/test_lke.py
@@ -226,16 +226,6 @@ def test_node_pool_create_with_disk_encryption(test_linode_client, lke_cluster):
         pool.delete()
 
 
-def test_cluster_dashboard_url_view(lke_cluster):
-    cluster = lke_cluster
-
-    url = send_request_when_resource_available(
-        300, cluster.cluster_dashboard_url_view
-    )
-
-    assert re.search("https://+", url)
-
-
 def test_get_and_delete_kubeconfig(lke_cluster):
     cluster = lke_cluster
 

--- a/test/integration/models/lke/test_lke.py
+++ b/test/integration/models/lke/test_lke.py
@@ -1,5 +1,4 @@
 import base64
-import re
 from test.integration.conftest import get_region
 from test.integration.helpers import (
     get_test_label,

--- a/test/unit/linode_client_test.py
+++ b/test/unit/linode_client_test.py
@@ -1334,6 +1334,7 @@ class ObjectStorageGroupTest(ClientBaseCase):
                 "us-east-1", "example-bucket", ObjectStorageACL.PRIVATE, True
             )
             self.assertIsNotNone(b)
+            self.assertEqual(b.region, "us-east-1")
             self.assertEqual(m.call_url, "/object-storage/buckets")
             self.assertEqual(
                 m.call_data,

--- a/test/unit/objects/lke_test.py
+++ b/test/unit/objects/lke_test.py
@@ -68,17 +68,6 @@ class LKETest(ClientBaseCase):
         assert pool.taints[0].value == "bar"
         assert pool.taints[0].effect == "NoSchedule"
 
-    def test_cluster_dashboard_url_view(self):
-        """
-        Tests that you can submit a correct cluster dashboard url api request.
-        """
-        cluster = LKECluster(self.client, 18881)
-
-        with self.mock_get("/lke/clusters/18881/dashboard") as m:
-            result = cluster.cluster_dashboard_url_view()
-            self.assertEqual(m.call_url, "/lke/clusters/18881/dashboard")
-            self.assertEqual(result, "https://example.dashboard.linodelke.net")
-
     def test_kubeconfig_delete(self):
         """
         Tests that you can submit a correct kubeconfig delete api request.


### PR DESCRIPTION
### Description
- Fix Object Storage bucket creation so the bucket region is initialized correctly
- Remove outdated LKE cluster dashboard URL tests
- Merge and fix Linode type override coverage with the existing Linode types test

### Testing

```
pytest test/integration/models/vpc/test_vpc.py -k test_get_vpc_ipv6s
pytest test/integration/models/linode/test_linode.py -k test_get_linode_types
pytest test/unit/linode_client_test.py -k test_bucket_create
```