### PR TITLE
TPT-4578: Add community contribution and hotfix labels

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -29,6 +29,12 @@
 - name: security
   description: for security fixes and improvements in the changelog.
   color: AA1111
+- name: community-contribution
+  description: contributions from the community.
+  color: 22ee47
+- name: hotfix
+  description: urgent fixes for production issues.
+  color: ff0000
 - name: ignore-for-release
   description: PRs you do not want to render in the changelog
   color: 7b8eac


### PR DESCRIPTION
## Description

Add `community-contribution` and `hotfix` to the GitHub label configuration so label automation applies these repository labels.