### PR TITLE
TPT-3501: update existing tests to validate python sdk support nodebalancer lke cluster and type fields

### DIFF
--- a/test/integration/filters/fixtures.py
+++ b/test/integration/filters/fixtures.py
@@ -1,9 +1,11 @@
 from test.integration.conftest import get_region
 from test.integration.helpers import get_test_label
+
+import pytest
+
 from linode_api4 import (
     LKEClusterControlPlaneOptions,
 )
-import pytest
 
 
 @pytest.fixture(scope="package")

--- a/test/integration/filters/fixtures.py
+++ b/test/integration/filters/fixtures.py
@@ -42,7 +42,7 @@ def lke_cluster_instance(test_linode_client):
 
 
 @pytest.fixture(scope="package")
-def lke_cluster(test_linode_client):
+def create_lke_cluster_with_related_nb(test_linode_client):
     node_type = "g6-dedicated-4"  # g6-standard-1
     version = test_linode_client.lke.versions()[0]
 

--- a/test/integration/filters/fixtures.py
+++ b/test/integration/filters/fixtures.py
@@ -1,6 +1,8 @@
 from test.integration.conftest import get_region
 from test.integration.helpers import get_test_label
-
+from linode_api4 import (
+    LKEClusterControlPlaneOptions,
+)
 import pytest
 
 
@@ -30,6 +32,30 @@ def lke_cluster_instance(test_linode_client):
 
     cluster = test_linode_client.lke.cluster_create(
         region, label, version, [node_pool]
+    )
+
+    yield cluster
+
+    cluster.delete()
+
+
+@pytest.fixture(scope="package")
+def lke_cluster(test_linode_client):
+    node_type = "g6-dedicated-4"  # g6-standard-1
+    version = test_linode_client.lke.versions()[0]
+
+    region = get_region(test_linode_client, {"Kubernetes"})
+
+    node_pool = test_linode_client.lke.node_pool(node_type, 3)
+    label = get_test_label() + "_cluster"
+
+    cluster = test_linode_client.lke.cluster_create(
+        region,
+        label,
+        version,
+        [node_pool],
+        apl_enabled=True,
+        control_plane=LKEClusterControlPlaneOptions(high_availability=True),
     )
 
     yield cluster

--- a/test/integration/models/nodebalancer/test_nodebalancer.py
+++ b/test/integration/models/nodebalancer/test_nodebalancer.py
@@ -6,7 +6,16 @@ from test.integration.conftest import (
     get_region,
     get_token,
 )
-from test.integration.helpers import get_test_label
+from test.integration.helpers import (
+    get_test_label,
+    wait_for_condition,
+)
+from test.integration.filters.fixtures import (
+    lke_cluster,
+)
+from linode_api4.objects import (
+    LKECluster,
+)
 
 import pytest
 
@@ -184,8 +193,41 @@ def test_get_nb(test_linode_client, create_nb):
     )
 
     assert nb.id == create_nb.id
-    assert nb.type == 'common'
+    assert nb.type == "common"
     assert nb.lke_cluster is None
+
+
+def find_related_nodebalancer(client, cluster: LKECluster):
+    nbs = client.nodebalancers()
+    for nb in nbs:
+        if nb.lke_cluster is not None and nb.lke_cluster.id == cluster.id:
+            return nb.id
+    return 0
+
+
+def is_related_nodebalancer_exist(client, cluster: LKECluster):
+    if find_related_nodebalancer(client, cluster):
+        return True
+    return False
+
+
+def test_get_nb_with_lke_cluster(test_linode_client, lke_cluster):
+    wait_for_condition(
+        10,
+        600,
+        is_related_nodebalancer_exist,
+        test_linode_client,
+        lke_cluster,
+    )
+    nb = test_linode_client.load(
+        NodeBalancer,
+        find_related_nodebalancer(test_linode_client, lke_cluster),
+    )
+    assert nb.type == "common"
+    assert nb.lke_cluster is not None
+    assert nb.lke_cluster.label is not None
+    assert nb.lke_cluster.type == "lkecluster"
+    assert "/lke/clusters/" in str(nb.lke_cluster.url)
 
 
 def test_update_nb(test_linode_client, create_nb):
@@ -207,7 +249,7 @@ def test_update_nb(test_linode_client, create_nb):
 
     assert new_label == nb_updated.label
     assert 5 == nb_updated.client_udp_sess_throttle
-    assert nb.type == 'common'
+    assert nb.type == "common"
     assert nb.lke_cluster is None
 
 
@@ -231,15 +273,32 @@ def test_create_nb_node(
 
 
 @pytest.mark.smoke
-def test_get_nb_node(test_linode_client, create_nb_config):
-    test_linode_client.load(
+def test_get_nb_node(
+    test_linode_client, create_nb_config, linode_with_private_ip
+):
+    address = [
+        a for a in linode_with_private_ip.ipv4 if re.search("192.168.+", a)
+    ][0]
+    create_nb_config.node_create(
+        "node_test", address + ":80", weight=50, mode="accept"
+    )
+    node = test_linode_client.load(
         NodeBalancerNode,
         create_nb_config.nodes[0].id,
         (create_nb_config.id, create_nb_config.nodebalancer_id),
     )
+    assert "node_test" == node.label
 
 
-def test_update_nb_node(test_linode_client, create_nb_config):
+def test_update_nb_node(
+    test_linode_client, create_nb_config, linode_with_private_ip
+):
+    address = [
+        a for a in linode_with_private_ip.ipv4 if re.search("192.168.+", a)
+    ][0]
+    create_nb_config.node_create(
+        "node_test", address + ":80", weight=50, mode="accept"
+    )
     config = test_linode_client.load(
         NodeBalancerConfig,
         create_nb_config.id,

--- a/test/integration/models/nodebalancer/test_nodebalancer.py
+++ b/test/integration/models/nodebalancer/test_nodebalancer.py
@@ -6,7 +6,7 @@ from test.integration.conftest import (
     get_region,
     get_token,
 )
-from test.integration.filters.fixtures import (
+from test.integration.filters.fixtures import (  # noqa: F401
     create_lke_cluster_with_related_nb,
 )
 from test.integration.helpers import (

--- a/test/integration/models/nodebalancer/test_nodebalancer.py
+++ b/test/integration/models/nodebalancer/test_nodebalancer.py
@@ -6,9 +6,6 @@ from test.integration.conftest import (
     get_region,
     get_token,
 )
-from test.integration.filters.fixtures import (
-    create_lke_cluster_with_related_nb,
-)
 from test.integration.helpers import (
     get_test_label,
     wait_for_condition,
@@ -209,7 +206,9 @@ def is_related_nodebalancer_exist(client, cluster: LKECluster):
     return False
 
 
-def test_get_nb_with_lke_cluster(test_linode_client, create_lke_cluster_with_related_nb):
+def test_get_nb_with_lke_cluster(
+    test_linode_client, create_lke_cluster_with_related_nb
+):
     wait_for_condition(
         10,
         600,
@@ -219,7 +218,9 @@ def test_get_nb_with_lke_cluster(test_linode_client, create_lke_cluster_with_rel
     )
     nb = test_linode_client.load(
         NodeBalancer,
-        find_related_nodebalancer(test_linode_client, create_lke_cluster_with_related_nb),
+        find_related_nodebalancer(
+            test_linode_client, create_lke_cluster_with_related_nb
+        ),
     )
     assert nb.type == "common"
     assert nb.lke_cluster is not None

--- a/test/integration/models/nodebalancer/test_nodebalancer.py
+++ b/test/integration/models/nodebalancer/test_nodebalancer.py
@@ -10,17 +10,12 @@ from test.integration.helpers import (
     get_test_label,
     wait_for_condition,
 )
-from test.integration.filters.fixtures import (
-    lke_cluster,
-)
-from linode_api4.objects import (
-    LKECluster,
-)
 
 import pytest
 
 from linode_api4 import ApiError, LinodeClient, NodeBalancer
 from linode_api4.objects import (
+    LKECluster,
     NodeBalancerConfig,
     NodeBalancerNode,
     NodeBalancerType,

--- a/test/integration/models/nodebalancer/test_nodebalancer.py
+++ b/test/integration/models/nodebalancer/test_nodebalancer.py
@@ -6,6 +6,9 @@ from test.integration.conftest import (
     get_region,
     get_token,
 )
+from test.integration.filters.fixtures import (
+    create_lke_cluster_with_related_nb,
+)
 from test.integration.helpers import (
     get_test_label,
     wait_for_condition,

--- a/test/integration/models/nodebalancer/test_nodebalancer.py
+++ b/test/integration/models/nodebalancer/test_nodebalancer.py
@@ -139,7 +139,7 @@ def test_create_nb(test_linode_client, e2e_test_firewall):
 
 
 def test_get_nodebalancer_config(test_linode_client, create_nb_config):
-    config = test_linode_client.load(
+    test_linode_client.load(
         NodeBalancerConfig,
         create_nb_config.id,
         create_nb_config.nodebalancer_id,
@@ -184,6 +184,8 @@ def test_get_nb(test_linode_client, create_nb):
     )
 
     assert nb.id == create_nb.id
+    assert nb.type == 'common'
+    assert nb.lke_cluster is None
 
 
 def test_update_nb(test_linode_client, create_nb):
@@ -205,6 +207,8 @@ def test_update_nb(test_linode_client, create_nb):
 
     assert new_label == nb_updated.label
     assert 5 == nb_updated.client_udp_sess_throttle
+    assert nb.type == 'common'
+    assert nb.lke_cluster is None
 
 
 @pytest.mark.smoke
@@ -228,7 +232,7 @@ def test_create_nb_node(
 
 @pytest.mark.smoke
 def test_get_nb_node(test_linode_client, create_nb_config):
-    node = test_linode_client.load(
+    test_linode_client.load(
         NodeBalancerNode,
         create_nb_config.nodes[0].id,
         (create_nb_config.id, create_nb_config.nodebalancer_id),

--- a/test/integration/models/nodebalancer/test_nodebalancer.py
+++ b/test/integration/models/nodebalancer/test_nodebalancer.py
@@ -6,6 +6,9 @@ from test.integration.conftest import (
     get_region,
     get_token,
 )
+from test.integration.filters.fixtures import (
+    create_lke_cluster_with_related_nb,
+)
 from test.integration.helpers import (
     get_test_label,
     wait_for_condition,
@@ -206,17 +209,17 @@ def is_related_nodebalancer_exist(client, cluster: LKECluster):
     return False
 
 
-def test_get_nb_with_lke_cluster(test_linode_client, lke_cluster):
+def test_get_nb_with_lke_cluster(test_linode_client, create_lke_cluster_with_related_nb):
     wait_for_condition(
         10,
         600,
         is_related_nodebalancer_exist,
         test_linode_client,
-        lke_cluster,
+        create_lke_cluster_with_related_nb,
     )
     nb = test_linode_client.load(
         NodeBalancer,
-        find_related_nodebalancer(test_linode_client, lke_cluster),
+        find_related_nodebalancer(test_linode_client, create_lke_cluster_with_related_nb),
     )
     assert nb.type == "common"
     assert nb.lke_cluster is not None


### PR DESCRIPTION
## ✔️ How to Test

> make test-int TEST_ARGS="-k test_get_nb"
> make test-int TEST_ARGS="-k test_update_nb"