### PR TITLE
Fixed several failing VPC integration tests

### DIFF
--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -473,7 +473,7 @@ def create_vpc(test_linode_client):
     vpc = client.vpcs.create(
         label=label,
         region=get_region(
-            test_linode_client, {"VPCs", "VPC IPv6 Stack", "Linode Interfaces"}
+            test_linode_client, {"VPCs", "VPC IPv6 Stack", "Linode Interfaces", "Custom VPC IPv4 Ranges"}
         ),
         description="test description",
         ipv6=[{"range": "auto"}],

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -473,7 +473,13 @@ def create_vpc(test_linode_client):
     vpc = client.vpcs.create(
         label=label,
         region=get_region(
-            test_linode_client, {"VPCs", "VPC IPv6 Stack", "Linode Interfaces", "Custom VPC IPv4 Ranges"}
+            test_linode_client,
+            {
+                "VPCs",
+                "VPC IPv6 Stack",
+                "Linode Interfaces",
+                "Custom VPC IPv4 Ranges",
+            },
         ),
         description="test description",
         ipv6=[{"range": "auto"}],

--- a/test/integration/models/networking/test_networking.py
+++ b/test/integration/models/networking/test_networking.py
@@ -15,11 +15,7 @@ from test.integration.helpers import (
 import pytest
 import requests
 
-from linode_api4 import (
-    ApiError,
-    Instance,
-    LinodeClient,
-)
+from linode_api4 import ApiError, Instance, LinodeClient
 from linode_api4.objects import (
     Config,
     ConfigInterfaceIPv4,

--- a/test/integration/models/vpc/test_vpc.py
+++ b/test/integration/models/vpc/test_vpc.py
@@ -164,9 +164,6 @@ def test_vpc_with_ipv4(test_linode_client, create_vpc_with_ipv4):
     loaded_vpc = client.load(VPC, vpc.id)
     assert loaded_vpc.ipv4[0].range == "10.0.0.0/8"
 
-    all_vpcs = client.vpcs()
-    assert vpc.id in [v.id for v in all_vpcs]
-
     vpc.ipv4 = [{"range": "192.168.0.0/17"}]
     vpc.save()
 


### PR DESCRIPTION
## 📝 Description

Fixed integration test issues introduced in Configurable VPC IPv4 merge.

## ✔️ How to Test

`make test-int TEST_CASE=test_update_vpc`
`make test-int TEST_CASE=test_vpc_with_ipv4`
