### PR TITLE
TPT-4056: Fix GitHub Actions script injection vulnerabilities

### DIFF
--- a/.github/workflows/e2e-test-pr.yml
+++ b/.github/workflows/e2e-test-pr.yml
@@ -112,9 +112,13 @@ jobs:
         run: |
           timestamp=$(date +'%Y%m%d%H%M')
           report_filename="${timestamp}_sdk_test_report.xml"
-          make test-int RUN_DB_FORK_TESTS=${{ github.event.inputs.run_db_fork_tests }} RUN_DB_TESTS=${{ github.event.inputs.run_db_tests }} RUN_ACLP_LOGS_STREAM_TESTS=${{ github.event.inputs.run_aclp_logs_stream_tests }} TEST_ARGS="--junitxml=${report_filename}" TEST_SUITE="${{ github.event.inputs.test_suite }}"
+          make test-int RUN_DB_FORK_TESTS="$RUN_DB_FORK_TESTS" RUN_DB_TESTS="$RUN_DB_TESTS" RUN_ACLP_LOGS_STREAM_TESTS="$RUN_ACLP_LOGS_STREAM_TESTS" TEST_ARGS="--junitxml=${report_filename}" TEST_SUITE="$TEST_SUITE"
         env:
           LINODE_TOKEN: ${{ secrets.LINODE_TOKEN }}
+          RUN_DB_FORK_TESTS: ${{ github.event.inputs.run_db_fork_tests }}
+          RUN_DB_TESTS: ${{ github.event.inputs.run_db_tests }}
+          RUN_ACLP_LOGS_STREAM_TESTS: ${{ github.event.inputs.run_aclp_logs_stream_tests }}
+          TEST_SUITE: ${{ github.event.inputs.test_suite }}
 
       - name: Upload test results
         if: always() && github.repository == 'linode/linode_api4-python' && (github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.test_report_upload == 'true'))

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -107,9 +107,13 @@ jobs:
         run: |
           timestamp=$(date +'%Y%m%d%H%M')
           report_filename="${timestamp}_sdk_test_report.xml"
-          make test-int RUN_DB_FORK_TESTS=${{ github.event.inputs.run_db_fork_tests }} RUN_DB_TESTS=${{ github.event.inputs.run_db_tests }} RUN_ACLP_LOGS_STREAM_TESTS=${{ github.event.inputs.run_aclp_logs_stream_tests }} TEST_SUITE="${{ github.event.inputs.test_suite }}" TEST_ARGS="--junitxml=${report_filename}"
+          make test-int RUN_DB_FORK_TESTS="$RUN_DB_FORK_TESTS" RUN_DB_TESTS="$RUN_DB_TESTS" RUN_ACLP_LOGS_STREAM_TESTS="$RUN_ACLP_LOGS_STREAM_TESTS" TEST_SUITE="$TEST_SUITE" TEST_ARGS="--junitxml=${report_filename}"
         env:
           LINODE_TOKEN: ${{ env.LINODE_TOKEN }}
+          RUN_DB_FORK_TESTS: ${{ github.event.inputs.run_db_fork_tests }}
+          RUN_DB_TESTS: ${{ github.event.inputs.run_db_tests }}
+          RUN_ACLP_LOGS_STREAM_TESTS: ${{ github.event.inputs.run_aclp_logs_stream_tests }}
+          TEST_SUITE: ${{ github.event.inputs.test_suite }}
 
       - name: Upload Test Report as Artifact
         if: always()


### PR DESCRIPTION
## 📝 Description

Pass workflow dispatch inputs through step-level environment variables to prevent script injection without changing integration-test behavior.