### PR TITLE
TPT-4623: Add databases and vpc OAuth scopes

### DIFF
--- a/linode_api4/login_client.py
+++ b/linode_api4/login_client.py
@@ -268,6 +268,33 @@ class OAuthScopes:
                 return "images:*"
             return "images:{}".format(self.name)
 
+    class Databases(Enum):
+        """
+        Access to Managed Databases
+        """
+
+        read_only = 0
+        read_write = 1
+        all = 2
+
+        def __repr__(self):
+            if self.name == "all":
+                return "databases:*"
+            return "databases:{}".format(self.name)
+
+    class VPC(Enum):
+        """
+        Access to VPCs and subnets
+        """
+
+        read_write = 1
+        all = 2
+
+        def __repr__(self):
+            if self.name == "all":
+                return "vpc:*"
+            return "vpc:{}".format(self.name)
+
     _scope_families = {
         "linodes": Linodes,
         "domains": Domains,
@@ -286,6 +313,8 @@ class OAuthScopes:
         "nodebalancers": NodeBalancers,
         "longview": Longview,
         "images": Images,
+        "databases": Databases,
+        "vpc": VPC,
     }
 
     @staticmethod

--- a/linode_api4/login_client.py
+++ b/linode_api4/login_client.py
@@ -30,10 +30,11 @@ class OAuthScopes:
     Lists of OAuth Scopes are accepted when calling the :any:`generate_login_url`
     method of the :any:`LinodeLoginClient`.
 
-    All contained enumerations of OAuth Scopes have two levels, "read_only" and
+    Most contained enumerations of OAuth Scopes have two levels, "read_only" and
     "read_write".  "read_only" access grants you the ability to get resources and
     of that type, but not to change, create, or delete them.  "read_write" access
-    allows to full access to resources of the requested type.  In the above
+    allows to full access to resources of the requested type.  :any:`OAuthScopes.VPC`
+    is the exception and exposes only "read_write" and "all".  In the above
     example, you are requesting access to view, modify, create, and delete
     Linodes, and to view Domains.
     """

--- a/test/unit/login_client_test.py
+++ b/test/unit/login_client_test.py
@@ -53,3 +53,21 @@ class OAuthScopesTest(TestCase):
             scopes,
             [getattr(c, "all") for c in OAuthScopes._scope_families.values()],
         )
+
+    def test_parse_scopes_databases_and_vpc(self):
+        """
+        Tests parsing documented databases and vpc scopes
+        """
+        scopes = OAuthScopes.parse(
+            "databases:read_only,databases:read_write,vpc:read_write,vpc:*"
+        )
+        self.assertEqual(
+            scopes,
+            [
+                OAuthScopes.Databases.read_only,
+                OAuthScopes.Databases.read_write,
+                OAuthScopes.VPC.read_write,
+                OAuthScopes.VPC.all,
+            ],
+        )
+        self.assertEqual(OAuthScopes.parse("vpc:read_only"), [])


### PR DESCRIPTION
## 📝 Description

`OAuthScopes` did not model the documented `databases` and `vpc` scopes, so apps could not request those grants through `generate_login_url` and tokens that already included them parsed as unknown.

This adds `OAuthScopes.Databases` (`read_only`, `read_write`, `all`) and `OAuthScopes.VPC` (`read_write`, `all`). VPC has no `read_only` grant.

## ✔️ How to Test

```bash
python -m pytest test/unit/login_client_test.py
```